### PR TITLE
fix: Remove Redshift partition/DISTSTYLE references from docs

### DIFF
--- a/v1.11.x/connectors/database/redshift.mdx
+++ b/v1.11.x/connectors/database/redshift.mdx
@@ -156,9 +156,6 @@ For a complete guide on managing secrets in hybrid setups, see the [Hybrid Inges
     - **Assume Role ARN** (Optional): ARN of a role to assume for cross-account access.
     - **Assume Role Session Name** (Optional): Session name when assuming a role.
 - **Database**: The database of the data source is an optional parameter, if you would like to restrict the metadata reading to a single database. If left blank, OpenMetadata ingestion attempts to scan all the databases.
-<Tip>
-During the metadata ingestion for redshift, the tables in which the distribution style i.e, `DISTSTYLE` is not `AUTO` will be marked as partitioned tables
-</Tip>
 **SSL Configuration**
 In order to integrate SSL in the Metadata Ingestion Config, the user will have to add the SSL config under connectionArguments which is placed in the source.
 **SSL Modes**

--- a/v1.11.x/connectors/database/redshift/yaml.mdx
+++ b/v1.11.x/connectors/database/redshift/yaml.mdx
@@ -145,7 +145,6 @@ the steps to create a YAML configuration able to connect to the source,
 process the Entities if needed, and reach the OpenMetadata server.
 The workflow is modeled around the following
 [JSON Schema](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/workflow.json)
-**Note:** During the metadata ingestion for redshift, the tables in which the distribution style i.e `DISTSTYLE` is not `AUTO` will be marked as partitioned tables
 It is recommended to exclude the schema "information_schema" from the metadata ingestion as it contains system tables and views.
 ### 1. Define the YAML Config
 

--- a/v1.12.x/connectors/database/redshift.mdx
+++ b/v1.12.x/connectors/database/redshift.mdx
@@ -156,9 +156,6 @@ For a complete guide on managing secrets in hybrid setups, see the [Hybrid Inges
     - **Assume Role ARN** (Optional): ARN of a role to assume for cross-account access.
     - **Assume Role Session Name** (Optional): Session name when assuming a role.
 - **Database**: The database of the data source is an optional parameter, if you would like to restrict the metadata reading to a single database. If left blank, OpenMetadata ingestion attempts to scan all the databases.
-<Tip>
-During the metadata ingestion for redshift, the tables in which the distribution style i.e, `DISTSTYLE` is not `AUTO` will be marked as partitioned tables
-</Tip>
 **SSL Configuration**
 In order to integrate SSL in the Metadata Ingestion Config, the user will have to add the SSL config under connectionArguments which is placed in the source.
 **SSL Modes**

--- a/v1.12.x/connectors/database/redshift/yaml.mdx
+++ b/v1.12.x/connectors/database/redshift/yaml.mdx
@@ -146,7 +146,6 @@ the steps to create a YAML configuration able to connect to the source,
 process the Entities if needed, and reach the OpenMetadata server.
 The workflow is modeled around the following
 [JSON Schema](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/workflow.json)
-**Note:** During the metadata ingestion for redshift, the tables in which the distribution style i.e `DISTSTYLE` is not `AUTO` will be marked as partitioned tables
 It is recommended to exclude the schema "information_schema" from the metadata ingestion as it contains system tables and views.
 ### 1. Define the YAML Config
 

--- a/v1.13.x-SNAPSHOT/connectors/database/redshift.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/database/redshift.mdx
@@ -156,9 +156,6 @@ For a complete guide on managing secrets in hybrid setups, see the [Hybrid Inges
     - **Assume Role ARN** (Optional): ARN of a role to assume for cross-account access.
     - **Assume Role Session Name** (Optional): Session name when assuming a role.
 - **Database**: The database of the data source is an optional parameter, if you would like to restrict the metadata reading to a single database. If left blank, OpenMetadata ingestion attempts to scan all the databases.
-<Tip>
-During the metadata ingestion for redshift, the tables in which the distribution style i.e, `DISTSTYLE` is not `AUTO` will be marked as partitioned tables
-</Tip>
 **SSL Configuration**
 In order to integrate SSL in the Metadata Ingestion Config, the user will have to add the SSL config under connectionArguments which is placed in the source.
 **SSL Modes**

--- a/v1.13.x-SNAPSHOT/connectors/database/redshift/yaml.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/database/redshift/yaml.mdx
@@ -146,7 +146,6 @@ the steps to create a YAML configuration able to connect to the source,
 process the Entities if needed, and reach the OpenMetadata server.
 The workflow is modeled around the following
 [JSON Schema](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/workflow.json)
-**Note:** During the metadata ingestion for redshift, the tables in which the distribution style i.e `DISTSTYLE` is not `AUTO` will be marked as partitioned tables
 It is recommended to exclude the schema "information_schema" from the metadata ingestion as it contains system tables and views.
 ### 1. Define the YAML Config
 


### PR DESCRIPTION
Removes documentation references to the incorrect Redshift partition detection logic (DISTSTYLE-based) that was removed in open-metadata/OpenMetadata#26443.

Changes across `v1.11.x`, `v1.12.x`, and `v1.13.x-SNAPSHOT`:
- Removed `<Tip>` about DISTSTYLE partitioned tables from `redshift.mdx`
- Removed `**Note:**` about DISTSTYLE partitioned tables from `redshift/yaml.mdx`