### PR TITLE
Docs: Update Snowflake connector docs with correct permissions and private key configuration

### DIFF
--- a/v1.11.x/connectors/database/snowflake.mdx
+++ b/v1.11.x/connectors/database/snowflake.mdx
@@ -56,12 +56,14 @@ GRANT USAGE ON WAREHOUSE WAREHOUSE_NAME TO ROLE NEW_ROLE;
 -- Grant USAGE Privilege on Database to New Role
 GRANT USAGE ON DATABASE TEST_DB TO ROLE NEW_ROLE;
 -- Grant USAGE Privilege on required Schemas to New Role
-GRANT USAGE ON SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
+GRANT USAGE on ALL SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT USAGE on FUTURE SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
 -- Grant SELECT Privilege on required tables & views to New Role
-GRANT SELECT ON ALL TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL EXTERNAL TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL VIEWS IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL DYNAMIC TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL FUTURE TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL VIEWS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
 -- Grant IMPORTED PRIVILEGES on all Schemas of SNOWFLAKE DB to New Role,
 -- optional but required for usage, lineage and stored procedure ingestion
 GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE NEW_ROLE;
@@ -98,8 +100,29 @@ For a complete guide on managing secrets in hybrid setups, see the [Hybrid Inges
 - **Role (Optional)**: You can specify the role of user that you would like to ingest with, if no role is specified the default roles assigned to user will be selected.
 - **Warehouse**: Snowflake warehouse is required for executing queries to fetch the metadata. Enter the name of warehouse against which you would like to execute these queries.
 - **Database (Optional)**: The database of the data source is an optional parameter, if you would like to restrict the metadata reading to a single database. If left blank, OpenMetadata ingestion attempts to scan all the databases.
-- **Private Key (Optional)**: If you have configured the key pair authentication for the given user you will have to pass the private key associated with the user in this field. You can checkout [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
-  - The multi-line key needs to be converted to one line with `\n` for line endings i.e. `-----BEGIN ENCRYPTED PRIVATE KEY-----\nMII...\n...\n-----END ENCRYPTED PRIVATE KEY-----`
+- **Private Key (Optional)**: If you have configured the key pair authentication for the given user you will have to pass the private key associated with the user in this field. For more information about key-pair authentication, see [Key-pair authentication and key-pair rotation](https://docs.snowflake.com/en/user-guide/key-pair-auth).
+
+  Ensure your private key is formatted correctly before passing it. The key must be a single line with all line breaks replaced by `\n`.
+    
+  For example, if you've the following multi-line key(raw format),
+
+  ```
+  -----BEGIN ENCRYPTED PRIVATE KEY-----
+  MII..
+  MBQ...
+  CgU..
+  8Lt..
+  ...
+  h+4=
+  -----END ENCRYPTED PRIVATE KEY-----
+  ```
+
+  Replace it with the following single-line key (required format):
+
+  ```
+  -----BEGIN ENCRYPTED PRIVATE KEY-----\nMII..\nMBQ...\nCgU..\n8Lt..\n...\nh+4=\n-----END ENCRYPTED PRIVATE KEY-----\n
+
+  Replace every newline character in your key with a literal `\n`, including after the final line.
 - **Snowflake Passphrase Key (Optional)**: If you have configured the encrypted key pair authentication for the given user you will have to pass the paraphrase associated with the private key in this field. You can checkout [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
 - **Include Temporary and Transient Tables**:
 Optional configuration for ingestion of `TRANSIENT` and `TEMPORARY` tables, By default, it will skip the `TRANSIENT` and `TEMPORARY` tables.

--- a/v1.11.x/connectors/database/snowflake.mdx
+++ b/v1.11.x/connectors/database/snowflake.mdx
@@ -39,48 +39,59 @@ Configure and schedule Snowflake metadata and profiler workflows from the OpenMe
 - [Troubleshooting](/v1.11.x/connectors/database/snowflake/troubleshooting)
 
 ## Requirements
-To ingest basic metadata snowflake user must have the following privileges:
+To ingest basic metadata, the Snowflake user must have the following privileges:
   - `USAGE` Privilege on Warehouse
   - `USAGE` Privilege on Database
   - `USAGE` Privilege on Schema
   - `SELECT` Privilege on Tables
+  
+Before you grant privileges, replace these placeholders with your own values:
+
+| Placeholder | Description |
+|---|---|
+| `<role_name>` | Name of the new Snowflake role you want to create and assign to the user |
+| `<user_name>` | Username for the new Snowflake user being created |
+| `<password>` | A strong password for the new Snowflake user |
+| `<warehouse_name>` | Name of the Snowflake warehouse the new role needs access to |
+| `<database_name>` | Name of the Snowflake database from which you want to ingest data |
+
 ```sql
--- Create New Role
-CREATE ROLE NEW_ROLE;
--- Create New User
-CREATE USER NEW_USER DEFAULT_ROLE=NEW_ROLE PASSWORD='PASSWORD';
+-- Create new role
+CREATE ROLE <role_name>;
+-- Create new user
+CREATE USER <user_name> DEFAULT_ROLE=<role_name> PASSWORD='<password>';
 -- Grant role to user
-GRANT ROLE NEW_ROLE TO USER NEW_USER;
--- Grant USAGE Privilege on Warehouse to New Role
-GRANT USAGE ON WAREHOUSE WAREHOUSE_NAME TO ROLE NEW_ROLE;
--- Grant USAGE Privilege on Database to New Role
-GRANT USAGE ON DATABASE TEST_DB TO ROLE NEW_ROLE;
--- Grant USAGE Privilege on required Schemas to New Role
-GRANT USAGE on ALL SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT USAGE on FUTURE SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
--- Grant SELECT Privilege on required tables & views to New Role
-GRANT SELECT ON ALL FUTURE TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL VIEWS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
--- Grant IMPORTED PRIVILEGES on all Schemas of SNOWFLAKE DB to New Role,
--- optional but required for usage, lineage and stored procedure ingestion
-GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE NEW_ROLE;
+GRANT ROLE <role_name> TO USER <user_name>;
+-- Grant USAGE Privilege on Warehouse to new role created above
+GRANT USAGE ON WAREHOUSE <warehouse_name> TO ROLE <role_name>;
+-- Grant USAGE Privilege on Database to new role created above
+GRANT USAGE ON DATABASE <database_name> TO ROLE <role_name>;
+-- Grant USAGE Privilege on required Schemas to new role created above
+GRANT USAGE ON ALL SCHEMAS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT USAGE ON FUTURE SCHEMAS IN DATABASE <database_name> TO ROLE <role_name>;
+-- Grant SELECT Privilege on required tables & views to new role created above
+GRANT SELECT ON ALL FUTURE TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE EXTERNAL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE DYNAMIC TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+-- Grant IMPORTED PRIVILEGES on all Schemas of SNOWFLAKE DB to new role created above. 
+-- This is optional but required for usage, lineage and stored procedure ingestion
+GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE <role_name>;
 ```
-<Tip>
-If running any of:
-  - Incremental Extraction
-  - Ingesting Tags
-  - Ingesting Stored Procedures
-  - Lineage & Usage Workflow
-The following Grant is needed
-</Tip>
-- **Incremental Extraction**: Openmetadata fetches the information by querying `snowflake.account_usage.tables`.
-- **Ingesting Tags**: Openmetadata fetches the information by querying `snowflake.account_usage.tag_references`.
-- **Lineage & Usage Workflow**: Openmetadata fetches the query logs by querying `snowflake.account_usage.query_history` table. For this the snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database `SNOWFLAKE`.
-You can find more information about the `account_usage` schema [here](https://docs.snowflake.com/en/sql-reference/account-usage).
-- **Ingesting Stored Procedures**: Openmetadata fetches the information by querying `snowflake.account_usage.procedures` & `snowflake.account_usage.functions`.
+### Additional Privileges
+The following workflows require additional grants:
+
+- **Incremental Extraction**: OpenMetadata fetches the information by querying `snowflake.account_usage.tables`.
+- **Ingesting Tags**: OpenMetadata fetches the information by querying `snowflake.account_usage.tag_references`.
+- **Ingesting Stored Procedures**: OpenMetadata fetches the information by querying `snowflake.account_usage.procedures` & `snowflake.account_usage.functions`.
+- **Lineage & Usage Workflow**: OpenMetadata fetches the query logs by querying `snowflake.account_usage.query_history`. For this, the Snowflake user must be granted the `ACCOUNTADMIN` role or a role with `IMPORTED PRIVILEGES` on the `SNOWFLAKE` database.
+
+  For more information about the `account_usage` schema, see [Account Usage](https://docs.snowflake.com/en/sql-reference/account-usage).
+
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"Snowflake"} selectServicePath={"/public/images/connectors/snowflake/select-service.png"} addNewServicePath={"/public/images/connectors/snowflake/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/snowflake/service-connection.png"} />
 # Connection Details
@@ -104,7 +115,7 @@ For a complete guide on managing secrets in hybrid setups, see the [Hybrid Inges
 
   Ensure your private key is formatted correctly before passing it. The key must be a single line with all line breaks replaced by `\n`.
     
-  For example, if you've the following multi-line key(raw format),
+  For example, if you have the following multi-line key (raw format):
 
   ```
   -----BEGIN ENCRYPTED PRIVATE KEY-----
@@ -121,9 +132,10 @@ For a complete guide on managing secrets in hybrid setups, see the [Hybrid Inges
 
   ```
   -----BEGIN ENCRYPTED PRIVATE KEY-----\nMII..\nMBQ...\nCgU..\n8Lt..\n...\nh+4=\n-----END ENCRYPTED PRIVATE KEY-----\n
+  ```
 
   Replace every newline character in your key with a literal `\n`, including after the final line.
-- **Snowflake Passphrase Key (Optional)**: If you have configured the encrypted key pair authentication for the given user you will have to pass the paraphrase associated with the private key in this field. You can checkout [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
+- **Snowflake Passphrase Key (Optional)**: If you have configured the encrypted key pair authentication for the given user you will have to pass the passphrase associated with the private key in this field. You can check out [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
 - **Include Temporary and Transient Tables**:
 Optional configuration for ingestion of `TRANSIENT` and `TEMPORARY` tables, By default, it will skip the `TRANSIENT` and `TEMPORARY` tables.
 - **Include Streams**:
@@ -132,8 +144,8 @@ Optional configuration for ingestion of streams, By default, it will skip the st
 Optional configuration for ingestion of Snowflake stages (internal and external). By default, stages are not ingested.
 - **Query Tag (Optional)**: Session query tag used to monitor usage on Snowflake. To use a query tag, the Snowflake user should have enough privileges to alter the session.
 - **Client Session Keep Alive**: Optional Configuration to keep the session active in case the ingestion job runs for longer duration.
-- **Account Usage Schema Name**: Full name of account usage schema, used in case your used do not have direct access to `SNOWFLAKE.ACCOUNT_USAGE` schema. In such case you can replicate tables `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS` to a custom schema let's say `CUSTOM_DB.CUSTOM_SCHEMA` and provide the same name in this field.
-When using this field make sure you have all these tables available within your custom schema  `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS`.
+- **Account Usage Schema Name**: Full name of account usage schema, used in case your user does not have direct access to `SNOWFLAKE.ACCOUNT_USAGE` schema. In such case you can replicate tables `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS` to a custom schema let's say `CUSTOM_DB.CUSTOM_SCHEMA` and provide the same name in this field.
+When using this field, make sure you have all these tables available within your custom schema  `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS`.
 </Step>
 <AdvancedConfiguration />
 <TestConnection />
@@ -142,7 +154,7 @@ When using this field make sure you have all these tables available within your 
 </Steps>
 ### Incomplete Column Level for Views
 For views with a tag or policy, you may see incorrect lineage, this can be because user may not have enough access to fetch those policies or tags. You need to grant the following privileges in order to fix it.
-checkout [snowflake docs](https://docs.snowflake.com/en/sql-reference/functions/get_ddl#usage-notes) for further details.
+Check out the [Snowflake docs](https://docs.snowflake.com/en/sql-reference/functions/get_ddl#usage-notes) for further details.
 ```
 GRANT APPLY MASKING POLICY TO ROLE NEW_ROLE;
 GRANT APPLY ROW ACCESS POLICY TO ROLE NEW_ROLE;
@@ -150,6 +162,6 @@ GRANT APPLY AGGREGATION POLICY TO ROLE NEW_ROLE;
 GRANT APPLY PROJECTION POLICY TO ROLE NEW_ROLE;
 GRANT APPLY TAG TO ROLE NEW_ROLE;
 ```
-Depending on your view ddl you can grant the relevant privileged as per above queries.
+Depending on your view ddl you can grant the relevant privileges as per above queries.
 
 <Related />

--- a/v1.11.x/connectors/database/snowflake.mdx
+++ b/v1.11.x/connectors/database/snowflake.mdx
@@ -156,11 +156,11 @@ When using this field, make sure you have all these tables available within your
 For views with a tag or policy, you may see incorrect lineage, this can be because user may not have enough access to fetch those policies or tags. You need to grant the following privileges in order to fix it.
 Check out the [Snowflake docs](https://docs.snowflake.com/en/sql-reference/functions/get_ddl#usage-notes) for further details.
 ```
-GRANT APPLY MASKING POLICY TO ROLE NEW_ROLE;
-GRANT APPLY ROW ACCESS POLICY TO ROLE NEW_ROLE;
-GRANT APPLY AGGREGATION POLICY TO ROLE NEW_ROLE;
-GRANT APPLY PROJECTION POLICY TO ROLE NEW_ROLE;
-GRANT APPLY TAG TO ROLE NEW_ROLE;
+GRANT APPLY MASKING POLICY TO ROLE <role_name>;
+GRANT APPLY ROW ACCESS POLICY TO ROLE <role_name>;
+GRANT APPLY AGGREGATION POLICY TO ROLE <role_name>;
+GRANT APPLY PROJECTION POLICY TO ROLE <role_name>;
+GRANT APPLY TAG TO ROLE <role_name>;
 ```
 Depending on your view ddl you can grant the relevant privileges as per above queries.
 

--- a/v1.11.x/connectors/database/snowflake/yaml.mdx
+++ b/v1.11.x/connectors/database/snowflake/yaml.mdx
@@ -74,12 +74,14 @@ GRANT USAGE ON WAREHOUSE WAREHOUSE_NAME TO ROLE NEW_ROLE;
 -- Grant USAGE Privilege on Database to New Role
 GRANT USAGE ON DATABASE TEST_DB TO ROLE NEW_ROLE;
 -- Grant USAGE Privilege on required Schemas to New Role
-GRANT USAGE ON SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
+GRANT USAGE on ALL SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT USAGE on FUTURE SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
 -- Grant SELECT Privilege on required tables & views to New Role
-GRANT SELECT ON ALL TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL EXTERNAL TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL VIEWS IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL DYNAMIC TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL FUTURE TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL VIEWS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
 ```
 While running the usage workflow, Openmetadata fetches the query logs by querying `snowflake.account_usage.query_history` table. For this the snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database `SNOWFLAKE`.
 ```sql
@@ -185,9 +187,30 @@ When using this field make sure you have all these tables available within your 
 
 <ContentSection id={13} title="Private Key" lines="18">
 
-**privateKey**: If you have configured the key pair authentication for the given user you will have to pass the private key associated with the user in this field. You can checkout [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
+**privateKey**: If you have configured the key pair authentication for the given user you will have to pass the private key associated with the user in this field. For more information about key-pair authentication, see [Key-pair authentication and key-pair rotation](https://docs.snowflake.com/en/user-guide/key-pair-auth).<br/><br/>
 
-- The multi-line key needs to be converted to one line with `\n` for line endings i.e. `-----BEGIN ENCRYPTED PRIVATE KEY-----\nMII...\n...\n-----END ENCRYPTED PRIVATE KEY-----`
+Ensure your private key is formatted correctly before passing it. The key must be a single line with all line breaks replaced by `\n`.<br/><br/>
+    
+For example, if you've the following multi-line key(raw format):
+
+```
+-----BEGIN ENCRYPTED PRIVATE KEY-----
+MII..
+MBQ...
+CgU..
+8Lt..
+...
+h+4=
+-----END ENCRYPTED PRIVATE KEY-----
+```
+
+Replace it with the following single-line key (required format):
+
+```
+-----BEGIN ENCRYPTED PRIVATE KEY-----\nMII..\nMBQ...\nCgU..\n8Lt..\n...\nh+4=\n-----END ENCRYPTED PRIVATE KEY-----\n
+```
+
+Replace every newline character in your key with a literal `\n`, including after the final line.
 
 </ContentSection>
 

--- a/v1.11.x/connectors/database/snowflake/yaml.mdx
+++ b/v1.11.x/connectors/database/snowflake/yaml.mdx
@@ -95,6 +95,7 @@ GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE <database_name> TO ROLE <role_na
 GRANT SELECT ON ALL FUTURE VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
 GRANT SELECT ON ALL VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
 GRANT SELECT ON ALL FUTURE DYNAMIC TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE <database_name> TO ROLE <role_name>;
 ```
 
 While running the usage workflow, OpenMetadata fetches the query logs by querying `snowflake.account_usage.query_history` table. For this, the Snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database `SNOWFLAKE`.

--- a/v1.11.x/connectors/database/snowflake/yaml.mdx
+++ b/v1.11.x/connectors/database/snowflake/yaml.mdx
@@ -62,38 +62,53 @@ To ingest basic metadata snowflake user must have the following privileges:
   - `USAGE` Privilege on Database
   - `USAGE` Privilege on Schema
   - `SELECT` Privilege on Tables
+
+Before you grant privileges, replace these placeholders with your own values:
+
+| Placeholder | Description |
+|---|---|
+| `<role_name>` | Name of the new Snowflake role you want to create and assign to the user |
+| `<user_name>` | Username for the new Snowflake user being created |
+| `<password>` | A strong password for the new Snowflake user |
+| `<warehouse_name>` | Name of the Snowflake warehouse the new role needs access to |
+| `<database_name>` | Name of the Snowflake database from which you want to ingest data |
+
 ```sql
--- Create New Role
-CREATE ROLE NEW_ROLE;
--- Create New User
-CREATE USER NEW_USER DEFAULT_ROLE=NEW_ROLE PASSWORD='PASSWORD';
+-- Create new role
+CREATE ROLE <role_name>;
+-- Create new user
+CREATE USER <user_name> DEFAULT_ROLE=<role_name> PASSWORD='<password>';
 -- Grant role to user
-GRANT ROLE NEW_ROLE TO USER NEW_USER;
--- Grant USAGE Privilege on Warehouse to New Role
-GRANT USAGE ON WAREHOUSE WAREHOUSE_NAME TO ROLE NEW_ROLE;
--- Grant USAGE Privilege on Database to New Role
-GRANT USAGE ON DATABASE TEST_DB TO ROLE NEW_ROLE;
--- Grant USAGE Privilege on required Schemas to New Role
-GRANT USAGE on ALL SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT USAGE on FUTURE SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
--- Grant SELECT Privilege on required tables & views to New Role
-GRANT SELECT ON ALL FUTURE TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL VIEWS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT ROLE <role_name> TO USER <user_name>;
+-- Grant USAGE Privilege on Warehouse to new role created above
+GRANT USAGE ON WAREHOUSE <warehouse_name> TO ROLE <role_name>;
+-- Grant USAGE Privilege on Database to new role created above
+GRANT USAGE ON DATABASE <database_name> TO ROLE <role_name>;
+-- Grant USAGE Privilege on required Schemas to new role created above
+GRANT USAGE ON ALL SCHEMAS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT USAGE ON FUTURE SCHEMAS IN DATABASE <database_name> TO ROLE <role_name>;
+-- Grant SELECT Privilege on required tables & views to new role created above
+GRANT SELECT ON ALL FUTURE TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE EXTERNAL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE DYNAMIC TABLES IN DATABASE <database_name> TO ROLE <role_name>;
 ```
-While running the usage workflow, Openmetadata fetches the query logs by querying `snowflake.account_usage.query_history` table. For this the snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database `SNOWFLAKE`.
+
+While running the usage workflow, OpenMetadata fetches the query logs by querying `snowflake.account_usage.query_history` table. For this, the Snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database `SNOWFLAKE`.
 ```sql
 -- Grant IMPORTED PRIVILEGES on all Schemas of SNOWFLAKE DB to New Role
-GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE NEW_ROLE;
+GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE <role_name>;
 ```
-If ingesting tags, the user should also have permissions to query `snowflake.account_usage.tag_references`.For this the snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database
+If ingesting tags, the user should also have permissions to query `snowflake.account_usage.tag_references`. For this, the Snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the `SNOWFLAKE` database.
 ```sql
 -- Grant IMPORTED PRIVILEGES on all Schemas of SNOWFLAKE DB to New Role
-GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE NEW_ROLE;
+GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE <role_name>;
 ```
-You can find more information about the `account_usage` schema [here](https://docs.snowflake.com/en/sql-reference/account-usage).
+For more information about the `account_usage` schema, see [Account Usage](https://docs.snowflake.com/en/sql-reference/account-usage).
+
 ## Metadata Ingestion
 All connectors are defined as JSON Schemas.
 [Here](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/snowflakeConnection.json)
@@ -149,9 +164,9 @@ Configure the source type and service name for your Snowflake connector.
 
 <ContentSection id={7} title="Account Usage Schema" lines="12">
 
-**accountUsageSchema**: Full name of account usage schema, used in case your used do not have direct access to `SNOWFLAKE.ACCOUNT_USAGE` schema. In such case you can replicate tables `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS` to a custom schema let's say `CUSTOM_DB.CUSTOM_SCHEMA` and provide the same name in this field.
+**accountUsageSchema**: Full name of account usage schema, used in case your user does not have direct access to `SNOWFLAKE.ACCOUNT_USAGE` schema. In such case you can replicate tables `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS` to a custom schema let's say `CUSTOM_DB.CUSTOM_SCHEMA` and provide the same name in this field.
 
-When using this field make sure you have all these tables available within your custom schema  `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS`.
+When using this field, make sure you have all these tables available within your custom schema  `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS`.
 
 </ContentSection>
 
@@ -191,7 +206,7 @@ When using this field make sure you have all these tables available within your 
 
 Ensure your private key is formatted correctly before passing it. The key must be a single line with all line breaks replaced by `\n`.<br/><br/>
     
-For example, if you've the following multi-line key(raw format):
+For example, if you have the following multi-line key (raw format):
 
 ```
 -----BEGIN ENCRYPTED PRIVATE KEY-----

--- a/v1.12.x/connectors/database/snowflake.mdx
+++ b/v1.12.x/connectors/database/snowflake.mdx
@@ -56,12 +56,14 @@ GRANT USAGE ON WAREHOUSE WAREHOUSE_NAME TO ROLE NEW_ROLE;
 -- Grant USAGE Privilege on Database to New Role
 GRANT USAGE ON DATABASE TEST_DB TO ROLE NEW_ROLE;
 -- Grant USAGE Privilege on required Schemas to New Role
-GRANT USAGE ON SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
+GRANT USAGE on ALL SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT USAGE on FUTURE SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
 -- Grant SELECT Privilege on required tables & views to New Role
-GRANT SELECT ON ALL TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL EXTERNAL TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL VIEWS IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL DYNAMIC TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL FUTURE TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL VIEWS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
 -- Grant IMPORTED PRIVILEGES on all Schemas of SNOWFLAKE DB to New Role,
 -- optional but required for usage, lineage and stored procedure ingestion
 GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE NEW_ROLE;
@@ -98,8 +100,29 @@ For a complete guide on managing secrets in hybrid setups, see the [Hybrid Inges
 - **Role (Optional)**: You can specify the role of user that you would like to ingest with, if no role is specified the default roles assigned to user will be selected.
 - **Warehouse**: Snowflake warehouse is required for executing queries to fetch the metadata. Enter the name of warehouse against which you would like to execute these queries.
 - **Database (Optional)**: The database of the data source is an optional parameter, if you would like to restrict the metadata reading to a single database. If left blank, OpenMetadata ingestion attempts to scan all the databases.
-- **Private Key (Optional)**: If you have configured the key pair authentication for the given user you will have to pass the private key associated with the user in this field. You can checkout [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
-  - The multi-line key needs to be converted to one line with `\n` for line endings i.e. `-----BEGIN ENCRYPTED PRIVATE KEY-----\nMII...\n...\n-----END ENCRYPTED PRIVATE KEY-----`
+- **Private Key (Optional)**: If you have configured the key pair authentication for the given user you will have to pass the private key associated with the user in this field. For more information about key-pair authentication, see [Key-pair authentication and key-pair rotation](https://docs.snowflake.com/en/user-guide/key-pair-auth).
+
+  Ensure your private key is formatted correctly before passing it. The key must be a single line with all line breaks replaced by `\n`.
+    
+  For example, if you've the following multi-line key(raw format),
+
+  ```
+  -----BEGIN ENCRYPTED PRIVATE KEY-----
+  MII..
+  MBQ...
+  CgU..
+  8Lt..
+  ...
+  h+4=
+  -----END ENCRYPTED PRIVATE KEY-----
+  ```
+
+  Replace it with the following single-line key (required format):
+
+  ```
+  -----BEGIN ENCRYPTED PRIVATE KEY-----\nMII..\nMBQ...\nCgU..\n8Lt..\n...\nh+4=\n-----END ENCRYPTED PRIVATE KEY-----\n
+
+  Replace every newline character in your key with a literal `\n`, including after the final line.
 - **Snowflake Passphrase Key (Optional)**: If you have configured the encrypted key pair authentication for the given user you will have to pass the paraphrase associated with the private key in this field. You can checkout [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
 - **Include Temporary and Transient Tables**:
 Optional configuration for ingestion of `TRANSIENT` and `TEMPORARY` tables, By default, it will skip the `TRANSIENT` and `TEMPORARY` tables.

--- a/v1.12.x/connectors/database/snowflake.mdx
+++ b/v1.12.x/connectors/database/snowflake.mdx
@@ -136,7 +136,7 @@ For a complete guide on managing secrets in hybrid setups, see the [Hybrid Inges
 
   Replace every newline character in your key with a literal `\n`, including after the final line.
 
-- **Snowflake Passphrase Key (Optional)**: If you have configured the encrypted key pair authentication for the given user you will have to pass the paraphrase associated with the private key in this field. You can check out [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
+- **Snowflake Passphrase Key (Optional)**: If you have configured the encrypted key pair authentication for the given user you will have to pass the passphrase associated with the private key in this field. You can check out [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
 - **Include Temporary and Transient Tables**:
 Optional configuration for ingestion of `TRANSIENT` and `TEMPORARY` tables, By default, it will skip the `TRANSIENT` and `TEMPORARY` tables.
 - **Include Streams**:

--- a/v1.12.x/connectors/database/snowflake.mdx
+++ b/v1.12.x/connectors/database/snowflake.mdx
@@ -157,11 +157,11 @@ When using this field, make sure you have all these tables available within your
 For views with a tag or policy, you may see incorrect lineage, this can be because user may not have enough access to fetch those policies or tags. You need to grant the following privileges in order to fix it.
 Check out the [Snowflake docs](https://docs.snowflake.com/en/sql-reference/functions/get_ddl#usage-notes) for further details.
 ```
-GRANT APPLY MASKING POLICY TO ROLE NEW_ROLE;
-GRANT APPLY ROW ACCESS POLICY TO ROLE NEW_ROLE;
-GRANT APPLY AGGREGATION POLICY TO ROLE NEW_ROLE;
-GRANT APPLY PROJECTION POLICY TO ROLE NEW_ROLE;
-GRANT APPLY TAG TO ROLE NEW_ROLE;
+GRANT APPLY MASKING POLICY TO ROLE <role_name>;
+GRANT APPLY ROW ACCESS POLICY TO ROLE <role_name>;
+GRANT APPLY AGGREGATION POLICY TO ROLE <role_name>;
+GRANT APPLY PROJECTION POLICY TO ROLE <role_name>;
+GRANT APPLY TAG TO ROLE <role_name>;
 ```
 Depending on your view ddl you can grant the relevant privileges as per above queries.
 

--- a/v1.12.x/connectors/database/snowflake.mdx
+++ b/v1.12.x/connectors/database/snowflake.mdx
@@ -44,43 +44,54 @@ To ingest basic metadata snowflake user must have the following privileges:
   - `USAGE` Privilege on Database
   - `USAGE` Privilege on Schema
   - `SELECT` Privilege on Tables
+
+Before you grant privileges, replace these placeholders with your own values:
+
+| Placeholder | Description |
+|---|---|
+| `<role_name>` | Name of the new Snowflake role you want to create and assign to the user |
+| `<user_name>` | Username for the new Snowflake user being created |
+| `<password>` | A strong password for the new Snowflake user |
+| `<warehouse_name>` | Name of the Snowflake warehouse the new role needs access to |
+| `<database_name>` | Name of the Snowflake database from which you want to ingest data |
+
 ```sql
--- Create New Role
-CREATE ROLE NEW_ROLE;
--- Create New User
-CREATE USER NEW_USER DEFAULT_ROLE=NEW_ROLE PASSWORD='PASSWORD';
+-- Create new role
+CREATE ROLE <role_name>;
+-- Create new user
+CREATE USER <user_name> DEFAULT_ROLE=<role_name> PASSWORD='<password>';
 -- Grant role to user
-GRANT ROLE NEW_ROLE TO USER NEW_USER;
--- Grant USAGE Privilege on Warehouse to New Role
-GRANT USAGE ON WAREHOUSE WAREHOUSE_NAME TO ROLE NEW_ROLE;
--- Grant USAGE Privilege on Database to New Role
-GRANT USAGE ON DATABASE TEST_DB TO ROLE NEW_ROLE;
--- Grant USAGE Privilege on required Schemas to New Role
-GRANT USAGE on ALL SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT USAGE on FUTURE SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
--- Grant SELECT Privilege on required tables & views to New Role
-GRANT SELECT ON ALL FUTURE TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL VIEWS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
--- Grant IMPORTED PRIVILEGES on all Schemas of SNOWFLAKE DB to New Role,
--- optional but required for usage, lineage and stored procedure ingestion
-GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE NEW_ROLE;
+GRANT ROLE <role_name> TO USER <user_name>;
+-- Grant USAGE Privilege on Warehouse to new role created above
+GRANT USAGE ON WAREHOUSE <warehouse_name> TO ROLE <role_name>;
+-- Grant USAGE Privilege on Database to new role created above
+GRANT USAGE ON DATABASE <database_name> TO ROLE <role_name>;
+-- Grant USAGE Privilege on required Schemas to new role created above
+GRANT USAGE ON ALL SCHEMAS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT USAGE ON FUTURE SCHEMAS IN DATABASE <database_name> TO ROLE <role_name>;
+-- Grant SELECT Privilege on required tables & views to new role created above
+GRANT SELECT ON ALL FUTURE TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE EXTERNAL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE DYNAMIC TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+-- Grant IMPORTED PRIVILEGES on all Schemas of SNOWFLAKE DB to new role created above. 
+-- This is optional but required for usage, lineage and stored procedure ingestion
+GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE <role_name>;
 ```
-<Tip>
-If running any of:
-  - Incremental Extraction
-  - Ingesting Tags
-  - Ingesting Stored Procedures
-  - Lineage & Usage Workflow
-The following Grant is needed
-</Tip>
-- **Incremental Extraction**: Openmetadata fetches the information by querying `snowflake.account_usage.tables`.
-- **Ingesting Tags**: Openmetadata fetches the information by querying `snowflake.account_usage.tag_references`.
-- **Lineage & Usage Workflow**: Openmetadata fetches the query logs by querying `snowflake.account_usage.query_history` table. For this the snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database `SNOWFLAKE`.
-You can find more information about the `account_usage` schema [here](https://docs.snowflake.com/en/sql-reference/account-usage).
-- **Ingesting Stored Procedures**: Openmetadata fetches the information by querying `snowflake.account_usage.procedures` & `snowflake.account_usage.functions`.
+### Additional Privileges
+The following workflows require additional grants:
+
+- **Incremental Extraction**: OpenMetadata fetches the information by querying `snowflake.account_usage.tables`.
+- **Ingesting Tags**: OpenMetadata fetches the information by querying `snowflake.account_usage.tag_references`.
+- **Ingesting Stored Procedures**: OpenMetadata fetches the information by querying `snowflake.account_usage.procedures` & `snowflake.account_usage.functions`.
+- **Lineage & Usage Workflow**: OpenMetadata fetches the query logs by querying `snowflake.account_usage.query_history`. For this, the Snowflake user must be granted the `ACCOUNTADMIN` role or a role with `IMPORTED PRIVILEGES` on the `SNOWFLAKE` database.
+
+  For more information about the `account_usage` schema, see [Account Usage](https://docs.snowflake.com/en/sql-reference/account-usage).
+
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"Snowflake"} selectServicePath={"/public/images/connectors/snowflake/select-service.png"} addNewServicePath={"/public/images/connectors/snowflake/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/snowflake/service-connection.png"} />
 # Connection Details
@@ -104,7 +115,7 @@ For a complete guide on managing secrets in hybrid setups, see the [Hybrid Inges
 
   Ensure your private key is formatted correctly before passing it. The key must be a single line with all line breaks replaced by `\n`.
     
-  For example, if you've the following multi-line key(raw format),
+  For example, if you have the following multi-line key (raw format):
 
   ```
   -----BEGIN ENCRYPTED PRIVATE KEY-----
@@ -121,9 +132,11 @@ For a complete guide on managing secrets in hybrid setups, see the [Hybrid Inges
 
   ```
   -----BEGIN ENCRYPTED PRIVATE KEY-----\nMII..\nMBQ...\nCgU..\n8Lt..\n...\nh+4=\n-----END ENCRYPTED PRIVATE KEY-----\n
+  ```
 
   Replace every newline character in your key with a literal `\n`, including after the final line.
-- **Snowflake Passphrase Key (Optional)**: If you have configured the encrypted key pair authentication for the given user you will have to pass the paraphrase associated with the private key in this field. You can checkout [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
+
+- **Snowflake Passphrase Key (Optional)**: If you have configured the encrypted key pair authentication for the given user you will have to pass the paraphrase associated with the private key in this field. You can check out [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
 - **Include Temporary and Transient Tables**:
 Optional configuration for ingestion of `TRANSIENT` and `TEMPORARY` tables, By default, it will skip the `TRANSIENT` and `TEMPORARY` tables.
 - **Include Streams**:
@@ -132,8 +145,8 @@ Optional configuration for ingestion of streams, By default, it will skip the st
 Optional configuration for ingestion of Snowflake stages (internal and external). By default, stages are not ingested.
 - **Query Tag (Optional)**: Session query tag used to monitor usage on Snowflake. To use a query tag, the Snowflake user should have enough privileges to alter the session.
 - **Client Session Keep Alive**: Optional Configuration to keep the session active in case the ingestion job runs for longer duration.
-- **Account Usage Schema Name**: Full name of account usage schema, used in case your used do not have direct access to `SNOWFLAKE.ACCOUNT_USAGE` schema. In such case you can replicate tables `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS` to a custom schema let's say `CUSTOM_DB.CUSTOM_SCHEMA` and provide the same name in this field.
-When using this field make sure you have all these tables available within your custom schema  `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS`.
+- **Account Usage Schema Name**: Full name of account usage schema, used in case your user does not have direct access to `SNOWFLAKE.ACCOUNT_USAGE` schema. In such case you can replicate tables `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS` to a custom schema let's say `CUSTOM_DB.CUSTOM_SCHEMA` and provide the same name in this field.
+When using this field, make sure you have all these tables available within your custom schema  `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS`.
 </Step>
 <AdvancedConfiguration />
 <TestConnection />
@@ -142,7 +155,7 @@ When using this field make sure you have all these tables available within your 
 </Steps>
 ### Incomplete Column Level for Views
 For views with a tag or policy, you may see incorrect lineage, this can be because user may not have enough access to fetch those policies or tags. You need to grant the following privileges in order to fix it.
-checkout [snowflake docs](https://docs.snowflake.com/en/sql-reference/functions/get_ddl#usage-notes) for further details.
+Check out the [Snowflake docs](https://docs.snowflake.com/en/sql-reference/functions/get_ddl#usage-notes) for further details.
 ```
 GRANT APPLY MASKING POLICY TO ROLE NEW_ROLE;
 GRANT APPLY ROW ACCESS POLICY TO ROLE NEW_ROLE;
@@ -150,6 +163,6 @@ GRANT APPLY AGGREGATION POLICY TO ROLE NEW_ROLE;
 GRANT APPLY PROJECTION POLICY TO ROLE NEW_ROLE;
 GRANT APPLY TAG TO ROLE NEW_ROLE;
 ```
-Depending on your view ddl you can grant the relevant privileged as per above queries.
+Depending on your view ddl you can grant the relevant privileges as per above queries.
 
 <Related />

--- a/v1.12.x/connectors/database/snowflake/yaml.mdx
+++ b/v1.12.x/connectors/database/snowflake/yaml.mdx
@@ -63,38 +63,53 @@ To ingest basic metadata snowflake user must have the following privileges:
   - `USAGE` Privilege on Database
   - `USAGE` Privilege on Schema
   - `SELECT` Privilege on Tables
+
+Before you grant privileges, replace these placeholders with your own values:
+
+| Placeholder | Description |
+|---|---|
+| `<role_name>` | Name of the new Snowflake role you want to create and assign to the user |
+| `<user_name>` | Username for the new Snowflake user being created |
+| `<password>` | A strong password for the new Snowflake user |
+| `<warehouse_name>` | Name of the Snowflake warehouse the new role needs access to |
+| `<database_name>` | Name of the Snowflake database from which you want to ingest data |
+
 ```sql
--- Create New Role
-CREATE ROLE NEW_ROLE;
--- Create New User
-CREATE USER NEW_USER DEFAULT_ROLE=NEW_ROLE PASSWORD='PASSWORD';
+-- Create new role
+CREATE ROLE <role_name>;
+-- Create new user
+CREATE USER <user_name> DEFAULT_ROLE=<role_name> PASSWORD='<password>';
 -- Grant role to user
-GRANT ROLE NEW_ROLE TO USER NEW_USER;
--- Grant USAGE Privilege on Warehouse to New Role
-GRANT USAGE ON WAREHOUSE WAREHOUSE_NAME TO ROLE NEW_ROLE;
--- Grant USAGE Privilege on Database to New Role
-GRANT USAGE ON DATABASE TEST_DB TO ROLE NEW_ROLE;
--- Grant USAGE Privilege on required Schemas to New Role
-GRANT USAGE on ALL SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT USAGE on FUTURE SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
--- Grant SELECT Privilege on required tables & views to New Role
-GRANT SELECT ON ALL FUTURE TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL VIEWS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT ROLE <role_name> TO USER <user_name>;
+-- Grant USAGE Privilege on Warehouse to new role created above
+GRANT USAGE ON WAREHOUSE <warehouse_name> TO ROLE <role_name>;
+-- Grant USAGE Privilege on Database to new role created above
+GRANT USAGE ON DATABASE <database_name> TO ROLE <role_name>;
+-- Grant USAGE Privilege on required Schemas to new role created above
+GRANT USAGE ON ALL SCHEMAS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT USAGE ON FUTURE SCHEMAS IN DATABASE <database_name> TO ROLE <role_name>;
+-- Grant SELECT Privilege on required tables & views to new role created above
+GRANT SELECT ON ALL FUTURE TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE EXTERNAL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE DYNAMIC TABLES IN DATABASE <database_name> TO ROLE <role_name>;
 ```
-While running the usage workflow, Openmetadata fetches the query logs by querying `snowflake.account_usage.query_history` table. For this the snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database `SNOWFLAKE`.
+
+While running the usage workflow, OpenMetadata fetches the query logs by querying `snowflake.account_usage.query_history` table. For this, the Snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database `SNOWFLAKE`.
 ```sql
 -- Grant IMPORTED PRIVILEGES on all Schemas of SNOWFLAKE DB to New Role
-GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE NEW_ROLE;
+GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE <role_name>;
 ```
-If ingesting tags, the user should also have permissions to query `snowflake.account_usage.tag_references`.For this the snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database
+If ingesting tags, the user should also have permissions to query `snowflake.account_usage.tag_references`. For this, the Snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the `SNOWFLAKE` database.
 ```sql
 -- Grant IMPORTED PRIVILEGES on all Schemas of SNOWFLAKE DB to New Role
-GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE NEW_ROLE;
+GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE <role_name>;
 ```
-You can find more information about the `account_usage` schema [here](https://docs.snowflake.com/en/sql-reference/account-usage).
+For more information about the `account_usage` schema, see [Account Usage](https://docs.snowflake.com/en/sql-reference/account-usage).
+
 ## Metadata Ingestion
 All connectors are defined as JSON Schemas.
 [Here](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/snowflakeConnection.json)
@@ -150,9 +165,9 @@ Configure the source type and service name for your Snowflake connector.
 
 <ContentSection id={7} title="Account Usage Schema" lines="12">
 
-**accountUsageSchema**: Full name of account usage schema, used in case your used do not have direct access to `SNOWFLAKE.ACCOUNT_USAGE` schema. In such case you can replicate tables `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS` to a custom schema let's say `CUSTOM_DB.CUSTOM_SCHEMA` and provide the same name in this field.
+**accountUsageSchema**: Full name of account usage schema, used in case your user does not have direct access to `SNOWFLAKE.ACCOUNT_USAGE` schema. In such case you can replicate tables `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS` to a custom schema let's say `CUSTOM_DB.CUSTOM_SCHEMA` and provide the same name in this field.
 
-When using this field make sure you have all these tables available within your custom schema  `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS`.
+When using this field, make sure you have all these tables available within your custom schema  `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS`.
 
 </ContentSection>
 
@@ -192,7 +207,7 @@ When using this field make sure you have all these tables available within your 
 
 Ensure your private key is formatted correctly before passing it. The key must be a single line with all line breaks replaced by `\n`.<br/><br/>
   
-For example, if you've the following multi-line key(raw format):
+For example, if you have the following multi-line key (raw format):
 
 ```
 -----BEGIN ENCRYPTED PRIVATE KEY-----

--- a/v1.12.x/connectors/database/snowflake/yaml.mdx
+++ b/v1.12.x/connectors/database/snowflake/yaml.mdx
@@ -75,12 +75,14 @@ GRANT USAGE ON WAREHOUSE WAREHOUSE_NAME TO ROLE NEW_ROLE;
 -- Grant USAGE Privilege on Database to New Role
 GRANT USAGE ON DATABASE TEST_DB TO ROLE NEW_ROLE;
 -- Grant USAGE Privilege on required Schemas to New Role
-GRANT USAGE ON SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
+GRANT USAGE on ALL SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT USAGE on FUTURE SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
 -- Grant SELECT Privilege on required tables & views to New Role
-GRANT SELECT ON ALL TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL EXTERNAL TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL VIEWS IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL DYNAMIC TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL FUTURE TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL VIEWS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
 ```
 While running the usage workflow, Openmetadata fetches the query logs by querying `snowflake.account_usage.query_history` table. For this the snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database `SNOWFLAKE`.
 ```sql
@@ -186,9 +188,30 @@ When using this field make sure you have all these tables available within your 
 
 <ContentSection id={13} title="Private Key" lines="18">
 
-**privateKey**: If you have configured the key pair authentication for the given user you will have to pass the private key associated with the user in this field. You can checkout [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
+**privateKey**: If you have configured the key pair authentication for the given user you will have to pass the private key associated with the user in this field. For more information about key-pair authentication, see [Key-pair authentication and key-pair rotation](https://docs.snowflake.com/en/user-guide/key-pair-auth).<br/><br/>
 
-- The multi-line key needs to be converted to one line with `\n` for line endings i.e. `-----BEGIN ENCRYPTED PRIVATE KEY-----\nMII...\n...\n-----END ENCRYPTED PRIVATE KEY-----`
+Ensure your private key is formatted correctly before passing it. The key must be a single line with all line breaks replaced by `\n`.<br/><br/>
+  
+For example, if you've the following multi-line key(raw format):
+
+```
+-----BEGIN ENCRYPTED PRIVATE KEY-----
+MII..
+MBQ...
+CgU..
+8Lt..
+...
+h+4=
+-----END ENCRYPTED PRIVATE KEY-----
+```
+
+Replace it with the following single-line key (required format):
+
+```
+-----BEGIN ENCRYPTED PRIVATE KEY-----\nMII..\nMBQ...\nCgU..\n8Lt..\n...\nh+4=\n-----END ENCRYPTED PRIVATE KEY-----\n
+```
+
+Replace every newline character in your key with a literal `\n`, including after the final line.
 
 </ContentSection>
 

--- a/v1.12.x/connectors/database/snowflake/yaml.mdx
+++ b/v1.12.x/connectors/database/snowflake/yaml.mdx
@@ -96,6 +96,7 @@ GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE <database_name> TO ROLE <role_na
 GRANT SELECT ON ALL FUTURE VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
 GRANT SELECT ON ALL VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
 GRANT SELECT ON ALL FUTURE DYNAMIC TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE <database_name> TO ROLE <role_name>;
 ```
 
 While running the usage workflow, OpenMetadata fetches the query logs by querying `snowflake.account_usage.query_history` table. For this, the Snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database `SNOWFLAKE`.

--- a/v1.13.x-SNAPSHOT/connectors/database/snowflake.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/database/snowflake.mdx
@@ -56,12 +56,14 @@ GRANT USAGE ON WAREHOUSE WAREHOUSE_NAME TO ROLE NEW_ROLE;
 -- Grant USAGE Privilege on Database to New Role
 GRANT USAGE ON DATABASE TEST_DB TO ROLE NEW_ROLE;
 -- Grant USAGE Privilege on required Schemas to New Role
-GRANT USAGE ON SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
+GRANT USAGE on ALL SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT USAGE on FUTURE SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
 -- Grant SELECT Privilege on required tables & views to New Role
-GRANT SELECT ON ALL TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL EXTERNAL TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL VIEWS IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL DYNAMIC TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL FUTURE TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL VIEWS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
 -- Grant IMPORTED PRIVILEGES on all Schemas of SNOWFLAKE DB to New Role,
 -- optional but required for usage, lineage and stored procedure ingestion
 GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE NEW_ROLE;
@@ -98,8 +100,29 @@ For a complete guide on managing secrets in hybrid setups, see the [Hybrid Inges
 - **Role (Optional)**: You can specify the role of user that you would like to ingest with, if no role is specified the default roles assigned to user will be selected.
 - **Warehouse**: Snowflake warehouse is required for executing queries to fetch the metadata. Enter the name of warehouse against which you would like to execute these queries.
 - **Database (Optional)**: The database of the data source is an optional parameter, if you would like to restrict the metadata reading to a single database. If left blank, OpenMetadata ingestion attempts to scan all the databases.
-- **Private Key (Optional)**: If you have configured the key pair authentication for the given user you will have to pass the private key associated with the user in this field. You can checkout [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
-  - The multi-line key needs to be converted to one line with `\n` for line endings i.e. `-----BEGIN ENCRYPTED PRIVATE KEY-----\nMII...\n...\n-----END ENCRYPTED PRIVATE KEY-----`
+- **Private Key (Optional)**: If you have configured the key pair authentication for the given user you will have to pass the private key associated with the user in this field. For more information about key-pair authentication, see [Key-pair authentication and key-pair rotation](https://docs.snowflake.com/en/user-guide/key-pair-auth).
+
+  Ensure your private key is formatted correctly before passing it. The key must be a single line with all line breaks replaced by `\n`.
+    
+  For example, if you've the following multi-line key(raw format),
+
+  ```
+  -----BEGIN ENCRYPTED PRIVATE KEY-----
+  MII..
+  MBQ...
+  CgU..
+  8Lt..
+  ...
+  h+4=
+  -----END ENCRYPTED PRIVATE KEY-----
+  ```
+
+  Replace it with the following single-line key (required format):
+
+  ```
+  -----BEGIN ENCRYPTED PRIVATE KEY-----\nMII..\nMBQ...\nCgU..\n8Lt..\n...\nh+4=\n-----END ENCRYPTED PRIVATE KEY-----\n
+
+  Replace every newline character in your key with a literal `\n`, including after the final line.
 - **Snowflake Passphrase Key (Optional)**: If you have configured the encrypted key pair authentication for the given user you will have to pass the paraphrase associated with the private key in this field. You can checkout [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
 - **Include Temporary and Transient Tables**:
 Optional configuration for ingestion of `TRANSIENT` and `TEMPORARY` tables, By default, it will skip the `TRANSIENT` and `TEMPORARY` tables.

--- a/v1.13.x-SNAPSHOT/connectors/database/snowflake.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/database/snowflake.mdx
@@ -135,7 +135,7 @@ For a complete guide on managing secrets in hybrid setups, see the [Hybrid Inges
   ```
 
   Replace every newline character in your key with a literal `\n`, including after the final line.
-- **Snowflake Passphrase Key (Optional)**: If you have configured the encrypted key pair authentication for the given user you will have to pass the paraphrase associated with the private key in this field. You can check out [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
+- **Snowflake Passphrase Key (Optional)**: If you have configured the encrypted key pair authentication for the given user you will have to pass the passphrase associated with the private key in this field. You can check out [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
 - **Include Temporary and Transient Tables**:
 Optional configuration for ingestion of `TRANSIENT` and `TEMPORARY` tables, By default, it will skip the `TRANSIENT` and `TEMPORARY` tables.
 - **Include Streams**:

--- a/v1.13.x-SNAPSHOT/connectors/database/snowflake.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/database/snowflake.mdx
@@ -44,43 +44,54 @@ To ingest basic metadata snowflake user must have the following privileges:
   - `USAGE` Privilege on Database
   - `USAGE` Privilege on Schema
   - `SELECT` Privilege on Tables
+  
+Before you grant privileges, replace these placeholders with your own values:
+
+| Placeholder | Description |
+|---|---|
+| `<role_name>` | Name of the new Snowflake role you want to create and assign to the user |
+| `<user_name>` | Username for the new Snowflake user being created |
+| `<password>` | A strong password for the new Snowflake user |
+| `<warehouse_name>` | Name of the Snowflake warehouse the new role needs access to |
+| `<database_name>` | Name of the Snowflake database from which you want to ingest data |
+
 ```sql
--- Create New Role
-CREATE ROLE NEW_ROLE;
--- Create New User
-CREATE USER NEW_USER DEFAULT_ROLE=NEW_ROLE PASSWORD='PASSWORD';
+-- Create new role
+CREATE ROLE <role_name>;
+-- Create new user
+CREATE USER <user_name> DEFAULT_ROLE=<role_name> PASSWORD='<password>';
 -- Grant role to user
-GRANT ROLE NEW_ROLE TO USER NEW_USER;
--- Grant USAGE Privilege on Warehouse to New Role
-GRANT USAGE ON WAREHOUSE WAREHOUSE_NAME TO ROLE NEW_ROLE;
--- Grant USAGE Privilege on Database to New Role
-GRANT USAGE ON DATABASE TEST_DB TO ROLE NEW_ROLE;
--- Grant USAGE Privilege on required Schemas to New Role
-GRANT USAGE on ALL SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT USAGE on FUTURE SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
--- Grant SELECT Privilege on required tables & views to New Role
-GRANT SELECT ON ALL FUTURE TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL VIEWS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
--- Grant IMPORTED PRIVILEGES on all Schemas of SNOWFLAKE DB to New Role,
--- optional but required for usage, lineage and stored procedure ingestion
-GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE NEW_ROLE;
+GRANT ROLE <role_name> TO USER <user_name>;
+-- Grant USAGE Privilege on Warehouse to new role created above
+GRANT USAGE ON WAREHOUSE <warehouse_name> TO ROLE <role_name>;
+-- Grant USAGE Privilege on Database to new role created above
+GRANT USAGE ON DATABASE <database_name> TO ROLE <role_name>;
+-- Grant USAGE Privilege on required Schemas to new role created above
+GRANT USAGE ON ALL SCHEMAS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT USAGE ON FUTURE SCHEMAS IN DATABASE <database_name> TO ROLE <role_name>;
+-- Grant SELECT Privilege on required tables & views to new role created above
+GRANT SELECT ON ALL FUTURE TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE EXTERNAL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE DYNAMIC TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+-- Grant IMPORTED PRIVILEGES on all Schemas of SNOWFLAKE DB to new role created above. 
+-- This is optional but required for usage, lineage and stored procedure ingestion
+GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE <role_name>;
 ```
-<Tip>
-If running any of:
-  - Incremental Extraction
-  - Ingesting Tags
-  - Ingesting Stored Procedures
-  - Lineage & Usage Workflow
-The following Grant is needed
-</Tip>
-- **Incremental Extraction**: Openmetadata fetches the information by querying `snowflake.account_usage.tables`.
-- **Ingesting Tags**: Openmetadata fetches the information by querying `snowflake.account_usage.tag_references`.
-- **Lineage & Usage Workflow**: Openmetadata fetches the query logs by querying `snowflake.account_usage.query_history` table. For this the snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database `SNOWFLAKE`.
-You can find more information about the `account_usage` schema [here](https://docs.snowflake.com/en/sql-reference/account-usage).
-- **Ingesting Stored Procedures**: Openmetadata fetches the information by querying `snowflake.account_usage.procedures` & `snowflake.account_usage.functions`.
+### Additional Privileges
+The following workflows require additional grants:
+
+- **Incremental Extraction**: OpenMetadata fetches the information by querying `snowflake.account_usage.tables`.
+- **Ingesting Tags**: OpenMetadata fetches the information by querying `snowflake.account_usage.tag_references`.
+- **Ingesting Stored Procedures**: OpenMetadata fetches the information by querying `snowflake.account_usage.procedures` & `snowflake.account_usage.functions`.
+- **Lineage & Usage Workflow**: OpenMetadata fetches the query logs by querying `snowflake.account_usage.query_history`. For this, the Snowflake user must be granted the `ACCOUNTADMIN` role or a role with `IMPORTED PRIVILEGES` on the `SNOWFLAKE` database.
+
+  For more information about the `account_usage` schema, see [Account Usage](https://docs.snowflake.com/en/sql-reference/account-usage).
+
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"Snowflake"} selectServicePath={"/public/images/connectors/snowflake/select-service.png"} addNewServicePath={"/public/images/connectors/snowflake/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/snowflake/service-connection.png"} />
 # Connection Details
@@ -104,7 +115,7 @@ For a complete guide on managing secrets in hybrid setups, see the [Hybrid Inges
 
   Ensure your private key is formatted correctly before passing it. The key must be a single line with all line breaks replaced by `\n`.
     
-  For example, if you've the following multi-line key(raw format),
+  For example, if you have the following multi-line key (raw format):
 
   ```
   -----BEGIN ENCRYPTED PRIVATE KEY-----
@@ -121,9 +132,10 @@ For a complete guide on managing secrets in hybrid setups, see the [Hybrid Inges
 
   ```
   -----BEGIN ENCRYPTED PRIVATE KEY-----\nMII..\nMBQ...\nCgU..\n8Lt..\n...\nh+4=\n-----END ENCRYPTED PRIVATE KEY-----\n
+  ```
 
   Replace every newline character in your key with a literal `\n`, including after the final line.
-- **Snowflake Passphrase Key (Optional)**: If you have configured the encrypted key pair authentication for the given user you will have to pass the paraphrase associated with the private key in this field. You can checkout [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
+- **Snowflake Passphrase Key (Optional)**: If you have configured the encrypted key pair authentication for the given user you will have to pass the paraphrase associated with the private key in this field. You can check out [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
 - **Include Temporary and Transient Tables**:
 Optional configuration for ingestion of `TRANSIENT` and `TEMPORARY` tables, By default, it will skip the `TRANSIENT` and `TEMPORARY` tables.
 - **Include Streams**:
@@ -132,8 +144,8 @@ Optional configuration for ingestion of streams, By default, it will skip the st
 Optional configuration for ingestion of Snowflake stages (internal and external). By default, stages are not ingested.
 - **Query Tag (Optional)**: Session query tag used to monitor usage on Snowflake. To use a query tag, the Snowflake user should have enough privileges to alter the session.
 - **Client Session Keep Alive**: Optional Configuration to keep the session active in case the ingestion job runs for longer duration.
-- **Account Usage Schema Name**: Full name of account usage schema, used in case your used do not have direct access to `SNOWFLAKE.ACCOUNT_USAGE` schema. In such case you can replicate tables `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS` to a custom schema let's say `CUSTOM_DB.CUSTOM_SCHEMA` and provide the same name in this field.
-When using this field make sure you have all these tables available within your custom schema  `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS`.
+- **Account Usage Schema Name**: Full name of account usage schema, used in case your user does not have direct access to `SNOWFLAKE.ACCOUNT_USAGE` schema. In such case you can replicate tables `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS` to a custom schema let's say `CUSTOM_DB.CUSTOM_SCHEMA` and provide the same name in this field.
+When using this field, make sure you have all these tables available within your custom schema  `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS`.
 </Step>
 <AdvancedConfiguration />
 <TestConnection />
@@ -142,7 +154,7 @@ When using this field make sure you have all these tables available within your 
 </Steps>
 ### Incomplete Column Level for Views
 For views with a tag or policy, you may see incorrect lineage, this can be because user may not have enough access to fetch those policies or tags. You need to grant the following privileges in order to fix it.
-checkout [snowflake docs](https://docs.snowflake.com/en/sql-reference/functions/get_ddl#usage-notes) for further details.
+Check out the [Snowflake docs](https://docs.snowflake.com/en/sql-reference/functions/get_ddl#usage-notes) for further details.
 ```
 GRANT APPLY MASKING POLICY TO ROLE NEW_ROLE;
 GRANT APPLY ROW ACCESS POLICY TO ROLE NEW_ROLE;
@@ -150,6 +162,6 @@ GRANT APPLY AGGREGATION POLICY TO ROLE NEW_ROLE;
 GRANT APPLY PROJECTION POLICY TO ROLE NEW_ROLE;
 GRANT APPLY TAG TO ROLE NEW_ROLE;
 ```
-Depending on your view ddl you can grant the relevant privileged as per above queries.
+Depending on your view ddl you can grant the relevant privileges as per above queries.
 
 <Related />

--- a/v1.13.x-SNAPSHOT/connectors/database/snowflake.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/database/snowflake.mdx
@@ -156,11 +156,11 @@ When using this field, make sure you have all these tables available within your
 For views with a tag or policy, you may see incorrect lineage, this can be because user may not have enough access to fetch those policies or tags. You need to grant the following privileges in order to fix it.
 Check out the [Snowflake docs](https://docs.snowflake.com/en/sql-reference/functions/get_ddl#usage-notes) for further details.
 ```
-GRANT APPLY MASKING POLICY TO ROLE NEW_ROLE;
-GRANT APPLY ROW ACCESS POLICY TO ROLE NEW_ROLE;
-GRANT APPLY AGGREGATION POLICY TO ROLE NEW_ROLE;
-GRANT APPLY PROJECTION POLICY TO ROLE NEW_ROLE;
-GRANT APPLY TAG TO ROLE NEW_ROLE;
+GRANT APPLY MASKING POLICY TO ROLE <role_name>;
+GRANT APPLY ROW ACCESS POLICY TO ROLE <role_name>;
+GRANT APPLY AGGREGATION POLICY TO ROLE <role_name>;
+GRANT APPLY PROJECTION POLICY TO ROLE <role_name>;
+GRANT APPLY TAG TO ROLE <role_name>;
 ```
 Depending on your view ddl you can grant the relevant privileges as per above queries.
 

--- a/v1.13.x-SNAPSHOT/connectors/database/snowflake/yaml.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/database/snowflake/yaml.mdx
@@ -63,38 +63,53 @@ To ingest basic metadata snowflake user must have the following privileges:
   - `USAGE` Privilege on Database
   - `USAGE` Privilege on Schema
   - `SELECT` Privilege on Tables
+
+Before you grant privileges, replace these placeholders with your own values:
+
+| Placeholder | Description |
+|---|---|
+| `<role_name>` | Name of the new Snowflake role you want to create and assign to the user |
+| `<user_name>` | Username for the new Snowflake user being created |
+| `<password>` | A strong password for the new Snowflake user |
+| `<warehouse_name>` | Name of the Snowflake warehouse the new role needs access to |
+| `<database_name>` | Name of the Snowflake database from which you want to ingest data |
+
 ```sql
--- Create New Role
-CREATE ROLE NEW_ROLE;
--- Create New User
-CREATE USER NEW_USER DEFAULT_ROLE=NEW_ROLE PASSWORD='PASSWORD';
+-- Create new role
+CREATE ROLE <role_name>;
+-- Create new user
+CREATE USER <user_name> DEFAULT_ROLE=<role_name> PASSWORD='<password>';
 -- Grant role to user
-GRANT ROLE NEW_ROLE TO USER NEW_USER;
--- Grant USAGE Privilege on Warehouse to New Role
-GRANT USAGE ON WAREHOUSE WAREHOUSE_NAME TO ROLE NEW_ROLE;
--- Grant USAGE Privilege on Database to New Role
-GRANT USAGE ON DATABASE TEST_DB TO ROLE NEW_ROLE;
--- Grant USAGE Privilege on required Schemas to New Role
-GRANT USAGE on ALL SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT USAGE on FUTURE SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
--- Grant SELECT Privilege on required tables & views to New Role
-GRANT SELECT ON ALL FUTURE TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL VIEWS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT ROLE <role_name> TO USER <user_name>;
+-- Grant USAGE Privilege on Warehouse to new role created above
+GRANT USAGE ON WAREHOUSE <warehouse_name> TO ROLE <role_name>;
+-- Grant USAGE Privilege on Database to new role created above
+GRANT USAGE ON DATABASE <database_name> TO ROLE <role_name>;
+-- Grant USAGE Privilege on required Schemas to new role created above
+GRANT USAGE ON ALL SCHEMAS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT USAGE ON FUTURE SCHEMAS IN DATABASE <database_name> TO ROLE <role_name>;
+-- Grant SELECT Privilege on required tables & views to new role created above
+GRANT SELECT ON ALL FUTURE TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE EXTERNAL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL FUTURE DYNAMIC TABLES IN DATABASE <database_name> TO ROLE <role_name>;
 ```
-While running the usage workflow, Openmetadata fetches the query logs by querying `snowflake.account_usage.query_history` table. For this the snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database `SNOWFLAKE`.
+
+While running the usage workflow, OpenMetadata fetches the query logs by querying `snowflake.account_usage.query_history` table. For this, the Snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database `SNOWFLAKE`.
 ```sql
 -- Grant IMPORTED PRIVILEGES on all Schemas of SNOWFLAKE DB to New Role
-GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE NEW_ROLE;
+GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE <role_name>;
 ```
-If ingesting tags, the user should also have permissions to query `snowflake.account_usage.tag_references`.For this the snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database
+If ingesting tags, the user should also have permissions to query `snowflake.account_usage.tag_references`. For this, the Snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the `SNOWFLAKE` database.
 ```sql
 -- Grant IMPORTED PRIVILEGES on all Schemas of SNOWFLAKE DB to New Role
-GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE NEW_ROLE;
+GRANT IMPORTED PRIVILEGES ON ALL SCHEMAS IN DATABASE SNOWFLAKE TO ROLE <role_name>;
 ```
-You can find more information about the `account_usage` schema [here](https://docs.snowflake.com/en/sql-reference/account-usage).
+For more information about the `account_usage` schema, see [Account Usage](https://docs.snowflake.com/en/sql-reference/account-usage).
+
 ## Metadata Ingestion
 All connectors are defined as JSON Schemas.
 [Here](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/snowflakeConnection.json)
@@ -150,9 +165,9 @@ Configure the source type and service name for your Snowflake connector.
 
 <ContentSection id={7} title="Account Usage Schema" lines="12">
 
-**accountUsageSchema**: Full name of account usage schema, used in case your used do not have direct access to `SNOWFLAKE.ACCOUNT_USAGE` schema. In such case you can replicate tables `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS` to a custom schema let's say `CUSTOM_DB.CUSTOM_SCHEMA` and provide the same name in this field.
+**accountUsageSchema**: Full name of account usage schema, used in case your user does not have direct access to `SNOWFLAKE.ACCOUNT_USAGE` schema. In such case you can replicate tables `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS` to a custom schema let's say `CUSTOM_DB.CUSTOM_SCHEMA` and provide the same name in this field.
 
-When using this field make sure you have all these tables available within your custom schema  `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS`.
+When using this field, make sure you have all these tables available within your custom schema  `QUERY_HISTORY`, `TAG_REFERENCES`, `PROCEDURES`, `FUNCTIONS`.
 
 </ContentSection>
 
@@ -192,7 +207,7 @@ When using this field make sure you have all these tables available within your 
 
 Ensure your private key is formatted correctly before passing it. The key must be a single line with all line breaks replaced by `\n`.<br/><br/>
   
-For example, if you've the following multi-line key(raw format):
+For example, if you have the following multi-line key (raw format):
 
 ```
 -----BEGIN ENCRYPTED PRIVATE KEY-----

--- a/v1.13.x-SNAPSHOT/connectors/database/snowflake/yaml.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/database/snowflake/yaml.mdx
@@ -75,12 +75,14 @@ GRANT USAGE ON WAREHOUSE WAREHOUSE_NAME TO ROLE NEW_ROLE;
 -- Grant USAGE Privilege on Database to New Role
 GRANT USAGE ON DATABASE TEST_DB TO ROLE NEW_ROLE;
 -- Grant USAGE Privilege on required Schemas to New Role
-GRANT USAGE ON SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
+GRANT USAGE on ALL SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT USAGE on FUTURE SCHEMAS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
 -- Grant SELECT Privilege on required tables & views to New Role
-GRANT SELECT ON ALL TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL EXTERNAL TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL VIEWS IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
-GRANT SELECT ON ALL DYNAMIC TABLES IN SCHEMA TEST_SCHEMA TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL FUTURE TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL VIEWS IN DATABASE TEST_DB TO ROLE NEW_ROLE;
+GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE TEST_DB TO ROLE NEW_ROLE;
 ```
 While running the usage workflow, Openmetadata fetches the query logs by querying `snowflake.account_usage.query_history` table. For this the snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database `SNOWFLAKE`.
 ```sql
@@ -186,9 +188,30 @@ When using this field make sure you have all these tables available within your 
 
 <ContentSection id={13} title="Private Key" lines="18">
 
-**privateKey**: If you have configured the key pair authentication for the given user you will have to pass the private key associated with the user in this field. You can checkout [this](https://docs.snowflake.com/en/user-guide/key-pair-auth) doc to get more details about key-pair authentication.
+**privateKey**: If you have configured the key pair authentication for the given user you will have to pass the private key associated with the user in this field. For more information about key-pair authentication, see [Key-pair authentication and key-pair rotation](https://docs.snowflake.com/en/user-guide/key-pair-auth).<br/><br/>
 
-- The multi-line key needs to be converted to one line with `\n` for line endings i.e. `-----BEGIN ENCRYPTED PRIVATE KEY-----\nMII...\n...\n-----END ENCRYPTED PRIVATE KEY-----`
+Ensure your private key is formatted correctly before passing it. The key must be a single line with all line breaks replaced by `\n`.<br/><br/>
+  
+For example, if you've the following multi-line key(raw format):
+
+```
+-----BEGIN ENCRYPTED PRIVATE KEY-----
+MII..
+MBQ...
+CgU..
+8Lt..
+...
+h+4=
+-----END ENCRYPTED PRIVATE KEY-----
+```
+
+Replace it with the following single-line key (required format):
+
+```
+-----BEGIN ENCRYPTED PRIVATE KEY-----\nMII..\nMBQ...\nCgU..\n8Lt..\n...\nh+4=\n-----END ENCRYPTED PRIVATE KEY-----\n
+```
+
+Replace every newline character in your key with a literal `\n`, including after the final line.
 
 </ContentSection>
 

--- a/v1.13.x-SNAPSHOT/connectors/database/snowflake/yaml.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/database/snowflake/yaml.mdx
@@ -96,6 +96,7 @@ GRANT SELECT ON ALL EXTERNAL TABLES IN DATABASE <database_name> TO ROLE <role_na
 GRANT SELECT ON ALL FUTURE VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
 GRANT SELECT ON ALL VIEWS IN DATABASE <database_name> TO ROLE <role_name>;
 GRANT SELECT ON ALL FUTURE DYNAMIC TABLES IN DATABASE <database_name> TO ROLE <role_name>;
+GRANT SELECT ON ALL DYNAMIC TABLES IN DATABASE <database_name> TO ROLE <role_name>;
 ```
 
 While running the usage workflow, OpenMetadata fetches the query logs by querying `snowflake.account_usage.query_history` table. For this, the Snowflake user should be granted the `ACCOUNTADMIN` role or a role granted IMPORTED PRIVILEGES on the database `SNOWFLAKE`.


### PR DESCRIPTION
# Summary

- **Permissions**: Updated SQL permission grants to use database-level scope instead of schema-level (`TEST_SCHEMA` → `TEST_DB`), covering all current and future schemas, tables, views, external tables, and dynamic tables. 
<img width="1351" height="629" alt="image" src="https://github.com/user-attachments/assets/d1cdba70-29cc-4bcb-a5aa-ab6354267489" />

- **Private Key formatting**: Replaced the one-liner hint with a clear before/after example showing the raw multi-line key format vs. the required single-line `\n`-escaped format. Clarified that the trailing newline must also be escaped.
<img width="2940" height="1622" alt="image" src="https://github.com/user-attachments/assets/407c72d1-c4d8-4f04-b919-8574cb0c68e9" />

Changes applied across all three versions: v1.11.x, v1.12.x, and v1.13.x-SNAPSHOT (both `snowflake.mdx` and `snowflake/yaml.mdx`).

## Test plan

- [ ] Verify SQL permission blocks render correctly in local preview (`mint dev`)
- [ ] Verify private key code block examples render correctly on all three version pages
- [ ] Check no broken links introduced (`mint broken-links`)