### PR TITLE
Docs: Restructure Metadata Ingestion topic in the Connector docs component for clarity and readability

### DIFF
--- a/snippets/components/MetadataIngestionUi.jsx
+++ b/snippets/components/MetadataIngestionUi.jsx
@@ -1,10 +1,9 @@
 export const MetadataIngestionUi = ({ connector, selectServicePath, addNewServicePath, serviceConnectionPath }) => {
   return (
-    
   <>
     <p>
       To ingest metadata from your sources, you need to create a service connection.
-      The service connects your source system with Collate. Once you create
+      The service connects your source system with OpenMetadata. Once you create
       a service, you can use it to configure your ingestion workflows.<br/>
       <br/>
       To create a service connection and ingest your metadata, follow the steps below:
@@ -33,23 +32,21 @@ export const MetadataIngestionUi = ({ connector, selectServicePath, addNewServic
         {selectServicePath && <img src={selectServicePath} alt="Select Service" />}
       </Step>
 
-      <Step title="Name and Describe your Service">
-        Enter a unique, descriptive <strong>Service Name</strong>, and <strong>Description</strong>.
+      <Step title="Name and Describe the Service">
+        Enter a unique <strong>Service Name</strong> and <strong>Description</strong>.
         <ul>
          <li><strong>Service Name</strong>: OpenMetadata identifies services by their service name. Enter a name that distinguishes this deployment from other services, including other {connector} services you are ingesting metadata from.</li>
         </ul>
 
         <Note>
-           The service name cannot be changed after it is set.
+          The service name cannot be changed after it is set.
        </Note>
 
         {addNewServicePath && <img src={addNewServicePath} alt="Add New Service" />}
       </Step>
 
       <Step title="Configure the Service Connection">
-        Set up the connection settings required for {connector}. <br/><br/>
-      
-        Configure the following connection settings to set up the service and start ingesting metadata from your sources. The right-hand panel displays help documentation for the selected connection type in the product UI. <br/><br/>
+        Set up the connection settings required for {connector} to set up the service and start ingesting metadata from your sources. The right-hand panel displays help documentation for the selected connection type in the product UI.
         {serviceConnectionPath && <img src={serviceConnectionPath} alt="Configure Service connection" />}
       </Step>
     </Steps>

--- a/snippets/components/MetadataIngestionUi.jsx
+++ b/snippets/components/MetadataIngestionUi.jsx
@@ -36,7 +36,7 @@ export const MetadataIngestionUi = ({ connector, selectServicePath, addNewServic
       <Step title="Name and Describe your Service">
         Enter a unique, descriptive <strong>Service Name</strong>, and <strong>Description</strong>.
         <ul>
-         <li><strong>Service Name</strong>: Collate identifies services by their service name. Enter a name that distinguishes this deployment from other services, including other {connector} services you are ingesting metadata from.</li>
+         <li><strong>Service Name</strong>: OpenMetadata identifies services by their service name. Enter a name that distinguishes this deployment from other services, including other {connector} services you are ingesting metadata from.</li>
         </ul>
 
         <Note>

--- a/snippets/components/MetadataIngestionUi.jsx
+++ b/snippets/components/MetadataIngestionUi.jsx
@@ -1,53 +1,58 @@
 export const MetadataIngestionUi = ({ connector, selectServicePath, addNewServicePath, serviceConnectionPath }) => {
   return (
-    <Steps>
-      <Step title="Visit the Services Page">
-        Click `Settings` in the side navigation bar and then `Services`.
-
-        The first step is to ingest the metadata from your sources. To do that, you first need to create a Service connection first.
-
-        This Service will be the bridge between OpenMetadata and your source system.
-
-        Once a Service is created, it can be used to configure your ingestion workflows.
-
-        <img src="/public/images/connectors/visit-services-page.png" alt="Visit Services Page" />
+    
+  <>
+    <p>
+      To ingest metadata from your sources, you need to create a service connection.
+      The service connects your source system with Collate. Once you create
+      a service, you can use it to configure your ingestion workflows.<br/>
+      <br/>
+      To create a service connection and ingest your metadata, follow the steps below:
+    </p>
+      <Steps>
+      <Step title="Select the Service">
+        <ol>
+          <li>
+            On the left navigation bar, click <strong>Settings</strong>.
+          </li>
+          <li>
+            On the next page, click <strong>Services</strong>, and then select the service.
+            <img src="/public/images/connectors/visit-services-page.png" alt="Visit Services Page" />
+          </li>
+        </ol>
       </Step>
 
       <Step title="Create a New Service">
-        Click on _Add New Service_ to start the Service creation.
-
+        To add a new service connection, click <strong>Add New Service</strong>.
         <img src="/public/images/connectors/create-new-service.png" alt="Create a new Service" />
       </Step>
 
-      <Step title="Select the Service Type">
-        Select {connector} as the Service type and click _Next_.
+      <Step title="Select the Connector">
+        Select <strong>{connector}</strong> as the service type and click <strong>Next</strong>.
 
         {selectServicePath && <img src={selectServicePath} alt="Select Service" />}
       </Step>
 
       <Step title="Name and Describe your Service">
-        Provide a name and description for your Service.
+        Enter a unique, descriptive <strong>Service Name</strong>, and <strong>Description</strong>.
+        <ul>
+         <li><strong>Service Name</strong>: Collate identifies services by their service name. Enter a name that distinguishes this deployment from other services, including other {connector} services you are ingesting metadata from.</li>
+        </ul>
 
-        <h4>Service Name</h4>
-
-        OpenMetadata uniquely identifies Services by their **Service Name**. Provide
-        a name that distinguishes your deployment from other Services, including
-        the other {connector} Services that you might be ingesting metadata
-        from.
-
-        Note that when the name is set, it cannot be changed.
+        <Note>
+           The service name cannot be changed after it is set.
+       </Note>
 
         {addNewServicePath && <img src={addNewServicePath} alt="Add New Service" />}
       </Step>
 
       <Step title="Configure the Service Connection">
-        In this step, we will configure the connection settings required for {connector}.
-
-        Please follow the instructions below to properly configure the Service to read from your sources. You will also find
-        helper documentation on the right-hand side panel in the UI.
-
+        Set up the connection settings required for {connector}. <br/><br/>
+      
+        Configure the following connection settings to set up the service and start ingesting metadata from your sources. The right-hand panel displays help documentation for the selected connection type in the product UI. <br/><br/>
         {serviceConnectionPath && <img src={serviceConnectionPath} alt="Configure Service connection" />}
       </Step>
     </Steps>
+  </>
   );
 };


### PR DESCRIPTION
## Summary

- Rewrote the `MetadataIngestionUi` shared component to improve step clarity and consistency across all connector docs
- Added an introductory paragraph explaining the purpose of a service connection before the steps begin
<img width="1355" height="606" alt="image" src="https://github.com/user-attachments/assets/fcfe1ac2-6dbe-4159-9d0a-87a1020aa368" />

- Restructured step titles and body copy to use direct, imperative language (`click`, `select`, `enter`) and `<strong>` tags instead of backtick/italic formatting
<img width="1349" height="569" alt="image" src="https://github.com/user-attachments/assets/9807df0b-d83d-4c4b-beef-371c2f898f25" />

- Renamed "Visit the Services Page" → "Select the Service" and split it into a numbered list for better scannability
- Renamed "Select the Service Type" → "Select the Connector" for consistency with connector doc terminology
- Added a bullet list and `<Note>` callout to the "Name and Describe your Service" step to highlight that the service name cannot be changed
<img width="1347" height="545" alt="image" src="https://github.com/user-attachments/assets/67ac0e3d-550c-442a-82a6-2b6d778e448f" />

## Test plan

- [ ] Verify the component renders correctly on at least one database connector page locally (`mint dev`)
- [ ] Check that all step images still load correctly
- [ ] Confirm no broken links introduced (`mint broken-links`)
