### PR TITLE
[codex] Fix v1.12 Python SDK overview examples

### DIFF
--- a/v1.12.x/api-reference/sdk/python.mdx
+++ b/v1.12.x/api-reference/sdk/python.mdx
@@ -18,7 +18,7 @@ We are now going to present a high-level Python API as a type-safe and gentle wr
 server at version 1.12.6, you will need to install:
 
 ```python
-pip install "openmetadata-ingestion==1.12.6.2"
+pip install "openmetadata-ingestion~=1.12.6.0"
 ```
 
 </div>
@@ -192,7 +192,7 @@ The OpenMetadata SDK configuration is backed by a JSON Schema. You can check the
 
 From this point onwards, we will interact with the API by using facade methods such as `Tables.create`, `Databases.retrieve_by_name`, or `DatabaseServices.delete`.
 
-An interesting validation we can already make at this point is verifying that the service is reachable and healthy. The `configure()` call performs a health check automatically; if the server is unreachable or the token is invalid, it will raise an error immediately.
+The `configure()` call initializes the SDK client and can validate that the client and server versions are compatible. To verify that the service is reachable and healthy, call `health_check()` separately.
 
 ### 2. Create the DatabaseService
 Following the hierarchy, we need to start by defining a `DatabaseService`. This will be system hosting our `Database`, which will contain the `Table`.

--- a/v1.12.x/api-reference/sdk/python.mdx
+++ b/v1.12.x/api-reference/sdk/python.mdx
@@ -1,6 +1,6 @@
 ---
 title: Python SDK | OpenMetadata Python SDK Documentation
-description: Master OpenMetadata'sPython SDK with comprehensive documentation, code examples, and API guides. Build powerful data discovery and governance solutions.
+description: Master OpenMetadata's Python SDK with comprehensive documentation, code examples, and API guides. Build powerful data discovery and governance solutions.
 sidebarTitle: Overview
 ---
 
@@ -18,7 +18,7 @@ We are now going to present a high-level Python API as a type-safe and gentle wr
 server at version 1.12.6, you will need to install:
 
 ```python
-pip install "openmetadata-ingestion~=1.12.6.0"
+pip install "openmetadata-ingestion==1.12.6.2"
 ```
 
 </div>
@@ -160,8 +160,8 @@ DatabaseService -> Database -> Schema -> Table
 
 This will help us showcase how we can reuse the same syntax with the three different Entities.
 
-### 1. Initialize OpenMetadata
-OpenMetadata is the class holding the connection to the API and handling the requests. We can instantiate this by passing the proper configuration to reach the server API:
+### 1. Configure the SDK
+The SDK facades use a shared connection to the API. We can configure it by passing the proper settings to reach the server API:
 
 ```python
 from metadata.sdk import configure, Tables, Databases, DatabaseSchemas, DatabaseServices, Users
@@ -169,14 +169,19 @@ from metadata.sdk import configure, Tables, Databases, DatabaseSchemas, Database
 configure(host="http://localhost:8585/api", jwt_token="<YOUR-INGESTION-BOT-JWT-TOKEN>")
 ```
 
