### PR TITLE
Fix MCP link and icon paths across documentation versions

### DIFF
--- a/v1.10.x/index.mdx
+++ b/v1.10.x/index.mdx
@@ -86,8 +86,8 @@ import { Integrations } from "/snippets/v1.10.x/components/ConnectorGrid/Integra
   <Icon icon="/public/images/connectors/snowflakes.webp" color="#6938EF" /> <span>Snowflake</span>
 </a>
 
-<a href="/v1.10.x/collate-ai/mcp" className="chip purple">
-  <Icon icon="/public/images/connectors/mcp.svg" color="#6938EF" /> <span>MCP</span>
+<a href="/v1.10.x/how-to-guides/mcp" className="chip purple">
+  <Icon icon="/public/images/icons/mcp.svg" color="#6938EF" /> <span>MCP</span>
 </a>
 
 </div>

--- a/v1.11.x/index.mdx
+++ b/v1.11.x/index.mdx
@@ -86,8 +86,8 @@ import { Integrations } from "/snippets/v1.11.x/components/ConnectorGrid/Integra
   <Icon icon="/public/images/connectors/snowflakes.webp" color="#6938EF" /> <span>Snowflake</span>
 </a>
 
-<a href="/v1.11.x/collate-ai/mcp" className="chip purple">
-  <Icon icon="/public/images/connectors/mcp.svg" color="#6938EF" /> <span>MCP</span>
+<a href="/v1.11.x/how-to-guides/mcp" className="chip purple">
+  <Icon icon="/public/images/icons/mcp.svg" color="#6938EF" /> <span>MCP</span>
 </a>
 
 </div>

--- a/v1.12.x-SNAPSHOT/index.mdx
+++ b/v1.12.x-SNAPSHOT/index.mdx
@@ -85,8 +85,8 @@ import { Integrations } from "/snippets/v1.12.x-SNAPSHOT/components/ConnectorGri
 <a href="/v1.12.x-SNAPSHOT/connectors/database/snowflake" className="chip purple">
   <Icon icon="/public/images/connectors/snowflakes.webp" color="#6938EF" /> <span>Snowflake</span>
 </a>
-<a href="/v1.12.x-SNAPSHOT/collate-ai/mcp" className="chip purple">
-  <Icon icon="/public/images/connectors/mcp.svg" color="#6938EF" /> <span>MCP</span>
+<a href="/v1.12.x-SNAPSHOT/how-to-guides/mcp" className="chip purple">
+  <Icon icon="/public/images/icons/mcp.svg" color="#6938EF" /> <span>MCP</span>
 </a>
 
 </div>


### PR DESCRIPTION
This pull request updates the MCP connector link and icon across documentation versions to improve consistency and accuracy. The changes ensure that the MCP connector now points to the correct "how-to-guides" section and uses the appropriate icon path.

Documentation updates:

* Updated the MCP connector link in `v1.10.x/index.mdx` to point to `/v1.10.x/how-to-guides/mcp` and changed the icon path to `/public/images/icons/mcp.svg`.
* Updated the MCP connector link in `v1.11.x/index.mdx` to point to `/v1.11.x/how-to-guides/mcp` and changed the icon path to `/public/images/icons/mcp.svg`.
* Updated the MCP connector link in `v1.12.x-SNAPSHOT/index.mdx` to point to `/v1.12.x-SNAPSHOT/how-to-guides/mcp` and changed the icon path to `/public/images/icons/mcp.svg`.