### PR TITLE
Docs: Restructure Admin Guide overview and sync content across v1.11.x, v1.12.x, and v1.13.x-SNAPSHOT

### DIFF
--- a/v1.11.x/how-to-guides/admin-guide.mdx
+++ b/v1.11.x/how-to-guides/admin-guide.mdx
@@ -6,9 +6,17 @@ sidebarTitle: Overview
 
 # Admin Guide
 
-Admin users have access to manage all the data assets. They can manage all the functions to create, edit, or delete. Admins can manage Roles, Policies, Services, Notifications, Custom Properties, Data Insights and more. They can add other users, or create teams to onboard users. An organization can have multiple Admins so that separate Admins can effectively manage different teams and departments.
+Administrators have full access to all data assets and can perform all create, edit, and delete operations across the platform.
 
-Get started with OpenMetadata with just **three quick and easy steps**.
+Administrators can manage the following:
+- **Roles and Policies** – define and enforce access controls across the organization.
+- **Services and Notifications** – configure platform services and set up notification rules.
+- **Custom Properties and Data Insights** – extend data models and monitor data health.
+- **Users and Teams** – add individual users or create teams to streamline onboarding.
+
+An organization can have multiple Administrators, allowing each to manage specific teams and departments independently.
+
+Get started with OpenMetadata with these three steps:
 <CardGroup cols={3}>
 <Card ico="regular" title="Ingest your Data from Multiple Sources" href="/v1.11.x/how-to-guides/admin-guide/how-to-ingest-metadata" >
     Integrate with third-party sources and ingest your metadata.

--- a/v1.12.x/how-to-guides/admin-guide.mdx
+++ b/v1.12.x/how-to-guides/admin-guide.mdx
@@ -18,7 +18,7 @@ Administrators can manage the following:
 An organization can have multiple Administrators, allowing each to manage specific teams and departments independently.
 
 
-Get started with OpenMetadata with just **three quick and easy steps**.
+Get started with OpenMetadata with these three steps:
 <CardGroup cols={3}>
 <Card ico="regular" title="Ingest your Data from Multiple Sources" href="/v1.12.x/how-to-guides/admin-guide/how-to-ingest-metadata" >
     Integrate with third-party sources and ingest your metadata.

--- a/v1.13.x-SNAPSHOT/how-to-guides/admin-guide.mdx
+++ b/v1.13.x-SNAPSHOT/how-to-guides/admin-guide.mdx
@@ -5,6 +5,7 @@ sidebarTitle: Overview
 ---
 
 # Admin Guide
+Administrators have full access to all data assets and can perform all create, edit, and delete operations across the platform.
 
 Administrators can manage the following:
 - **Roles and Policies** – define and enforce access controls across the organization.

--- a/v1.13.x-SNAPSHOT/how-to-guides/admin-guide.mdx
+++ b/v1.13.x-SNAPSHOT/how-to-guides/admin-guide.mdx
@@ -6,9 +6,15 @@ sidebarTitle: Overview
 
 # Admin Guide
 
-Admin users have access to manage all the data assets. They can manage all the functions to create, edit, or delete. Admins can manage Roles, Policies, Services, Notifications, Custom Properties, Data Insights and more. They can add other users, or create teams to onboard users. An organization can have multiple Admins so that separate Admins can effectively manage different teams and departments.
+Administrators can manage the following:
+- **Roles and Policies** – define and enforce access controls across the organization.
+- **Services and Notifications** – configure platform services and set up notification rules.
+- **Custom Properties and Data Insights** – extend data models and monitor data health.
+- **Users and Teams** – add individual users or create teams to streamline onboarding.
 
-Get started with OpenMetadata with just **three quick and easy steps**.
+An organization can have multiple Administrators, allowing each to manage specific teams and departments independently.
+
+Get started with OpenMetadata with these three steps:
 <CardGroup cols={3}>
 <Card ico="regular" title="Ingest your Data from Multiple Sources" href="/v1.13.x-SNAPSHOT/how-to-guides/admin-guide/how-to-ingest-metadata" >
     Integrate with third-party sources and ingest your metadata.


### PR DESCRIPTION
## Summary

- Rewrites the Admin Guide intro for clarity and conciseness across all three versions
- Replaces a dense run-on sentence with a bulleted list of admin capabilities (Roles & Policies, Services & Notifications, Custom Properties & Data Insights, Users & Teams)
- Updates "three quick and easy steps" to plain "these three steps"
<img width="2912" height="1458" alt="image" src="https://github.com/user-attachments/assets/f412467d-2385-4522-a8d9-4bdaf5498fed" />


## Files Changed

- `v1.11.x/how-to-guides/admin-guide.mdx`
- `v1.12.x/how-to-guides/admin-guide.mdx`
- `v1.13.x-SNAPSHOT/how-to-guides/admin-guide.mdx`

## Test Plan

- [ ] Run `mint dev` locally and navigate to `/v1.11.x/how-to-guides/admin-guide`, `/v1.12.x/how-to-guides/admin-guide`, and `/v1.13.x-SNAPSHOT/how-to-guides/admin-guide` — confirm all three pages render without errors
- [ ] Verify the bulleted list displays correctly with bold labels and em-dash separators
- [ ] Confirm the `<CardGroup>` below the intro still renders properly after the text change
- [ ] Check no broken links were introduced (`mint broken-links`)