### PR TITLE
Docs: Add release notes for 1.11.10

### DIFF
--- a/snippets/releases/1.11.9.mdx
+++ b/snippets/releases/1.11.9.mdx
@@ -1,0 +1,32 @@
+<Update label="1.11.9 Release" description="16th February 2026">
+
+You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.11.9-release).
+
+## Improvements
+
+- Enabled "Updated By," "Synonyms," "Related Terms," and "Status" fields in workflow check conditions
+- Added search functionality in the ingestion runner dropdown and fallback logic to select Collate SaaS Runner by default
+- Optimized Unity Catalog lineage retrieval by using system tables instead of the API
+- Added bulk APIs for checking pipeline status
+- General improvements to import/export functionality
+
+## Fixes
+
+- Fixed Databricks view definition extraction and resolved circular lineage issues
+- Fixed BigQuery project ID input handling in the ingestion class
+- Fixed Trino shadowing of the `http_scheme` argument
+- Added Airflow `DriveService` to the entity class map
+- Fixed source hash instability during ingestion runs to prevent unnecessary updates
+- Fixed CSV parsing logic for escape characters and resolved timeout issues during CSV imports
+- Fixed column tag insertion and removal during Database Service imports
+- Fixed issue where nested columns were not updating in real-time
+- Added auto-scroll to form errors when they occur
+- Fixed translation for "most-viewed-data-assets"
+- Fixed filters for Impact Analysis
+- Fixed issue where `sourceHash`-only changes were generating unwanted notification emails
+- Fixed aggregation incident re-indexing
+- Added missing Data Quality SDK parameters
+
+**Full Changelog**: [link](https://github.com/open-metadata/OpenMetadata/compare/1.11.8-release...1.11.9-release)
+
+</Update>

--- a/snippets/releases/latest.mdx
+++ b/snippets/releases/latest.mdx
@@ -1,32 +1,35 @@
-<Update label="Latest Release" description="16th February 2026">
+<Update label="Latest Release" description="18th February 2026">
 
-You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.11.9-release).
+You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.11.10-release).
 
 ## Improvements
 
-- Enabled "Updated By," "Synonyms," "Related Terms," and "Status" fields in workflow check conditions
-- Added search functionality in the ingestion runner dropdown and fallback logic to select Collate SaaS Runner by default
-- Optimized Unity Catalog lineage retrieval by using system tables instead of the API
-- Added bulk APIs for checking pipeline status
-- General improvements to import/export functionality
+- Added new BurstIQ database connector
+- Implemented Athena struct profiling following established patterns
+- Added support for `displayName` extraction from user profile during login
+- Excluded unused fields from suggestion API calls to improve performance
 
 ## Fixes
 
-- Fixed Databricks view definition extraction and resolved circular lineage issues
-- Fixed BigQuery project ID input handling in the ingestion class
-- Fixed Trino shadowing of the `http_scheme` argument
-- Added Airflow `DriveService` to the entity class map
-- Fixed source hash instability during ingestion runs to prevent unnecessary updates
-- Fixed CSV parsing logic for escape characters and resolved timeout issues during CSV imports
-- Fixed column tag insertion and removal during Database Service imports
-- Fixed issue where nested columns were not updating in real-time
-- Added auto-scroll to form errors when they occur
-- Fixed translation for "most-viewed-data-assets"
-- Fixed filters for Impact Analysis
-- Fixed issue where `sourceHash`-only changes were generating unwanted notification emails
-- Fixed aggregation incident re-indexing
-- Added missing Data Quality SDK parameters
+- Fixed ingestion pipelines incorrectly storing the ingestion runner
+- Fixed ingestion runner fetching
+- Fixed horizontal scroll not working for table components
+- Fixed enum default values being dropped during POJO generation
+- Updated axios library to address a security vulnerability
+- Fixed `usageLocation` not being added to the BigQuery connection URL
+- Fixed Oracle stored procedure line ordering with `ORDER BY` clause; ensured packages are ordered before package bodies
+- Fixed DB2 iSeries connection issue
+- Added Dagster asset key prefix configuration for lineage
+- Fixed Airflow Task Instance link not correctly filtering by DAG
+- Fixed Metabase dataset query type detection for native queries and improved error logging
+- Fixed ingestion pipeline exit handler skipping status update when pipeline is already in a terminal state
+- Resolved Flowable suspension state conflict after migration
+- Fixed Delete Table Constraint when the column is not present in the patch request
+- Fixed `NoneType` attribute error on usage workflow cost calculation
+- Fixed Out-of-Memory (OOM) issue during large CSV processing
+- Fixed boolean parameters in test case forms that could not be toggled OFF
+- Fixed nested fields repetition issue in table display
 
-**Full Changelog**: [link](https://github.com/open-metadata/OpenMetadata/compare/1.11.8-release...1.11.9-release)
+**Full Changelog**: [link](https://github.com/open-metadata/OpenMetadata/compare/1.11.9-release...1.11.10-release)
 
 </Update>

--- a/v1.11.x/releases/all-releases.mdx
+++ b/v1.11.x/releases/all-releases.mdx
@@ -120,6 +120,7 @@ import ReleaseNotes113 from '/snippets/releases/1.11.5.mdx';
 import ReleaseNotes114 from '/snippets/releases/1.11.6.mdx';
 import ReleaseNotes115 from '/snippets/releases/1.11.7.mdx';
 import ReleaseNotes116 from '/snippets/releases/1.11.8.mdx';
+import ReleaseNotes117 from '/snippets/releases/1.11.9.mdx';
 import ReleaseNotes from '/snippets/releases/latest.mdx';
 
 
@@ -131,11 +132,13 @@ The OpenMetadata community is on a monthly release cadence. At every 4-5 weeks w
 
 <CardGroup>
 <Card icon="party-horn" title="Upgrade OpenMetadata" href="/v1.11.x/deployment/upgrade">
-Learn how to upgrade your OpenMetadata instance to 1.11.9!
+Learn how to upgrade your OpenMetadata instance to 1.11.10!
 </Card>
 </CardGroup>
 
 <ReleaseNotes />
+
+<ReleaseNotes117 />
 
 <ReleaseNotes116 />
 


### PR DESCRIPTION
This pull request updates the OpenMetadata release notes to include the new 1.11.9 and 1.11.10 releases, updates the "Latest Release" information, and ensures the documentation references the most recent release. The main changes are the addition of new release notes, updates to the release summary, and adjustments to the upgrade instructions.

**Release Notes and Documentation Updates:**

* Added the 1.11.9 release notes to `snippets/releases/1.11.9.mdx`, detailing improvements (such as workflow check enhancements, ingestion runner improvements, and lineage optimizations) and multiple bug fixes (including ingestion stability, CSV import, and UI fixes).
* Updated the "Latest Release" in `snippets/releases/latest.mdx` to 1.11.10, with new improvements (e.g., BurstIQ connector, Athena struct profiling, UI enhancements, and search optimizations) and a comprehensive list of bug fixes (including ingestion, UI, schema, security, and connector-specific issues).
* Registered the new 1.11.9 release notes in the release notes aggregation file `v1.11.x/releases/all-releases.mdx`.
* Updated the upgrade prompt in the releases documentation to reference version 1.11.10 instead of 1.11.9, and ensured the new release notes are displayed in the correct order.