-For local development, we can get a JWT token for the ingestion bot as described [here](/v1.12.x/deployment/security/enable-jwt-tokens#generate-token) and use that when we specify the `jwtToken`. For a real-world deployment, we can also use [different authentication methods](/v1.12.x/deployment/security) and specify other settings of the connection (such as `sslConfig`).
+For local development, we can get a JWT token for the ingestion bot as described [here](/v1.12.x/deployment/security/enable-jwt-tokens#generate-token) and use that when we specify the `jwt_token`. For a real-world deployment, we can also use [different authentication methods](/v1.12.x/deployment/security) and specify other settings of the connection.
 
-Below is an example of how the user can configure `sslConfig` using `Python SDK`.
+Below is an example of how the user can enable SSL verification and provide a CA bundle using the Python SDK.
 
 ```python
 from metadata.sdk import configure, Tables, Databases, DatabaseSchemas, DatabaseServices, Users
 
-configure(host="http://localhost:8585/api", jwt_token="<YOUR-INGESTION-BOT-JWT-TOKEN>")
+configure(
+    host="https://localhost:8585/api",
+    jwt_token="<YOUR-INGESTION-BOT-JWT-TOKEN>",
+    verify_ssl=True,
+    ca_bundle="/path/to/ca-bundle.pem",
+)
 ```
 
 
@@ -185,9 +190,9 @@ configure(host="http://localhost:8585/api", jwt_token="<YOUR-INGESTION-BOT-JWT-T
 The OpenMetadata SDK configuration is backed by a JSON Schema. You can check the connection definitions [here](https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-spec/src/main/resources/json/schema/entity/services/connections).
 </Tip>
 
-From this point onwards, we will interact with the API by using `OpenMetadata` methods.
+From this point onwards, we will interact with the API by using facade methods such as `Tables.create`, `Databases.retrieve_by_name`, or `DatabaseServices.delete`.
 
-An interesting validation we can already make at this point is verifying that the service is reachable and healthy. The `configure()` call performs a health check automatically — if the server is unreachable or the token is invalid, it will raise an error immediately.
+An interesting validation we can already make at this point is verifying that the service is reachable and healthy. The `configure()` call performs a health check automatically; if the server is unreachable or the token is invalid, it will raise an error immediately.
 
 ### 2. Create the DatabaseService
 Following the hierarchy, we need to start by defining a `DatabaseService`. This will be system hosting our `Database`, which will contain the `Table`.
@@ -237,7 +242,7 @@ Another important point here is that the connection definitions are centralized 
 We can review the information that will be passed to the API by visiting the JSON definition of the class we just instantiated. As all these models are powered by `pydantic`, this conversion is transparent to us:
 
 ```python
-create_service.json()
+create_service.model_dump_json()
 # '{"name": "test-service-table", "description": null, "serviceType": "Mysql", "connection": {"config": {"type": "Mysql", "scheme": "mysql+pymysql", "username": "username", "password": "**********", "hostPort": "http://localhost:1234", "database": null, "connectionOptions": null, "connectionArguments": null, "supportsMetadataExtraction": null, "supportsProfiler": null}}, "owner": null}'
 ```
 
@@ -261,7 +266,7 @@ Moreover, running `.create()` will return the Entity type, so we can explore its
 type(service_entity)
 # metadata.generated.schema.entity.services.databaseService.DatabaseService
 
-service_entity.json()
+service_entity.model_dump_json()
 # '{"id": "a823952a-1fc1-46d4-bd0e-27f9812871f4", "name": "test-service-table", "displayName": null, "serviceType": "Mysql", "description": null, "connection": {"config": {"type": "Mysql", "scheme": "mysql+pymysql", "username": "username", "password": "**********", "hostPort": "http://localhost:1234", "database": null, "connectionOptions": null, "connectionArguments": null, "supportsMetadataExtraction": null, "supportsProfiler": null}}, "pipelines": null, "version": 0.1, "updatedAt": 1651237632058, "updatedBy": "anonymous", "owner": null, "href": "http://localhost:8585/api/v1/services/databaseServices/a823952a-1fc1-46d4-bd0e-27f9812871f4", "changeDescription": null, "deleted": false}'
 ```
 
@@ -307,7 +312,7 @@ To retrieve the `id`, we can look it up by FQN:
 service_query = DatabaseServices.retrieve_by_name("test-service-table")
 ```
 
-We have just used the `retrieve_by_name` method. This method is the same that we will use for any Entity — no need to specify an entity type argument, as each entity class already knows its type.
+We have just used the `retrieve_by_name` method. This method is the same that we will use for any Entity; no need to specify an entity type argument, as each entity class already knows its type.
 
 ```python
 from metadata.generated.schema.api.data.createDatabase import (
@@ -346,7 +351,6 @@ from metadata.generated.schema.api.data.createTable import CreateTableRequest
 from metadata.generated.schema.entity.data.table import (
     Column,
     DataType,
-    Table,
 )
 
 create_table = CreateTableRequest(
@@ -364,7 +368,7 @@ Let's now update the `Table` by adding an owner. This will require us to create 
 First, make sure that no owner has been set during the creation:
 
 ```python
-print(table_entity.owner)
+print(table_entity.owners)
 # None
 ```
 
@@ -376,16 +380,21 @@ from metadata.generated.schema.api.teams.createUser import CreateUserRequest
 user = Users.create(CreateUserRequest(name="random-user", email="random@user.com"))
 ```
 
-Update our instance of `create_table` to add the `owner` field (we need to use the `Create` class as we'll run a `PUT`), and update the Entity:
+Retrieve the `Table` with its owners, mutate the returned Entity, and update it:
 
 ```python
 from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.generated.schema.type.entityReferenceList import EntityReferenceList
 
-create_table.owner = EntityReference(id=user.id, type="user")
-updated_table_entity = Tables.create(create_table)
+table_to_update = Tables.retrieve(str(table_entity.id.root), fields=["owners"])
+table_to_update.owners = EntityReferenceList(
+    root=[EntityReference(id=user.id, type="user")]
+)
 
-print(updated_table_entity.owner)
-# EntityReference(id=Uuid(__root__=UUID('48793f0c-5308-45c1-9bf4-06a82c8d7bf9')), type='user', name='random-user', description=None, displayName=None, href=Href(__root__=AnyUrl('http://localhost:8585/api/v1/users/48793f0c-5308-45c1-9bf4-06a82c8d7bf9', scheme='http', host='localhost', host_type='int_domain', port='8585', path='/api/v1/users/48793f0c-5308-45c1-9bf4-06a82c8d7bf9')))
+updated_table_entity = Tables.update(table_to_update)
+
+print(updated_table_entity.owners.root)
+# [EntityReference(id=Uuid(root=UUID('48793f0c-5308-45c1-9bf4-06a82c8d7bf9')), type='user', name='random-user', description=None, displayName=None, href=Href(root=AnyUrl('http://localhost:8585/api/v1/users/48793f0c-5308-45c1-9bf4-06a82c8d7bf9')))]
 ```
 
 If we did not save the `updated_table_entity` variable, we can retrieve it using `retrieve_by_name` with the proper FQN for `Table`s:
@@ -398,14 +407,14 @@ my_table = Tables.retrieve_by_name("test-service-table.test-db.test-schema.test"
 
 When querying an Entity we might not find it! The Entity could not exist, or there might be an error in the `id` or `fullyQualifiedName`.
 
-In those cases, the `get` method won't fail, but instead will return None. Note that the signature of the `get` methods is `Optional[T]`, so make sure to validate that there is data coming back!
+In those cases, call `retrieve` or `retrieve_by_name` with `nullable=True` if you want a missing Entity to return `None`. Make sure to validate that there is data coming back before using the result.
 </Tip>
 
 ### 7. Cleanup
 Finally, we can clean up the Table by running the `delete` method:
 
 ```python
-Tables.delete(str(my_table.id))
+Tables.delete(str(my_table.id.root))
 ```
 
 We could directly clean up the service itself with a Hard and Recursive delete. Note that this is ok for this test, but beware when working with production data!
@@ -413,5 +422,5 @@ We could directly clean up the service itself with a Hard and Recursive delete. 
 ```python
 service_id = DatabaseServices.retrieve_by_name("test-service-table").id
 
-DatabaseServices.delete(str(service_id), recursive=True, hard_delete=True)
+DatabaseServices.delete(str(service_id.root), recursive=True, hard_delete=True)
 ```

--- a/v1.12.x/api-reference/sdk/python/api-reference.mdx
+++ b/v1.12.x/api-reference/sdk/python/api-reference.mdx
@@ -7,6 +7,15 @@ sidebarTitle: Overview
 
 # API Overview
 
+<Tip>
+
+This generated API reference documents the lower-level `metadata.ingestion.ometa`
+client and its mixins. For the current `metadata.sdk` facade examples, use
+the [Python SDK overview](/v1.12.x/api-reference/sdk/python/overview) and the
+entity-specific guides.
+
+</Tip>
+
 ## Modules
 
 - [`auth_provider`](/v1.12.x/api-reference/sdk/python/api-reference/auth-provider#module-auth_provider): Interface definition for an Auth provider
@@ -111,5 +120,4 @@ sidebarTitle: Overview
 - [`utils.model_str`](/v1.12.x/api-reference/sdk/python/api-reference/utils#function-model_str): Default model stringifying method.
 - [`patch_mixin.update_column_description`](/v1.12.x/api-reference/sdk/python/api-reference/patch-mixin#function-update_column_description): Inplace update for the incoming column list
 - [`patch_mixin.update_column_tags`](/v1.12.x/api-reference/sdk/python/api-reference/patch-mixin#function-update_column_tags): Inplace update for the incoming column list
-
 

--- a/v1.12.x/api-reference/sdk/python/api-reference/lineage-mixin.mdx
+++ b/v1.12.x/api-reference/sdk/python/api-reference/lineage-mixin.mdx
@@ -12,6 +12,14 @@ Mixin class containing Lineage specific methods
 
 To be used by OpenMetadata class
 
+<Tip>
+
+These methods belong to the lower-level `metadata.ingestion.ometa` client. For
+the current `metadata.sdk` surface, use `metadata.sdk.api.Lineage`.
+SQL-query lineage parsing is not exposed through `metadata.sdk.api.Lineage`.
+
+</Tip>
+
 **Global Variables**
 ---------------
 - **LINEAGE_PARSING_TIMEOUT**
@@ -129,5 +137,4 @@ Get lineage details for an entity `id`
 
 
 ---
-
 

--- a/v1.12.x/api-reference/sdk/python/api-reference/mlmodel-mixin.mdx
+++ b/v1.12.x/api-reference/sdk/python/api-reference/mlmodel-mixin.mdx
@@ -12,6 +12,14 @@ Mixin class containing Lineage specific methods
 
 To be used by OpenMetadata class
 
+<Tip>
+
+These methods belong to the lower-level `metadata.ingestion.ometa` client. For
+the current `metadata.sdk` surface, use `MLModels` for CRUD and
+`metadata.sdk.api.Lineage` for explicit ML model lineage edges.
+
+</Tip>
+
 
 
 ---
@@ -88,5 +96,4 @@ OpenMetadata CreateMlModelRequest Entity
 
 
 ---
-
 

--- a/v1.12.x/api-reference/sdk/python/api-reference/patch-mixin.mdx
+++ b/v1.12.x/api-reference/sdk/python/api-reference/patch-mixin.mdx
@@ -12,6 +12,15 @@ Mixin class containing PATCH specific methods
 
 To be used by OpenMetadata class
 
+<Tip>
+
+These methods belong to the lower-level `metadata.ingestion.ometa` client. The
+current `metadata.sdk` entity facades do not expose `patch_tag` or
+`patch_column_tag`; use helpers such as `Tables.add_tag(...)` or retrieve,
+mutate, and call `Tables.update(entity)`.
+
+</Tip>
+
 **Global Variables**
 ---------------
 - **OWNER_TYPES**
@@ -374,5 +383,4 @@ Given a test case and a test case definition JSON PATCH the test case
 
 
 ---
-
 

--- a/v1.12.x/api-reference/sdk/python/build-connector/bulk-sink.mdx
+++ b/v1.12.x/api-reference/sdk/python/build-connector/bulk-sink.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bulk Sink
-description: Learn to build powerful bulk sink connectors with OpenMetadata'sPython SDK. Step-by-step guide with code examples for efficient data ingestion.
+description: Learn to build powerful bulk sink connectors with OpenMetadata's Python SDK. Step-by-step guide with code examples for efficient data ingestion.
 sidebarTitle: Bulk Sink
 ---
 

--- a/v1.12.x/api-reference/sdk/python/entities/ml-model.mdx
+++ b/v1.12.x/api-reference/sdk/python/entities/ml-model.mdx
@@ -40,7 +40,7 @@ While we can already extract certain pieces of information automatically via our
 ## Properties
 Now that we have a clearer view of what we are trying to achieve, let's jump into a deeper view on the `MlModel` Entity [definition](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-spec/src/main/resources/json/schema/entity/data/mlmodel.json):
 
-- The `name` and `algorithm` are the only required properties when [creating](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-spec/src/main/resources/json/schema/api/data/createMlModel.json) an `MlModel`. We can just bring the top shell to the catalogue automatically and then choose which models we want to enrich.
+- The `name` and `service` are required when [creating](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-spec/src/main/resources/json/schema/api/data/createMlModel.json) an `MlModel`. The `algorithm` defaults to `mlmodel`, but we normally set it explicitly to make the model easier to discover and compare.
 - The `dashboard` is a reference to a Dashboard Entity present in OpenMetadata (what we call an `EntityReference`). This should be a dashboard we have built that shows the evolution of our performance metrics. The **transparency** on ML services is integral, and that is why we have added it to the `MlModel` properties.
 - A server with the URL on where to reach the model **endpoint**, to `POST` input data or retrieve a prediction.
 - The mlStore specifies the **location** containing the model. Here we support both passing a URI with the object (e.g. `pkl`) location and/or a Docker image in its repository.
@@ -71,6 +71,8 @@ To fully understand what we are going to show now, it would be interesting for t
 Let's create an example of an MlFeature:
 
 ```python
+from metadata.generated.schema.entity.data.mlmodel import FeatureType, MlFeature
+
 MlFeature(
     name="persona",
     dataType=FeatureType.categorical,
@@ -82,9 +84,18 @@ Some properties that we can define when instantiating an `MlFeature` are the nam
 
 Here we want to give more **depth**. In order to do so, we can inform another property of the `MlFeature`, which are the `MlFeatureSource`s. The idea is that any feature can be based on an arbitrary number of real/physical sources (e.g., the columns of a Table), and informing this field will allow us to obtain this **relationship**.
 
-If we add this extra information, our feature will look like this:
+If we add this extra information, our feature will look like this, assuming `table1_entity` and `table2_entity`
+are existing Table entities:
 
 ```python
+from metadata.generated.schema.entity.data.mlmodel import (
+    FeatureSource,
+    FeatureSourceDataType,
+    FeatureType,
+    MlFeature,
+)
+from metadata.generated.schema.type.entityReference import EntityReference
+
 MlFeature(
     name="persona",
     dataType=FeatureType.categorical,
@@ -113,19 +124,112 @@ MlFeature(
 
 Note how we added a list of `FeatureSource`, with values such as `name`, `dataType` (regarding the source type, not the categorical/numerical distinction of the `MlFeature`) and an `EntityReference` as the `dataSource`.
 
-Thanks to this extra piece of information, we now can run the following method on our `MlModel` instance:
+With the current Python SDK, the ML model lifecycle goes through the plural `MLModels` facade. The generated
+`MlModel` entity is the Pydantic shape returned by the API, while `MLModels` exposes the CRUD helpers.
 
 ```python
-from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.ometa.openmetadata_rest import MetadataServerConfig
+from metadata.sdk import MLModels, Tables, configure
+from metadata.generated.schema.api.data.createMlModel import CreateMlModelRequest
+from metadata.generated.schema.entity.data.mlmodel import (
+    FeatureSource,
+    FeatureSourceDataType,
+    FeatureType,
+    MlFeature,
+)
+from metadata.generated.schema.type.entityReference import EntityReference
 
-server_config = MetadataServerConfig(api_endpoint="http://localhost:8585/api")
-metadata = OpenMetadata(server_config)
+configure(
+    host="http://localhost:8585/api",
+    jwt_token="<token>",
+)
 
-metadata.add_mlmodel_lineage(model=my_mlmodel_entity)
+table1_entity = Tables.retrieve_by_name("sample_service.sample_db.sample_schema.customer_profile")
+table2_entity = Tables.retrieve_by_name("sample_service.sample_db.sample_schema.education_profile")
+
+persona_feature = MlFeature(
+    name="persona",
+    dataType=FeatureType.categorical,
+    featureSources=[
+        FeatureSource(
+            name="age",
+            dataType=FeatureSourceDataType.integer,
+            dataSource=EntityReference(id=table1_entity.id, type="table"),
+        ),
+        FeatureSource(
+            name="education",
+            dataType=FeatureSourceDataType.string,
+            dataSource=EntityReference(id=table2_entity.id, type="table"),
+        ),
+    ],
+    featureAlgorithm="PCA",
+)
+
+create_model = CreateMlModelRequest(
+    name="persona-classifier",
+    service="mlflow_service",
+    algorithm="random_forest",
+    mlFeatures=[persona_feature],
+)
+
+my_mlmodel_entity = MLModels.create(create_model)
 ```
 
-This call will register the **Lineage** information between our MlModel instance and the tables referenced in the dataSources. Then, we will be able to explore these relationships either via the API or the UI.
+To change model metadata later, retrieve the model, update a copy, and submit it back through the same facade:
+
+```python
+from metadata.generated.schema.type.basic import Markdown
+
+model = MLModels.retrieve_by_name("mlflow_service.persona-classifier")
+updated_model = model.model_copy(deep=True)
+updated_model.description = Markdown("Predicts the user persona segment.")
+
+my_mlmodel_entity = MLModels.update(updated_model)
+```
+
+Lineage is explicit in the new SDK. The SDK does not expose the legacy `metadata.add_mlmodel_lineage(model=...)`
+helper through `metadata.sdk`; instead, add edges from each feature-source table to the ML model with
+`Lineage.add_lineage(...)`:
+
+```python
+from metadata.sdk.api import Lineage
+
+Lineage.add_lineage(
+    from_entity_id=str(table1_entity.id.root),
+    from_entity_type="table",
+    to_entity_id=str(my_mlmodel_entity.id.root),
+    to_entity_type="mlmodel",
+    description="Feature source for persona.age",
+)
+
+Lineage.add_lineage(
+    from_entity_id=str(table2_entity.id.root),
+    from_entity_type="table",
+    to_entity_id=str(my_mlmodel_entity.id.root),
+    to_entity_type="mlmodel",
+    description="Feature source for persona.education",
+)
+```
+
+If you need to send a full lineage payload, build an `AddLineageRequest` and submit it with
+`Lineage.add_lineage_request(...)`:
+
+```python
+from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
+from metadata.generated.schema.type.entityLineage import EntitiesEdge
+from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.sdk.api import Lineage
+
+add_lineage_request = AddLineageRequest(
+    edge=EntitiesEdge(
+        fromEntity=EntityReference(id=table1_entity.id, type="table"),
+        toEntity=EntityReference(id=my_mlmodel_entity.id, type="mlmodel"),
+    ),
+)
+
+Lineage.add_lineage_request(add_lineage_request)
+```
+
+These calls register the **Lineage** information between the feature-source tables and our MlModel instance. Then, we will be able to explore these relationships either via the API or the UI.
 
 If we also have ingested the Lineage from the different Tables in our platform as well as how they relate to the data processing Pipelines, we can obtain a global end-to-end view on our ML Model and all its dependencies.
 
@@ -144,4 +248,4 @@ In this doc, we have seen the role that OpenMetadata serves from a Machine Learn
 
 We have shown how to use the Python API to enrich the models' metadata and add the lineage information with its related Entities and how the versioning will respond to changes.
 
-For further information on the properties, do not hesitate to review the [JSON Schema](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-spec/src/main/resources/json/schema/entity/data/mlmodel.json) and for examples and usages with the Python API, you can take a look at our [integration tests](https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/tests/integration/ometa/test_ometa_mlmodel_api.py).
+For further information on the properties, do not hesitate to review the [JSON Schema](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-spec/src/main/resources/json/schema/entity/data/mlmodel.json) and for examples and usages with the Python SDK, you can take a look at our [SDK integration tests](https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/tests/integration/sdk/test_sdk_integration.py).

--- a/v1.12.x/api-reference/sdk/python/ingestion/lineage.mdx
+++ b/v1.12.x/api-reference/sdk/python/ingestion/lineage.mdx
@@ -1,6 +1,6 @@
 ---
 title: Python SDK for Lineage
-description: Learn to implement data lineage tracking with OpenMetadata'sPython SDK. Complete guide with code examples, API usage, and best practices for data flow ...
+description: Learn to implement data lineage tracking with OpenMetadata's Python SDK. Complete guide with code examples, API usage, and best practices for data flow ...
 sidebarTitle: Lineage
 ---
 
@@ -154,9 +154,9 @@ With everything prepared, we can now create the lineage between both entities.
 from metadata.sdk.api import Lineage
 
 created_lineage = Lineage.add_lineage(
-    from_entity_id=str(table_a_entity.id),
+    from_entity_id=str(table_a_entity.id.root),
     from_entity_type="table",
-    to_entity_id=str(table_b_entity.id),
+    to_entity_id=str(table_b_entity.id.root),
     to_entity_type="table",
     description="test lineage",
 )
@@ -289,11 +289,11 @@ from metadata.generated.schema.type.entityLineage import (
 # Prepare a new table
 table_c = CreateTableRequest(
     name="tableC",
-    databaseSchema=create_schema_entity.ifullyQualifiedName,
+    databaseSchema=create_schema_entity.fullyQualifiedName,
     columns=[Column(name="id", dataType=DataType.BIGINT)],
 )
 
-table_c_entity = metadata.create_or_update(data=table_c)
+table_c_entity = Tables.create(table_c)
 ```
 
 ## Column Level Lineage
@@ -318,8 +318,8 @@ lineage_details = LineageDetails(
 
 add_lineage_request = AddLineageRequest(
     edge=EntitiesEdge(
-        fromEntity=EntityReference(id=table_a_entity.id, type="table"),
-        toEntity=EntityReference(id=table_c_entity.id, type="table"),
+        fromEntity=EntityReference(id=str(table_a_entity.id.root), type="table"),
+        toEntity=EntityReference(id=str(table_c_entity.id.root), type="table"),
         lineageDetails=lineage_details,
     ),
 )
@@ -336,21 +336,24 @@ This information will now be reflected in the UI as well:
 We can as well pass the reference to the pipeline used to create the lineage (e.g., the ETL feeding the tables).
 
 To prepare this example, we need to start by creating the Pipeline Entity. Again, we'll need first
-to prepare the Pipeline Service:
+to prepare the Pipeline Service. The SDK does not currently expose a `PipelineServices` facade, so
+this example uses `metadata.sdk.client()` for the service creation only:
 
 ```python
-from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.sdk import Pipelines, client
 from metadata.generated.schema.api.data.createPipeline import CreatePipelineRequest
 from metadata.generated.schema.api.services.createPipelineService import (
     CreatePipelineServiceRequest,
 )
-from metadata.generated.schema.entity.services.pipelineService import (
-    PipelineConnection,
-    PipelineService,
-    PipelineServiceType,
+from metadata.generated.schema.entity.services.connections.pipeline.airflowConnection import (
+    AirflowConnection,
 )
 from metadata.generated.schema.entity.services.connections.pipeline.backendConnection import (
     BackendConnection,
+)
+from metadata.generated.schema.entity.services.pipelineService import (
+    PipelineConnection,
+    PipelineServiceType,
 )
 
 pipeline_service = CreatePipelineServiceRequest(
@@ -364,14 +367,14 @@ pipeline_service = CreatePipelineServiceRequest(
     ),
 )
 
-pipeline_service_entity = metadata.create_or_update(data=pipeline_service)
+pipeline_service_entity = client().ometa.create_or_update(pipeline_service)
 
 create_pipeline = CreatePipelineRequest(
     name="test",
     service=pipeline_service_entity.fullyQualifiedName,
 )
 
-pipeline_entity = metadata.create_or_update(data=create_pipeline)
+pipeline_entity = Pipelines.create(create_pipeline)
 ```
 
 With these ingredients ready, we can then follow the code above and add there a `pipeline` argument
@@ -381,7 +384,7 @@ as an Entity Reference:
 lineage_details = LineageDetails(
     sqlQuery="SELECT * FROM AWESOME",
     columnsLineage=[column_lineage],
-    pipeline=EntityReference(id=pipeline_entity.id, type="pipeline"),
+    pipeline=EntityReference(id=str(pipeline_entity.id.root), type="pipeline"),
 )
 ```
 

--- a/v1.12.x/api-reference/sdk/python/ingestion/tags.mdx
+++ b/v1.12.x/api-reference/sdk/python/ingestion/tags.mdx
@@ -186,7 +186,7 @@ table_with_columns = Tables.retrieve(
 
 for column in table_with_columns.columns or []:
     if column.name.root == "id":
-        column.tags = [
+        column.tags = list(column.tags or []) + [
             TagLabel(
                 tagFQN=tag_fqn,
                 source=TagSource.Classification,

--- a/v1.12.x/api-reference/sdk/python/ingestion/tags.mdx
+++ b/v1.12.x/api-reference/sdk/python/ingestion/tags.mdx
@@ -21,24 +21,12 @@ To prepare the necessary ingredients, execute the following steps.
 ### 1. Preparing the Client
 
 ```python
-from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
-    OpenMetadataConnection,
-)
-from metadata.generated.schema.security.client.openMetadataJWTClientConfig import (
-    OpenMetadataJWTClientConfig,
-)
-from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.sdk import configure
 
-server_config = OpenMetadataConnection(
-    hostPort="http://localhost:8585/api",
-    authProvider="openmetadata",
-    securityConfig=OpenMetadataJWTClientConfig(
-        jwtToken="<token>"
-    ),
+configure(
+    host="http://localhost:8585/api",
+    jwt_token="<token>",
 )
-metadata = OpenMetadata(server_config)
-
-assert metadata.health_check()  # Will fail if we cannot reach the server
 ```
 
 ### 2. Creating the Database Service
@@ -47,6 +35,7 @@ We are mocking a MySQL instance. Note how we need to pass the right configuratio
 parameter for the generic `DatabaseConnection` type.
 
 ```python
+from metadata.sdk import DatabaseServices
 from metadata.generated.schema.api.services.createDatabaseService import (
     CreateDatabaseServiceRequest,
 )
@@ -58,12 +47,11 @@ from metadata.generated.schema.entity.services.connections.database.mysqlConnect
 )
 from metadata.generated.schema.entity.services.databaseService import (
     DatabaseConnection,
-    DatabaseService,
     DatabaseServiceType,
 )
 
 db_service = CreateDatabaseServiceRequest(
-    name="test-service-db-lineage",
+    name="test-service-db-tags",
     serviceType=DatabaseServiceType.Mysql,
     connection=DatabaseConnection(
         config=MysqlConnection(
@@ -74,7 +62,7 @@ db_service = CreateDatabaseServiceRequest(
     ),
 )
 
-db_service_entity = metadata.create_or_update(data=db_service)
+db_service_entity = DatabaseServices.create(db_service)
 ```
 
 ### 3. Creating the Database
@@ -83,14 +71,15 @@ Any Entity that is created and linked to another Entity, has to hold the `fullyQ
 relates to. In this case, a Database is bound to a specific service.
 
 ```python
+from metadata.sdk import Databases
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
 
 create_db = CreateDatabaseRequest(
     name="test-db",
-    service=db_service_entity.EntityName,
+    service=db_service_entity.fullyQualifiedName,
 )
 
-create_db_entity = metadata.create_or_update(data=create_db)
+create_db_entity = Databases.create(create_db)
 ```
 
 ### 4. Creating the Schema
@@ -98,6 +87,7 @@ create_db_entity = metadata.create_or_update(data=create_db)
 The same happens with the Schemas. They are related to a Database.
 
 ```python
+from metadata.sdk import DatabaseSchemas
 from metadata.generated.schema.api.data.createDatabaseSchema import (
     CreateDatabaseSchemaRequest,
 )
@@ -106,7 +96,7 @@ create_schema = CreateDatabaseSchemaRequest(
     name="test-schema", database=create_db_entity.fullyQualifiedName
 )
 
-create_schema_entity = metadata.create_or_update(data=create_schema)
+create_schema_entity = DatabaseSchemas.create(create_schema)
 ```
 
 ### 5. Creating the Table
@@ -114,6 +104,7 @@ create_schema_entity = metadata.create_or_update(data=create_schema)
 We are doing a simple example with a single column.
 
 ```python
+from metadata.sdk import Tables
 from metadata.generated.schema.api.data.createTable import CreateTableRequest
 from metadata.generated.schema.entity.data.table import Column, DataType
 
@@ -123,7 +114,7 @@ table = CreateTableRequest(
     columns=[Column(name="id", dataType=DataType.BIGINT)],
 )
 
-table = metadata.create_or_update(data=table)
+table_entity = Tables.create(table)
 ```
 
 ### 6. Creating the Classification
@@ -131,17 +122,17 @@ table = metadata.create_or_update(data=table)
 Classifications are the entities we use to group tag definitions. Let's create a sample one:
 
 ```python
+from metadata.sdk import Classifications
 from metadata.generated.schema.api.classification.createClassification import (
     CreateClassificationRequest,
 )
-from metadata.generated.schema.api.classification.createTag import CreateTagRequest
 
-classification_request=CreateClassificationRequest(
+classification_request = CreateClassificationRequest(
     name="TestClassification",
     description="Sample classification.",
 )
 
-metadata.create_or_update(classification_request)
+classification_entity = Classifications.create(classification_request)
 ```
 
 ### 7. Creating the Tag
@@ -149,45 +140,61 @@ metadata.create_or_update(classification_request)
 Once there is an existing classification, we create tags within that given classification:
 
 ```python
-tag_request=CreateTagRequest(
-    classification=classification_request.name,
+from metadata.sdk import Tags
+from metadata.generated.schema.api.classification.createTag import CreateTagRequest
+
+tag_request = CreateTagRequest(
+    classification=classification_entity.fullyQualifiedName,
     name="TestTag",
     description="Sample Tag.",
 )
 
-metadata.create_or_update(tag_request)
+tag_entity = Tags.create(tag_request)
 ```
 
 ### 8. Tagging a Table
 
 Now that we have the Tag, we can proceed and tag a specific asset. In this example, we'll
-tag the Table we created above. For that, the API uses a PATCH request, but the Python SDK has
-a helper method that handles most of the work:
+tag the Table we created above. The Python SDK exposes a helper method that handles the
+update:
 
 ```python
-from metadata.generated.schema.entity.data.table import Table
+tag_fqn = str(tag_entity.fullyQualifiedName.root)
 
-metadata.patch_tag(
-    entity=Table,
-    entity_id=table.id,
-    tag_fqn="TestClassification.TestTag",
+table_entity = Tables.add_tag(
+    table_id=str(table_entity.id.root),
+    tag_fqn=tag_fqn,
 )
 ```
 
 If we now check the tags for the Table, the new tag will be appearing in there.
 
-Note that we now used the `patch_tag` method because the Table already existed. If we can
-control the Tag creation process when the Table metadata is generated, we can assign
-the tags in the `tags` property of `CreateTableRequest`.
+If we can control the Tag creation process when the Table metadata is generated, we can
+also assign the tags in the `tags` property of `CreateTableRequest`.
 
 ### 9. Tagging a Column
 
 The same idea can be replicated to tag a column:
 
 ```python
-metadata.patch_column_tag(
-    entity_id=table.id,
-    tag_fqn="TestClassification.TestTag",
-    column_name="id",
+from metadata.generated.schema.type.tagLabel import LabelType, State, TagLabel, TagSource
+
+table_with_columns = Tables.retrieve(
+    str(table_entity.id.root),
+    fields=["columns", "tags"],
 )
+
+for column in table_with_columns.columns or []:
+    if column.name.root == "id":
+        column.tags = [
+            TagLabel(
+                tagFQN=tag_fqn,
+                source=TagSource.Classification,
+                labelType=LabelType.Manual,
+                state=State.Confirmed,
+            )
+        ]
+        break
+
+table_entity = Tables.update(table_with_columns)
 ```

--- a/v1.12.x/api-reference/sdk/python/overview.mdx
+++ b/v1.12.x/api-reference/sdk/python/overview.mdx
@@ -1,11 +1,11 @@
 ---
 title: Python SDK Overview
-description: 'Full-featured Python client library for OpenMetadata integration'
+description: 'Python client library for OpenMetadata integration'
 ---
 
 # Python SDK
 
-The OpenMetadata Python SDK provides a comprehensive interface for interacting with the OpenMetadata API. It offers type-safe operations for managing metadata entities and seamless integration with your Python applications.
+The OpenMetadata Python SDK provides typed helpers for common OpenMetadata API operations. SDK operations live on plural facade classes such as `Tables`, `Databases`, and `Users`. The singular generated entity classes, such as `metadata.generated.schema.entity.data.table.Table`, are Pydantic models and do not expose SDK CRUD methods.
 
 ## Installation
 
@@ -29,23 +29,23 @@ configure(
 )
 ```
 
-You can also configure from environment variables (`OPENMETADATA_HOST` and `OPENMETADATA_JWT_TOKEN`):
+You can also configure from environment variables (`OPENMETADATA_HOST` or `OPENMETADATA_SERVER_URL`, and `OPENMETADATA_JWT_TOKEN` or `OPENMETADATA_API_KEY`):
 
 ```python
 from metadata.sdk import configure
 
-# Reads OPENMETADATA_HOST and OPENMETADATA_JWT_TOKEN automatically
+# Reads OpenMetadata host and token environment variables automatically
 configure()
 ```
 
 ### Working with Entities
 
 ```python
-from metadata.sdk import Tables, DatabaseServices
+from metadata.sdk import Tables
 
-# Get all database services
-services = list(DatabaseServices.list().auto_paging_iterable())
-print(f"Found {len(services)} database services")
+# Get one page of tables
+tables = Tables.list(limit=10, fields=["columns"])
+print(f"Found {len(tables.entities)} tables")
 
 # Get a specific table by name
 table = Tables.retrieve_by_name("your-service.your-database.your-schema.your-table")
@@ -59,20 +59,22 @@ if table:
 
 ### Entity Management
 
-The Python SDK provides full CRUD operations for all OpenMetadata entities:
+The Python SDK facade classes provide common CRUD operations for supported OpenMetadata entities:
 
 #### Create or Update Entities
 
 ```python
 from metadata.sdk import Tables
 from metadata.generated.schema.api.data.createTable import CreateTableRequest
+from metadata.generated.schema.entity.data.table import Column, DataType
 
 # Create table request
 create_table = CreateTableRequest(
     name="sample_table",
-    databaseSchema="your_database.your_schema",
+    databaseSchema="service.database.schema",
     columns=[
-        # Define your columns here
+        Column(name="id", dataType=DataType.BIGINT),
+        Column(name="status", dataType=DataType.VARCHAR, dataLength=255),
     ],
     description="Sample table created via Python SDK"
 )
@@ -104,8 +106,8 @@ table = Tables.retrieve_by_name(
 ```python
 from metadata.sdk import Tables
 
-# Auto-paginating iterator for large datasets
-for table in Tables.list().auto_paging_iterable():
+# Auto-pagination for large datasets
+for table in Tables.list_all(batch_size=100):
     print(f"Processing table: {table.name}")
 ```
 
@@ -113,21 +115,31 @@ for table in Tables.list().auto_paging_iterable():
 
 ```python
 from metadata.sdk import Tables
-from metadata.sdk.entities.tables import TableListParams
 
 # List with filters and field selection
-params = TableListParams.builder().limit(50).fields(["owners", "tags"]).build()
-tables = Tables.list(params)
+page = Tables.list(
+    limit=50,
+    fields=["owners", "tags"],
+    filters={"databaseSchema": "service.database.schema"},
+)
+
+for table in page.entities:
+    print(table.fullyQualifiedName)
+
+if page.after:
+    next_page = Tables.list(limit=50, after=page.after)
 ```
 
 #### Update Entities
 
 ```python
 from metadata.sdk import Tables
+from metadata.generated.schema.type.basic import Markdown
 
 table = Tables.retrieve_by_name("service.database.schema.table")
-table.description = "Updated description"
-updated = Tables.update(str(table.id), table)
+updated_table = table.model_copy(deep=True)
+updated_table.description = Markdown("Updated description")
+updated = Tables.update(updated_table)
 ```
 
 #### Delete Entities
@@ -153,7 +165,7 @@ ref = to_entity_reference(table)
 
 # Use in other entity creation
 if ref:
-    print(f"Table reference ID: {ref.id}")
+    print(f"Table reference ID: {ref['id']}")
 ```
 
 ## Advanced Features
@@ -184,7 +196,7 @@ from metadata.sdk import Tables
 
 # Iterate all tables and filter for a keyword
 matching_tables = [
-    table for table in Tables.list().auto_paging_iterable()
+    table for table in Tables.list_all(batch_size=100)
     if "customer" in table.name.lower()
 ]
 
@@ -196,12 +208,14 @@ for table in matching_tables:
 
 ```python
 from metadata.sdk import Tables
+from metadata.generated.schema.type.basic import Markdown
 
 # Bulk update table descriptions
-for table in Tables.list().auto_paging_iterable():
+for table in Tables.list_all(batch_size=100):
     if not table.description:
-        table.description = f"Production table: {table.name}"
-        Tables.update(str(table.id), table)
+        updated_table = table.model_copy(deep=True)
+        updated_table.description = Markdown(f"Production table: {table.name}")
+        Tables.update(updated_table)
 ```
 
 ### Lineage Management
@@ -216,8 +230,8 @@ lineage = Lineage.get_lineage(
 )
 
 if lineage:
-    print(f"Upstream entities: {len(lineage.get('upstreamEdges', []))}")
-    print(f"Downstream entities: {len(lineage.get('downstreamEdges', []))}")
+    print(f"Upstream entities: {len(lineage.upstreamEdges or [])}")
+    print(f"Downstream entities: {len(lineage.downstreamEdges or [])}")
 ```
 
 ## API Reference
@@ -226,7 +240,7 @@ The Python SDK provides a comprehensive API based on the OpenMetadata data model
 
 ### Core Classes
 
-- **Entity classes** (`Tables`, `Databases`, `DatabaseSchemas`, `DatabaseServices`, `Users`, etc.): Static-method interfaces for each entity type — no instantiation required
+- **Entity facade classes** (`Tables`, `Databases`, `DatabaseSchemas`, `DatabaseServices`, `Users`, etc.): plural static-method interfaces, no instantiation required
 - **`configure()`**: One-time global setup for host and JWT token
 - **`to_entity_reference(entity)`**: Convert a retrieved entity to an `EntityReference` for use in relationships
 - **Entity Request Classes**: Pydantic-based typed request objects (e.g., `CreateTableRequest`)
@@ -238,10 +252,18 @@ Each entity class exposes the same consistent interface:
 - `EntityClass.create(request)`: Create a new entity
 - `EntityClass.retrieve(entity_id)`: Retrieve entity by UUID
 - `EntityClass.retrieve_by_name(fqn, fields=[])`: Retrieve entity by fully qualified name
-- `EntityClass.list(params=None)`: List entities (returns a pageable result)
-- `EntityClass.list().auto_paging_iterable()`: Auto-paginating generator for all entities
-- `EntityClass.update(entity_id, entity)`: Update an existing entity
+- `EntityClass.list(limit=10, after=None, before=None, fields=None, filters=None)`: List one page of entities as an `EntityList`
+- `EntityClass.list_all(batch_size=100, fields=None, filters=None)`: Fetch all pages
+- `EntityClass.update(entity)`: Update an existing entity by reading `entity.id`
 - `EntityClass.delete(entity_id, recursive=False, hard_delete=False)`: Delete an entity
+
+The facade classes do not expose `patch(entity_id, json_patch)` helpers. For ordinary partial updates, retrieve the entity, mutate a copy, and call `update(entity)`. For lower-level patch flows, use the OpenMetadata client returned by `metadata.sdk.client()`.
+
+### Current Facade Coverage
+
+The SDK currently exports facade classes for common data assets, services, governance, team/user, and data quality entities, including `Tables`, `Databases`, `DatabaseSchemas`, `DatabaseServices`, `Dashboards`, `Pipelines`, `Glossaries`, `GlossaryTerms`, `Classifications`, `Tags`, `Teams`, `Users`, `TestCases`, `TestDefinitions`, and `TestSuites`.
+
+If a facade does not exist for an entity yet, use the underlying OpenMetadata client returned by `metadata.sdk.client()` or the ingestion client APIs directly.
 
 ## Type Safety
 
@@ -256,7 +278,7 @@ The Python SDK is built on generated Pydantic models, providing:
 from metadata.sdk import Tables
 from metadata.generated.schema.entity.data.table import Table
 
-# Type-safe retrieval — IDE provides auto-completion and type checking
+# Type-safe retrieval with IDE auto-completion and type checking
 table: Table = Tables.retrieve_by_name("service.database.schema.table")
 if table:
     columns_count: int = len(table.columns) if table.columns else 0
@@ -264,7 +286,7 @@ if table:
 
 ## Best Practices
 
-1. **Configure once**: Call `configure()` once at application startup and reuse globally — no need to pass a client object around
+1. **Configure once**: Call `configure()` once at application startup and reuse globally; no need to pass a client object around
 2. **Error Handling**: Always handle `APIError` exceptions for robust integrations
-3. **Pagination**: Use `.auto_paging_iterable()` for large datasets to avoid loading everything into memory at once
+3. **Pagination**: Use `list_all()` for full auto-pagination or `list()` with `after`/`before` cursors for page-by-page control
 4. **Performance**: Specify only required fields when fetching entities (e.g., `fields=["owners", "tags"]`)

--- a/v1.12.x/api-reference/sdk/python/overview.mdx
+++ b/v1.12.x/api-reference/sdk/python/overview.mdx
@@ -261,7 +261,7 @@ The facade classes do not expose `patch(entity_id, json_patch)` helpers. For ord
 
 ### Current Facade Coverage
 
-The SDK currently exports facade classes for common data assets, services, governance, team/user, and data quality entities, including `Tables`, `Databases`, `DatabaseSchemas`, `DatabaseServices`, `Dashboards`, `Pipelines`, `Glossaries`, `GlossaryTerms`, `Classifications`, `Tags`, `Teams`, `Users`, `TestCases`, `TestDefinitions`, and `TestSuites`.
+The SDK currently exports facade classes for common data assets, services, governance, team/user, and data quality entities, including `Tables`, `Databases`, `DatabaseSchemas`, `DatabaseServices`, `Dashboards`, `Pipelines`, `MLModels`, `Glossaries`, `GlossaryTerms`, `Classifications`, `Tags`, `Teams`, `Users`, `TestCases`, `TestDefinitions`, and `TestSuites`.
 
 If a facade does not exist for an entity yet, use the underlying OpenMetadata client returned by `metadata.sdk.client()` or the ingestion client APIs directly.
 


### PR DESCRIPTION
## What changed

- Updated the v1.12.x Python SDK overview pages to use the implemented plural facade classes and `configure(...)` connection flow.
- Replaced stale `auto_paging_iterable()`, `TableListParams`, `update(id, entity)`, singular facade, and unavailable facade patch examples with `list_all()`, keyword-based `list(...)`, `update(entity)`, and lower-level `client().ometa` where needed.
- Updated Tags, Lineage, and ML Model guides to cover current SDK scenarios: classifications/tags, table tags, column tags, direct lineage, pipeline-backed lineage details, ML model CRUD, and explicit ML model lineage.
- Added clarification notes to the generated lower-level `metadata.ingestion.ometa` API reference pages so mixin methods are not mistaken for current `metadata.sdk` facade methods.
- Fixed Python SDK copy typos in affected pages.

## Why

The published v1.12.x Python SDK docs contained examples that do not match the Python SDK shipped in `openmetadata-ingestion==1.12.6.2`, causing import and attribute errors for users following the docs.

## Validation

- Installed `openmetadata-ingestion==1.12.6.2` in a temporary Python 3.12 venv and validated the documented SDK paths against `https://sandbox-beta.open-metadata.org/api` using a temporary script.
- The sandbox script verified plural facades, absent old APIs, `Tables.list`, `Tables.list_all`, `Tables.retrieve_by_name`, `Tables.update(entity)`, owner updates via `EntityReferenceList`, table tags, column tags, table lineage, pipeline lineage details, `MLModels`, lower-level service creation through `client().ometa`, and cleanup for all temporary entities.
- Parsed changed MDX Python fenced blocks with `ast.parse` where applicable.
- Ran `git diff --check`.
- Searched the hand-authored SDK docs for stale positive examples of the removed APIs. Remaining patch/lineage/mlmodel mixin references are lower-level `metadata.ingestion.ometa` API reference pages and now include explicit clarification notes.
