### PR TITLE
Docs: Update MySQL minimum version requirement to 8.0.42

### DIFF
--- a/snippets/components/VersionMatrix/versionMatrixData.mdx
+++ b/snippets/components/VersionMatrix/versionMatrixData.mdx
@@ -1,6 +1,6 @@
 export const VERSION_MATRIX_DATA = [
   { service: "Java", version: "21" },
-  { service: "Mysql", version: "8.0.8" },
+  { service: "Mysql", version: "8.0.42" },
   { service: "Postgres", version: "1.15.0" },
   { service: "OpenSearch", version: "3.2.0" },
   { service: "ElasticSearch", version: "9.3.0" },
@@ -8,7 +8,7 @@ export const VERSION_MATRIX_DATA = [
 
 export const VERSION_MATRIX_DATA_WITH_UPDATES = [
   { service: "Java", version: "21" },
-  { service: "Mysql", version: "8.0.8" },
+  { service: "Mysql", version: "8.0.42" },
   { service: "Postgres", version: "1.15.0" },
   { service: "OpenSearch", version: "3.2.0", updated: true },
   { service: "ElasticSearch", version: "9.3.0", updated: true },

--- a/v1.12.x/connectors/database/mysql.mdx
+++ b/v1.12.x/connectors/database/mysql.mdx
@@ -31,7 +31,7 @@ Configure and schedule MySQL metadata and profiler workflows from the OpenMetada
 
 ## Requirements
 ### Metadata
-Note that We support MySQL (version 8.0.0 or greater) and the user should have access to the `INFORMATION_SCHEMA` table.  By default a user can see only the rows in the `INFORMATION_SCHEMA` that correspond to objects for which the user has the proper access privileges.
+Note that We support MySQL (version 8.0.42 or greater) and the user should have access to the `INFORMATION_SCHEMA` table.  By default a user can see only the rows in the `INFORMATION_SCHEMA` that correspond to objects for which the user has the proper access privileges.
 ```SQL
 -- Create user. If <hostName> is omitted, defaults to '%'
 -- More details https://dev.mysql.com/doc/refman/8.0/en/create-user.html

--- a/v1.12.x/connectors/database/mysql/yaml.mdx
+++ b/v1.12.x/connectors/database/mysql/yaml.mdx
@@ -46,7 +46,7 @@ To run the MySQL ingestion, you will need to install:
 pip3 install "openmetadata-ingestion[mysql]"
 ```
 ### Metadata
-Note that We support MySQL (version 8.0.0 or greater) and the user should have access to the `INFORMATION_SCHEMA` table.  By default a user can see only the rows in the `INFORMATION_SCHEMA` that correspond to objects for which the user has the proper access privileges.
+Note that We support MySQL (version 8.0.42 or greater) and the user should have access to the `INFORMATION_SCHEMA` table.  By default a user can see only the rows in the `INFORMATION_SCHEMA` that correspond to objects for which the user has the proper access privileges.
 ```SQL
 -- Create user. If <hostName> is omitted, defaults to '%'
 -- More details https://dev.mysql.com/doc/refman/8.0/en/create-user.html

--- a/v1.12.x/deployment/bare-metal.mdx
+++ b/v1.12.x/deployment/bare-metal.mdx
@@ -24,7 +24,7 @@ java --version
 To install Java or upgrade to Java 21, see the instructions for your operating system at [How do I install
 Java?](https://java.com/en/download/help/download_options.html#mac).
 
-## MySQL (version 8.0.0 or higher)
+## MySQL (version 8.0.42 or higher)
 
 To install MySQL see the instructions for your operating system (OS) at [Installing and Upgrading MySQL](https://dev.mysql.com/doc/mysql-installation-excerpt/8.0/en/installing.html)
 or visit one of the following OS-specific guides.

--- a/v1.12.x/deployment/minimum-requirements.mdx
+++ b/v1.12.x/deployment/minimum-requirements.mdx
@@ -32,7 +32,7 @@ These settings apply as well when using managed instances, such as AWS RDS or GC
 
 OpenMetadata currently supports -
 
-- MySQL version 8.0.0 or higher
+- MySQL version 8.0.42 or higher
 - PostgreSQL version 12.0 or higher
 
 ## ElasticSearch or OpenSearch as Search Instance

--- a/v1.13.x-SNAPSHOT/connectors/database/mysql.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/database/mysql.mdx
@@ -31,7 +31,7 @@ Configure and schedule MySQL metadata and profiler workflows from the OpenMetada
 
 ## Requirements
 ### Metadata
-Note that We support MySQL (version 8.0.0 or greater) and the user should have access to the `INFORMATION_SCHEMA` table.  By default a user can see only the rows in the `INFORMATION_SCHEMA` that correspond to objects for which the user has the proper access privileges.
+Note that We support MySQL (version 8.0.42 or greater) and the user should have access to the `INFORMATION_SCHEMA` table.  By default a user can see only the rows in the `INFORMATION_SCHEMA` that correspond to objects for which the user has the proper access privileges.
 ```SQL
 -- Create user. If <hostName> is omitted, defaults to '%'
 -- More details https://dev.mysql.com/doc/refman/8.0/en/create-user.html

--- a/v1.13.x-SNAPSHOT/connectors/database/mysql/yaml.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/database/mysql/yaml.mdx
@@ -46,7 +46,7 @@ To run the MySQL ingestion, you will need to install:
 pip3 install "openmetadata-ingestion[mysql]"
 ```
 ### Metadata
-Note that We support MySQL (version 8.0.0 or greater) and the user should have access to the `INFORMATION_SCHEMA` table.  By default a user can see only the rows in the `INFORMATION_SCHEMA` that correspond to objects for which the user has the proper access privileges.
+Note that We support MySQL (version 8.0.42 or greater) and the user should have access to the `INFORMATION_SCHEMA` table.  By default a user can see only the rows in the `INFORMATION_SCHEMA` that correspond to objects for which the user has the proper access privileges.
 ```SQL
 -- Create user. If <hostName> is omitted, defaults to '%'
 -- More details https://dev.mysql.com/doc/refman/8.0/en/create-user.html

--- a/v1.13.x-SNAPSHOT/deployment/bare-metal.mdx
+++ b/v1.13.x-SNAPSHOT/deployment/bare-metal.mdx
@@ -24,7 +24,7 @@ java --version
 To install Java or upgrade to Java 21, see the instructions for your operating system at [How do I install
 Java?](https://java.com/en/download/help/download_options.html#mac).
 
-## MySQL (version 8.0.0 or higher)
+## MySQL (version 8.0.42 or higher)
 
 To install MySQL see the instructions for your operating system (OS) at [Installing and Upgrading MySQL](https://dev.mysql.com/doc/mysql-installation-excerpt/8.0/en/installing.html)
 or visit one of the following OS-specific guides.

--- a/v1.13.x-SNAPSHOT/deployment/minimum-requirements.mdx
+++ b/v1.13.x-SNAPSHOT/deployment/minimum-requirements.mdx
@@ -32,7 +32,7 @@ These settings apply as well when using managed instances, such as AWS RDS or GC
 
 OpenMetadata currently supports -
 
-- MySQL version 8.0.0 or higher
+- MySQL version 8.0.42 or higher
 - PostgreSQL version 12.0 or higher
 
 ## ElasticSearch or OpenSearch as Search Instance


### PR DESCRIPTION
## Summary

- Updates MySQL minimum version to `8.0.42` across all supported OpenMetadata versions (v1.12.x, v1.13.x-SNAPSHOT)
- Updates the version matrix data used in the compatibility matrix component
- Affected pages: MySQL connector docs, bare metal deployment guides, and minimum requirements pages
<img width="2880" height="1614" alt="image" src="https://github.com/user-attachments/assets/7972cacf-1998-4819-89c5-e29c6b5d237f" />

## Test plan

- [ ] Verify version matrix renders correctly on the deployment/minimum-requirements pages
- [ ] Confirm MySQL connector docs show updated version in requirements section