### PR TITLE
docs(airbyte): auth section in connector config

### DIFF
--- a/v1.12.x/connectors/pipeline/airbyte/yaml.mdx
+++ b/v1.12.x/connectors/pipeline/airbyte/yaml.mdx
@@ -74,8 +74,9 @@ source:
     config:
       type: Airbyte
       hostPort: http://localhost:8000
-      username: <username>
-      password: <password>
+      auth:
+        username: <username>
+        password: <password>
       apiVersion: api/v1
 ```
 <SourceConfig />

--- a/v1.13.x-SNAPSHOT/connectors/pipeline/airbyte/yaml.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/pipeline/airbyte/yaml.mdx
@@ -74,8 +74,9 @@ source:
     config:
       type: Airbyte
       hostPort: http://localhost:8000
-      username: <username>
-      password: <password>
+      auth:
+        username: <username>
+        password: <password>
       apiVersion: api/v1
 ```
 <SourceConfig />


### PR DESCRIPTION
Updating the Airbyte connector config `auth` section : `username` and `password` must be under `auth` according to https://github.com/open-metadata/OpenMetadata/blob/c43a215bf0ef25d14033c46adbcdcf80dce2de54/ingestion/src/metadata/ingestion/source/pipeline/airbyte/client.py#L77-L78