### PR TITLE
Fix curl command formatting issue in Docker Compose docs

### DIFF
--- a/v1.12.x/quick-start/local-docker-deployment.mdx
+++ b/v1.12.x/quick-start/local-docker-deployment.mdx
@@ -70,8 +70,7 @@ Follow the instructions [here](https://docs.docker.com/compose/cli-command/#inst
     DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
 
     mkdir -p $DOCKER_CONFIG/cli-plugins 
-    curl -SL https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-x86_64 -o
-    $DOCKER_CONFIG/cli-plugins/docker-compose
+    curl -SL https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
     ```
     
    This command installs Compose V2 for the active user under $HOME directory. To install Docker Compose for all users


### PR DESCRIPTION
Fix curl command formatting issue in Docker Compose docs

Closes #167

Fixed the curl command by keeping the `-o` flag and output path on the same line so it executes correctly.

Before
<img width="975" height="152" alt="Screenshot from 2026-04-09 02-48-04" src="https://github.com/user-attachments/assets/cb218e53-7697-4b90-8055-cc2159ffbd32" />

After
<img width="1299" height="160" alt="Screenshot from 2026-04-09 02-50-26" src="https://github.com/user-attachments/assets/5cc7c820-7ba6-4c93-bba4-e33474ead952" />

