### PR TITLE
chore: release notes for 1.12.8

### DIFF
--- a/snippets/releases/1.12.7.mdx
+++ b/snippets/releases/1.12.7.mdx
@@ -1,10 +1,10 @@
-<Update label="Latest Release" description="13th May 2026">
+<Update label="Latest Release" description="11th May 2026">
 
-You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.8-release).
+You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.7-release).
 
 ## Changelog
 
-OpenMetadata 1.12.8 is a maintenance release focused on hardening the platform against newly disclosed CVEs, eliminating long-standing database hotspots in the search and tag pipelines, and tightening connector behavior across Databricks, Unity Catalog, Athena, Datalake, and OpenLineage. The release also lands several quality-of-life UI fixes around governance approvals, advanced search, and custom properties.
+OpenMetadata 1.12.7 is a maintenance release focused on hardening the platform against newly disclosed CVEs, eliminating long-standing database hotspots in the search and tag pipelines, and tightening connector behavior across Databricks, Unity Catalog, Athena, Datalake, and OpenLineage. The release also lands several quality-of-life UI fixes around governance approvals, advanced search, and custom properties.
 
 ### ⚠️ Backward Incompatible / Notable Behavior Changes
 
@@ -98,7 +98,7 @@ This release addresses the May 8 2026 Snyk scan against the 1.12.7 branch and ad
 
 **Improvements**
 
-- **Reindex memory optimization for DatabaseSchema** [#27723](https://github.com/open-metadata/OpenMetadata/pull/27723) / [#28061](https://github.com/open-metadata/OpenMetadata/pull/28061): `DatabaseSchemaIndex` now skips the `tables` fan-out during reindex, reducing memory pressure on catalogs with very large schemas. All other entity indexes hydrate the full field set as before.
+- **Selective field fetch during reindexing** [#27723](https://github.com/open-metadata/OpenMetadata/pull/27723): Introduces `SearchIndex#getRequiredReindexFields()` so each entity index declares the minimum field set it needs. `EntityReader` now prunes the underlying DB query accordingly, dramatically reducing memory pressure during full reindex on large catalogs.
 - **SearchUtils consolidated; fuzzy ngram removed** [#27636](https://github.com/open-metadata/OpenMetadata/pull/27636): Merged the duplicated SearchUtils classes into one and dropped the redundant fuzzy match on ngram-tokenized fields (fuzzy + ngram compounded false positives). Adds substantial unit-test coverage.
 - **Certification tag batch query — source filter + indexed hash prefix** [#27847](https://github.com/open-metadata/OpenMetadata/pull/27847): The `TagUsageDAO.getCertTagsInternalBatch` query previously did a `tagFQN LIKE 'Certification.%'` scan and ran ~12s per call on heavy classification hierarchies. With a `source` filter and a hash-prefix predicate it now uses the covering index — eliminating ~19 hours of cumulative DB time per Data Insights run on a representative customer instance.
 - **Container data-model column tags — batched** [#27894](https://github.com/open-metadata/OpenMetadata/pull/27894): Replaces per-column tag lookups with a single batched query.
@@ -118,6 +118,6 @@ This release addresses the May 8 2026 Snyk scan against the 1.12.7 branch and ad
 - **`TableColumnCountToBeBetween` API response** [#27900](https://github.com/open-metadata/OpenMetadata/pull/27900): The Data Quality endpoint now returns the expected response shape for this test.
 - **Hyperlink workflow rules — `.keyword` suffix + Tags/Tier disambiguation** [#27799](https://github.com/open-metadata/OpenMetadata/pull/27799): Workflow rule conditions referencing tags/tier no longer match on the analyzed text field; they bind to `.keyword` so prefix collisions between Tags and Tier are resolved.
 
-**Full Changelog**: [link](https://github.com/open-metadata/OpenMetadata/compare/1.12.7-release...1.12.8-release)
+**Full Changelog**: [link](https://github.com/open-metadata/OpenMetadata/compare/1.12.6-release...1.12.7-release)
 
 </Update>

--- a/v1.12.x/releases/all-releases.mdx
+++ b/v1.12.x/releases/all-releases.mdx
@@ -9,6 +9,7 @@ import ReleaseNotes2 from '/snippets/releases/1.12.3.mdx';
 import ReleaseNotes3 from '/snippets/releases/1.12.4.mdx';
 import ReleaseNotes4 from '/snippets/releases/1.12.5.mdx';
 import ReleaseNotes5 from '/snippets/releases/1.12.6.mdx';
+import ReleaseNotes6 from '/snippets/releases/1.12.7.mdx';
 import ReleaseNotes from '/snippets/releases/latest.mdx';
 
 
@@ -20,11 +21,13 @@ The OpenMetadata community is on a monthly release cadence. At every 4-5 weeks w
 
 <CardGroup>
 <Card icon="party-horn" title="Upgrade OpenMetadata" href="/v1.12.x/deployment/upgrade">
-Learn how to upgrade your OpenMetadata instance to 1.12.6!
+Learn how to upgrade your OpenMetadata instance to 1.12.8!
 </Card>
 </CardGroup>
 
 <ReleaseNotes />
+
+<ReleaseNotes6 />
 
 <ReleaseNotes5 />
 


### PR DESCRIPTION
## Summary
- Add release notes for OpenMetadata 1.12.8 (released 13th May 2026)
- Archive the prior `latest.mdx` as `snippets/releases/1.12.7.mdx`, register it in `v1.12.x/releases/all-releases.mdx`, and bump the upgrade-card text to 1.12.8
- Reindex improvement bullet rewritten to reflect 1.12.8's final scope (DatabaseSchema-only opt-out for the `tables` fan-out)
- Mirrors the GitHub 1.12.8 release: https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.8-release

## Test plan
- [ ] `mint dev` → `/v1.12.x/releases/all-releases` renders 1.12.8 at the top
- [ ] `mint broken-links` passes