### PR TITLE
Docs: Add release notes for 1.11.9

### DIFF
--- a/snippets/releases/1.11.8.mdx
+++ b/snippets/releases/1.11.8.mdx
@@ -1,0 +1,28 @@
+<Update label="1.11.8 Release" description="4th February 2026">
+
+You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.11.8-release).
+
+## Improvements
+
+- Added BigQuery lineage support for PowerBI .pbit files
+- Added sobjectNames field for multi-object selection in Salesforce connector
+- Added PBI rdl report lineage
+- Included API result properties descriptions from OpenAPI schemas
+
+## Fixes
+
+- Fixed PowerBI .pbit parser failing on multiline DAX expressions
+- Fixed tag search in mUI Tag Suggestion
+- Fixed app stuck on refresh call for basic
+- Fixed testsuite result summary
+- Fixed okta renewal
+- Fixed Ingest Schema & View Definition For Unity Catalog
+- Fixed DB2 TLS certificate connection issue
+- Fixed Snowflake View DDL Fallback To Preserve Exact Case Identifiers
+- Skip and warn when autoclassification values are too long
+- Deploy pipeline before DB update to prevent inconsistent state
+- Clean OpenMetadataWorkflowConfig in IngestionPipeline
+
+**Full Changelog**: [link](https://github.com/open-metadata/OpenMetadata/compare/1.11.7-release...1.11.8-release)
+
+</Update>

--- a/snippets/releases/latest.mdx
+++ b/snippets/releases/latest.mdx
@@ -1,28 +1,32 @@
-<Update label="Latest Release" description="4th February 2026">
+<Update label="Latest Release" description="16th February 2026">
 
-You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.11.8-release).
+You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.11.9-release).
 
 ## Improvements
 
-- Added BigQuery lineage support for PowerBI .pbit files
-- Added sobjectNames field for multi-object selection in Salesforce connector
-- Added PBI rdl report lineage
-- Included API result properties descriptions from OpenAPI schemas
+- Enabled "Updated By," "Synonyms," "Related Terms," and "Status" fields in workflow check conditions
+- Added search functionality in the ingestion runner dropdown and fallback logic to select Collate SaaS Runner by default
+- Optimized Unity Catalog lineage retrieval by using system tables instead of the API
+- Added bulk APIs for checking pipeline status
+- General improvements to import/export functionality
 
 ## Fixes
 
-- Fixed PowerBI .pbit parser failing on multiline DAX expressions
-- Fixed tag search in mUI Tag Suggestion
-- Fixed app stuck on refresh call for basic
-- Fixed testsuite result summary
-- Fixed okta renewal
-- Fixed Ingest Schema & View Definition For Unity Catalog
-- Fixed DB2 TLS certificate connection issue
-- Fixed Snowflake View DDL Fallback To Preserve Exact Case Identifiers
-- Skip and warn when autoclassification values are too long
-- Deploy pipeline before DB update to prevent inconsistent state
-- Clean OpenMetadataWorkflowConfig in IngestionPipeline
+- Fixed Databricks view definition extraction and resolved circular lineage issues
+- Fixed BigQuery project ID input handling in the ingestion class
+- Fixed Trino shadowing of the `http_scheme` argument
+- Added Airflow `DriveService` to the entity class map
+- Fixed source hash instability during ingestion runs to prevent unnecessary updates
+- Fixed CSV parsing logic for escape characters and resolved timeout issues during CSV imports
+- Fixed column tag insertion and removal during Database Service imports
+- Fixed issue where nested columns were not updating in real-time
+- Added auto-scroll to form errors when they occur
+- Fixed translation for "most-viewed-data-assets"
+- Fixed filters for Impact Analysis
+- Fixed issue where `sourceHash`-only changes were generating unwanted notification emails
+- Fixed aggregation incident re-indexing
+- Added missing Data Quality SDK parameters
 
-**Full Changelog**: [link](https://github.com/open-metadata/OpenMetadata/compare/1.11.7-release...1.11.8-release)
+**Full Changelog**: [link](https://github.com/open-metadata/OpenMetadata/compare/1.11.8-release...1.11.9-release)
 
 </Update>

--- a/v1.11.x/releases/all-releases.mdx
+++ b/v1.11.x/releases/all-releases.mdx
@@ -119,6 +119,7 @@ import ReleaseNotes112 from '/snippets/releases/1.11.4.mdx';
 import ReleaseNotes113 from '/snippets/releases/1.11.5.mdx';
 import ReleaseNotes114 from '/snippets/releases/1.11.6.mdx';
 import ReleaseNotes115 from '/snippets/releases/1.11.7.mdx';
+import ReleaseNotes116 from '/snippets/releases/1.11.8.mdx';
 import ReleaseNotes from '/snippets/releases/latest.mdx';
 
 
@@ -130,11 +131,13 @@ The OpenMetadata community is on a monthly release cadence. At every 4-5 weeks w
 
 <CardGroup>
 <Card icon="party-horn" title="Upgrade OpenMetadata" href="/v1.11.x/deployment/upgrade">
-Learn how to upgrade your OpenMetadata instance to 1.11.8!
+Learn how to upgrade your OpenMetadata instance to 1.11.9!
 </Card>
 </CardGroup>
 
 <ReleaseNotes />
+
+<ReleaseNotes116 />
 
 <ReleaseNotes115 />
 


### PR DESCRIPTION
## Summary
- Archived 1.11.8 release notes into `snippets/releases/1.11.8.mdx`
- Updated `snippets/releases/latest.mdx` with the 1.11.9 release notes (5 improvements, 14 fixes)
- Updated `v1.11.x/releases/all-releases.mdx` to reference the archived 1.11.8 and bump the upgrade card to 1.11.9

Reference PR: https://github.com/open-metadata/docs-om/pull/15