### PR TITLE
Docs: Fix release label names in 1.12.6 and 1.12.7 snippets

### DIFF
--- a/snippets/releases/1.12.6.mdx
+++ b/snippets/releases/1.12.6.mdx
@@ -1,4 +1,4 @@
-<Update label="Latest Release" description="22nd April 2026">
+<Update label="1.12.6 Release" description="22nd April 2026">
 
 You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.6-release).
 

--- a/snippets/releases/1.12.7.mdx
+++ b/snippets/releases/1.12.7.mdx
@@ -1,4 +1,4 @@
-<Update label="Latest Release" description="11th May 2026">
+<Update label="1.12.7 Release" description="11th May 2026">
 
 You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.7-release).
 

--- a/snippets/releases/latest.mdx
+++ b/snippets/releases/latest.mdx
@@ -1,4 +1,4 @@
-<Update label="Latest Release" description="11th May 2026">
+<Update label="1.12.7 Release" description="11th May 2026">
 
 You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.7-release).
 

--- a/v1.12.x/releases/all-releases.mdx
+++ b/v1.12.x/releases/all-releases.mdx
@@ -20,7 +20,7 @@ The OpenMetadata community is on a monthly release cadence. At every 4-5 weeks w
 
 <CardGroup>
 <Card icon="party-horn" title="Upgrade OpenMetadata" href="/v1.12.x/deployment/upgrade">
-Learn how to upgrade your OpenMetadata instance to 1.12.6!
+Learn how to upgrade your OpenMetadata instance to 1.12.7!
 </Card>
 </CardGroup>
 

--- a/v1.13.x-SNAPSHOT/releases/all-releases.mdx
+++ b/v1.13.x-SNAPSHOT/releases/all-releases.mdx
@@ -20,7 +20,7 @@ The OpenMetadata community is on a monthly release cadence. At every 4-5 weeks w
 
 <CardGroup>
 <Card icon="party-horn" title="Upgrade OpenMetadata" href="/v1.13.x-SNAPSHOT/deployment/upgrade">
-Learn how to upgrade your OpenMetadata instance to 1.12.6!
+Learn how to upgrade your OpenMetadata instance to 1.12.7!
 </Card>
 </CardGroup>
 


### PR DESCRIPTION
# Summary
- Fixed `1.12.6` release snippet label from `"Latest Release"` to `"1.12.6 Release"`
- Fixed `1.12.7` (latest) release snippet label from `"Latest Release"` to `"1.12.7 Release"`
<img width="2984" height="1282" alt="image" src="https://github.com/user-attachments/assets/afad8989-db0c-4850-a9e0-67eb4bf73f5a" />

## Why
Generic "Latest Release" labels are ambiguous and become misleading as newer versions ship. Versioned labels make the changelog easier to navigate.

## Test plan
- [ ] Verify release notes page renders correct version labels on the docs site