### PR TITLE
chore: release notes for 1.12.9

### DIFF
--- a/snippets/releases/1.12.8.mdx
+++ b/snippets/releases/1.12.8.mdx
@@ -1,0 +1,123 @@
+<Update label="1.12.8 Release" description="13th May 2026">
+
+You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.8-release).
+
+## Changelog
+
+OpenMetadata 1.12.8 is a maintenance release focused on hardening the platform against newly disclosed CVEs, eliminating long-standing database hotspots in the search and tag pipelines, and tightening connector behavior across Databricks, Unity Catalog, Athena, Datalake, and OpenLineage. The release also lands several quality-of-life UI fixes around governance approvals, advanced search, and custom properties.
+
+### ⚠️ Backward Incompatible / Notable Behavior Changes
+
+- **Notification alerts — `Location` source removed** [#27683](https://github.com/open-metadata/OpenMetadata/pull/27683): The deprecated `Location` entity has been removed from the list of supported sources in notification alerts. `Domain` and `Data Product` are now first-class sources. Existing alerts configured against `Location` will need to be re-created against a supported source.
+- **`ContainerResource` default fields trimmed** ([#27894](https://github.com/open-metadata/OpenMetadata/pull/27894) follow-up): `children` is no longer returned by default on `GET /v1/containers` list responses; clients that depended on the implicit inclusion must request it explicitly via the `fields` query parameter. This restores the documented behavior and unblocks the batched data-model column tag retrieval below.
+- **Soft-deleted users excluded from Experts/Reviewers** [#27120](https://github.com/open-metadata/OpenMetadata/pull/27120): Users marked `deleted` no longer appear in the Experts/Reviewers selector across entities. Workflows that relied on soft-deleted users remaining visible (for example, restoring an entity to its previous reviewer) must restore the user first.
+
+### 🔒 Security (Vulnerability Remediation)
+
+This release addresses the May 8 2026 Snyk scan against the 1.12.7 branch and additional CVEs picked up by AWS Inspector. Nine of the highest-severity findings are resolved through direct version bumps; one (`libthrift`) is force-pinned because upstream Jena has not yet rebased.
+
+**Backend / Java**
+
+- **CRITICAL — Jetty HTTP Request Smuggling (CVE-2026-2332):** `org.eclipse.jetty:jetty-http` bumped `12.1.6 → 12.1.7` [#27996](https://github.com/open-metadata/OpenMetadata/pull/27996).
+- **HIGH — Apache Thrift (CVE-2026-43869):** `libthrift` force-pinned to `0.23.0` via `dependencyManagement` to override the vulnerable transitive shipped by `apache-jena-libs` [#28010](https://github.com/open-metadata/OpenMetadata/pull/28010) / [#28035](https://github.com/open-metadata/OpenMetadata/pull/28035).
+- **HIGH — PostgreSQL JDBC SCRAM-SHA-256 DoS (CVE-2026-42198):** `org.postgresql:postgresql` bumped `42.7.7 → 42.7.11` [#27996](https://github.com/open-metadata/OpenMetadata/pull/27996).
+- **HIGH — BouncyCastle Crypto Signature Bypass + Timing Attack (CVE-2026-5598):** `bcprov-jdk18on` / `bcpkix-jdk18on` pinned to `1.84`, also addressing CVE-2026-0636 and CVE-2026-5588 [#27996](https://github.com/open-metadata/OpenMetadata/pull/27996).
+- **HIGH — Apache Log4j (CVE-2026-34477, CVE-2026-34478, CVE-2026-34480):** `log4j` bumped `2.25.3 → 2.25.4` [#27994](https://github.com/open-metadata/OpenMetadata/pull/27994).
+- **MED — Jackson 3.x deserialization CVEs (GHSA-72hv-8253-57qq):** `jackson-core` bumped `2.17.2 → 2.18.7`. `jsonschema2pojo-core` is now declared `<scope>provided</scope>` in the `common` module so the Jackson 3.x transitive is excluded from the runtime classpath, since the annotators it powers only run at build time [#28010](https://github.com/open-metadata/OpenMetadata/pull/28010).
+- **MED — jsonschema2pojo (CVE-2025-3588):** `jsonschema2pojo` bumped `1.2.2 → 1.3.0` (later aligned to `1.3.1` to resolve a maven-plugin classpath issue) [#27994](https://github.com/open-metadata/OpenMetadata/pull/27994).
+- **MED/LOW — Logback (CVE-2025-11226, CVE-2026-1225):** `logback-core` / `logback-classic` bumped `1.5.19 → 1.5.25` [#27996](https://github.com/open-metadata/OpenMetadata/pull/27996).
+- **Netty:** `netty-bom` bumped `4.1.132 → 4.1.133`. `netty-transport-native-epoll` excluded (Linux-only perf optimization flagged by an overly-broad GHSA range, not used at runtime) [#27994](https://github.com/open-metadata/OpenMetadata/pull/27994) / [#28010](https://github.com/open-metadata/OpenMetadata/pull/28010).
+- **Azure Identity (CVE-2024-35255):** `azure-identity` aligned to `1.15.2` and `azure-keyvault` bumped to remove vulnerable transitives [#27994](https://github.com/open-metadata/OpenMetadata/pull/27994) / [#28010](https://github.com/open-metadata/OpenMetadata/pull/28010).
+- **Reactor Netty & Spring:** `reactor-netty` and `spring` bumped to their current patched lines [#27996](https://github.com/open-metadata/OpenMetadata/pull/27996) / [#28010](https://github.com/open-metadata/OpenMetadata/pull/28010).
+
+**Frontend / UI**
+
+- **axios** upgraded to `1.15.2` to clear reported CVEs in the UI bundle.
+- **postcss** pinned to `8.5.10` with a Yarn `resolutions` override in `openmetadata-ui-core-components` to resolve the Dependabot advisory [#27778](https://github.com/open-metadata/OpenMetadata/pull/27778).
+- **postcss** bumped in the main UI module as well [#27729](https://github.com/open-metadata/OpenMetadata/pull/27729).
+
+**Ingestion / Container Images**
+
+- **ImageMagick purged** from the ingestion image — it was only a transitive of the Airflow base image, was never used by ingestion code, and continued to surface CVEs after Airflow upgrades. Removing it eliminates the surface entirely [#27752](https://github.com/open-metadata/OpenMetadata/pull/27752).
+
+### 🎨 UI Changes
+
+**Improvements**
+
+- **Approvals show proposed changes inline** [#27201](https://github.com/open-metadata/OpenMetadata/pull/27201): Governance approval task threads now render a *Proposed Changes* section with clickable entity links, so reviewers can see exactly what changed before approving instead of opening the entity in a new tab.
+- **Description added to Advanced Search query builder** [#27913](https://github.com/open-metadata/OpenMetadata/pull/27913): The `description` field is now a first-class searchable attribute with `Contains`, `Not Contains`, `Is Null`, and `Is Not Null` operators. The `descriptionStatus` label was also corrected (previously rendered with the wrong key).
+- **Service documentation panel: admonitions + code copy button** [#27732](https://github.com/open-metadata/OpenMetadata/pull/27732): The in-product service docs now render note/warning/tip admonitions and add a copy button to fenced code blocks.
+
+**Fixes**
+
+- **Clipboard works on non-secure (HTTP) contexts** [#28003](https://github.com/open-metadata/OpenMetadata/pull/28003): `CodeBlockComponent` now uses the `useClipboard` hook, which falls back to `document.execCommand` when the modern Clipboard API is unavailable, fixing copy actions for users on self-hosted HTTP deployments.
+- **Custom properties with dots in their name now display** [#27390](https://github.com/open-metadata/OpenMetadata/pull/27390): The UI was treating `.` in custom-property names as a path separator, hiding the property entirely. Names with dots are now rendered correctly.
+- **Tier/Certification tag matching uses FQN prefix, not substring** [#27700](https://github.com/open-metadata/OpenMetadata/pull/27700): Prevents unrelated tags whose FQN happened to *contain* a tier or certification tag's FQN from being mis-classified.
+- **Upvote/Downvote icon retains primary color after blur** [#27898](https://github.com/open-metadata/OpenMetadata/pull/27898): The vote indicator no longer reverts to a neutral color when the entity page loses focus.
+- **AdvancedSearch description option — translations** [#27961](https://github.com/open-metadata/OpenMetadata/pull/27961): Missing/incorrect i18n strings on the new description operator filled in across supported locales.
+- **Rich-text editor migration** [#26887](https://github.com/open-metadata/OpenMetadata/pull/26887): Removed `@toast-ui/react-editor` and migrated remaining usages to the in-house `BlockEditor`, reducing bundle size and eliminating the transitive CVE surface from the abandoned editor package.
+- **ContainerPage tab counts now update reactively**: Added `childrenCount` to the `useMemo` dependency array so tab badges refresh when children load.
+
+### 🔌 Connectors
+
+**Databases**
+
+- **Databricks — nested column descriptions + SQLAlchemy 2.x** [#27766](https://github.com/open-metadata/OpenMetadata/pull/27766): Descriptions on STRUCT/MAP/ARRAY-typed nested columns are now captured during metadata ingestion. The connector is also compatible with `sqlalchemy-databricks` running on SQLAlchemy 2.x.
+- **Unity Catalog — missing `httpPath`** [#27844](https://github.com/open-metadata/OpenMetadata/pull/27844): The connector no longer hard-fails when `httpPath` is omitted; it now produces a clear configuration error instead of an opaque stack trace.
+- **Athena — Iceberg table properties** [#27715](https://github.com/open-metadata/OpenMetadata/pull/27715): Iceberg-on-Athena tables now ingest table properties from the `$properties` metatable, surfacing Iceberg-specific metadata (format-version, write.target-file-size-bytes, etc.) in OpenMetadata.
+- **PostgreSQL / MSSQL — mutual TLS** [#27104](https://github.com/open-metadata/OpenMetadata/pull/27104): Both connectors now support client-certificate mTLS in addition to server-side SSL, matching enterprise PG/MSSQL hardening requirements.
+- **PostgreSQL — tag_usage seq-scan eliminated** [#27824](https://github.com/open-metadata/OpenMetadata/pull/27824): Backport of #27158. The certification tag query now uses the covering index instead of a sequential scan, removing a multi-second hotspot during Data Insights runs on large catalogs.
+- **SQLAlchemy 2.x row access** [#27643](https://github.com/open-metadata/OpenMetadata/pull/27643): Replaced old-style row indexing that emitted deprecation warnings on SQLAlchemy 2.x.
+
+**Datalake / Object Stores**
+
+- **Datalake — nested arrays of structs in JSON** [#27798](https://github.com/open-metadata/OpenMetadata/pull/27798): Array-typed fields whose elements are nested structures are now parsed correctly and surface as proper nested column schemas.
+
+**Pipelines / Dashboards**
+
+- **Power BI — additional lineage logging** [#27970](https://github.com/open-metadata/OpenMetadata/pull/27970): More granular diagnostic logs in the Power BI lineage extractor make customer-side debugging substantially faster.
+
+**OpenLineage**
+
+- **AWS Glue, Kusto, and Cosmos DB dataset naming** [#27533](https://github.com/open-metadata/OpenMetadata/pull/27533): Adds dataset-naming support so OpenLineage events from these sources are resolved to the correct OpenMetadata entities.
+- **Namespace-based DB service resolution for `db_table`** [#27005](https://github.com/open-metadata/OpenMetadata/pull/27005): OpenLineage `db_table` lookups now resolve to the right DB service by namespace, fixing cross-service lineage gaps.
+- **Pipeline/job resolution by integration type** [#26821](https://github.com/open-metadata/OpenMetadata/pull/26821): OpenLineage pipelines and jobs are now mapped to their integration type so they show up under the correct pipeline service.
+
+**AI / Vector Embeddings**
+
+- **OpenAI embedding concurrency control** [#26574](https://github.com/open-metadata/OpenMetadata/pull/26574): Adds a configurable concurrency cap on outbound OpenAI embedding HTTP requests, preventing rate-limit storms during bulk reindex.
+
+**Ingestion Runtime**
+
+- **Bulk sink OOM under persistent flush failures** [#26838](https://github.com/open-metadata/OpenMetadata/pull/26838): The bulk sink no longer accumulates an unbounded retry buffer when downstream flushes keep failing; the buffer is now bounded and drops with a clear error.
+- **CronOMJob tolerations propagated** [#27955](https://github.com/open-metadata/OpenMetadata/pull/27955): Pod tolerations defined on a `CronOMJob` are now copied to the scheduled `OMJob`, so taint-isolated nodes keep working after a restart.
+- **PII recognizer language scoping** [#27919](https://github.com/open-metadata/OpenMetadata/pull/27919): PII recognizers are now included based on the configured language, eliminating false positives from recognizers loaded for unrelated locales.
+- **`dbt-extractor` pinned `>=0.5.0`** [#27777](https://github.com/open-metadata/OpenMetadata/pull/27777): Prevents the ARM-on-pip resolver from falling back to a source distribution that fails to build inside the ingestion container.
+
+### 🛠 API (Backend)
+
+**Improvements**
+
+- **Reindex memory optimization for DatabaseSchema** [#27723](https://github.com/open-metadata/OpenMetadata/pull/27723) / [#28061](https://github.com/open-metadata/OpenMetadata/pull/28061): `DatabaseSchemaIndex` now skips the `tables` fan-out during reindex, reducing memory pressure on catalogs with very large schemas. All other entity indexes hydrate the full field set as before.
+- **SearchUtils consolidated; fuzzy ngram removed** [#27636](https://github.com/open-metadata/OpenMetadata/pull/27636): Merged the duplicated SearchUtils classes into one and dropped the redundant fuzzy match on ngram-tokenized fields (fuzzy + ngram compounded false positives). Adds substantial unit-test coverage.
+- **Certification tag batch query — source filter + indexed hash prefix** [#27847](https://github.com/open-metadata/OpenMetadata/pull/27847): The `TagUsageDAO.getCertTagsInternalBatch` query previously did a `tagFQN LIKE 'Certification.%'` scan and ran ~12s per call on heavy classification hierarchies. With a `source` filter and a hash-prefix predicate it now uses the covering index — eliminating ~19 hours of cumulative DB time per Data Insights run on a representative customer instance.
+- **Container data-model column tags — batched** [#27894](https://github.com/open-metadata/OpenMetadata/pull/27894): Replaces per-column tag lookups with a single batched query.
+- **`IndexResource` logs lowered to debug** [#27588](https://github.com/open-metadata/OpenMetadata/pull/27588): Reduces production log noise; verbose index lifecycle logs are now gated on `DEBUG`.
+
+**Fixes**
+
+- **`DataContract` 400 on entities without `dataProducts`** [#27861](https://github.com/open-metadata/OpenMetadata/pull/27861): The endpoint now handles entities that don't carry a `dataProducts` field, instead of rejecting the request.
+- **`/search` endpoint for Roles** [#27335](https://github.com/open-metadata/OpenMetadata/pull/27335): Adds the missing `GET /v1/roles/search` endpoint and aligns role selectors to use server-side search [#27737](https://github.com/open-metadata/OpenMetadata/pull/27737).
+- **MCP — SSE response when client negotiates `text/event-stream`** [#27917](https://github.com/open-metadata/OpenMetadata/pull/27917): The MCP endpoint now correctly returns an SSE-framed response when the client's `Accept` header asks for `text/event-stream`.
+- **MCP OAuth on Databricks** [#27922](https://github.com/open-metadata/OpenMetadata/pull/27922): Fixes the OAuth callback handling specific to Databricks-backed MCP clients.
+- **Time-series reindex — stale `parentOf` is a warning, not a failure** [#27800](https://github.com/open-metadata/OpenMetadata/pull/27800): During time-series reindex, an orphaned `parentOf` reference no longer aborts the run; it's logged as a warning and the reindex continues.
+- **Column bulk-ops search at scale** [#27216](https://github.com/open-metadata/OpenMetadata/pull/27216): Bulk operations on columns now return results consistently on large indices where the previous code path silently returned an empty set above a query-size threshold.
+- **OpenSearch HC5 transport — recoverable I/O reactor shutdown** [#27698](https://github.com/open-metadata/OpenMetadata/pull/27698): Transient `I/O reactor has been shut down` errors are now recovered automatically instead of leaving the client in a permanently failed state.
+- **Vector embedding healthcheck** [#27616](https://github.com/open-metadata/OpenMetadata/pull/27616): The `/health` probe now correctly reflects vector-embedding subsystem availability instead of always reporting healthy.
+- **CSV import — recursive extension validation + row-count accounting** [#27593](https://github.com/open-metadata/OpenMetadata/pull/27593) / [#27669](https://github.com/open-metadata/OpenMetadata/pull/27669): Recursive imports now validate `entityType` per row correctly and the post-import row counts match the file.
+- **`TableColumnCountToBeBetween` API response** [#27900](https://github.com/open-metadata/OpenMetadata/pull/27900): The Data Quality endpoint now returns the expected response shape for this test.
+- **Hyperlink workflow rules — `.keyword` suffix + Tags/Tier disambiguation** [#27799](https://github.com/open-metadata/OpenMetadata/pull/27799): Workflow rule conditions referencing tags/tier no longer match on the analyzed text field; they bind to `.keyword` so prefix collisions between Tags and Tier are resolved.
+
+**Full Changelog**: [link](https://github.com/open-metadata/OpenMetadata/compare/1.12.7-release...1.12.8-release)
+
+</Update>

--- a/snippets/releases/latest.mdx
+++ b/snippets/releases/latest.mdx
@@ -1,123 +1,89 @@
-<Update label="1.12.8 Release" description="13th May 2026">
+<Update label="1.12.9 Release" description="28th May 2026">
 
-You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.8-release).
+You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.9-release).
 
 ## Changelog
 
-OpenMetadata 1.12.8 is a maintenance release focused on hardening the platform against newly disclosed CVEs, eliminating long-standing database hotspots in the search and tag pipelines, and tightening connector behavior across Databricks, Unity Catalog, Athena, Datalake, and OpenLineage. The release also lands several quality-of-life UI fixes around governance approvals, advanced search, and custom properties.
+OpenMetadata 1.12.9 is a maintenance release delivering new connector capabilities, performance improvements for workflow execution, and targeted bug fixes across search, ingestion, UI, and the OpenMetadata Python client.
 
-### ⚠️ Backward Incompatible / Notable Behavior Changes
+### ✨ New Features
 
-- **Notification alerts — `Location` source removed** [#27683](https://github.com/open-metadata/OpenMetadata/pull/27683): The deprecated `Location` entity has been removed from the list of supported sources in notification alerts. `Domain` and `Data Product` are now first-class sources. Existing alerts configured against `Location` will need to be re-created against a supported source.
-- **`ContainerResource` default fields trimmed** ([#27894](https://github.com/open-metadata/OpenMetadata/pull/27894) follow-up): `children` is no longer returned by default on `GET /v1/containers` list responses; clients that depended on the implicit inclusion must request it explicitly via the `fields` query parameter. This restores the documented behavior and unblocks the batched data-model column tag retrieval below.
-- **Soft-deleted users excluded from Experts/Reviewers** [#27120](https://github.com/open-metadata/OpenMetadata/pull/27120): Users marked `deleted` no longer appear in the Experts/Reviewers selector across entities. Workflows that relied on soft-deleted users remaining visible (for example, restoring an entity to its previous reviewer) must restore the user first.
+- **Unity Catalog — incremental metadata extraction** [#28380](https://github.com/open-metadata/OpenMetadata/pull/28380): Unity Catalog connector now detects changed tables via `information_schema.tables.last_altered` and only re-ingests modified entities. Delete detection uses exact catalog matching (preventing wildcard misfires on catalog names containing underscores). Catalog names are validated against an allowlist before SQL interpolation.
+- **Task domains backfilled + stamped on approval** [#28402](https://github.com/open-metadata/OpenMetadata/pull/28402): Approval task threads now inherit the domain of the entity being approved, and a migration backfills domains on existing tasks.
+- **Workflow entity extended fields** [#28398](https://github.com/open-metadata/OpenMetadata/pull/28398): `Workflow` entities now support `inputPorts`, `outputPorts`, and `glossaryTerms` fields, bringing them to parity with pipeline and data-flow entities.
+- **MySQL — custom `queryHistoryTable`** [#28388](https://github.com/open-metadata/OpenMetadata/pull/28388): MySQL connector accepts a configurable `queryHistoryTable` for usage and lineage extraction, enabling use-cases where query history is stored in a non-default location.
 
-### 🔒 Security (Vulnerability Remediation)
+### 🔒 Security
 
-This release addresses the May 8 2026 Snyk scan against the 1.12.7 branch and additional CVEs picked up by AWS Inspector. Nine of the highest-severity findings are resolved through direct version bumps; one (`libthrift`) is force-pinned because upstream Jena has not yet rebased.
-
-**Backend / Java**
-
-- **CRITICAL — Jetty HTTP Request Smuggling (CVE-2026-2332):** `org.eclipse.jetty:jetty-http` bumped `12.1.6 → 12.1.7` [#27996](https://github.com/open-metadata/OpenMetadata/pull/27996).
-- **HIGH — Apache Thrift (CVE-2026-43869):** `libthrift` force-pinned to `0.23.0` via `dependencyManagement` to override the vulnerable transitive shipped by `apache-jena-libs` [#28010](https://github.com/open-metadata/OpenMetadata/pull/28010) / [#28035](https://github.com/open-metadata/OpenMetadata/pull/28035).
-- **HIGH — PostgreSQL JDBC SCRAM-SHA-256 DoS (CVE-2026-42198):** `org.postgresql:postgresql` bumped `42.7.7 → 42.7.11` [#27996](https://github.com/open-metadata/OpenMetadata/pull/27996).
-- **HIGH — BouncyCastle Crypto Signature Bypass + Timing Attack (CVE-2026-5598):** `bcprov-jdk18on` / `bcpkix-jdk18on` pinned to `1.84`, also addressing CVE-2026-0636 and CVE-2026-5588 [#27996](https://github.com/open-metadata/OpenMetadata/pull/27996).
-- **HIGH — Apache Log4j (CVE-2026-34477, CVE-2026-34478, CVE-2026-34480):** `log4j` bumped `2.25.3 → 2.25.4` [#27994](https://github.com/open-metadata/OpenMetadata/pull/27994).
-- **MED — Jackson 3.x deserialization CVEs (GHSA-72hv-8253-57qq):** `jackson-core` bumped `2.17.2 → 2.18.7`. `jsonschema2pojo-core` is now declared `<scope>provided</scope>` in the `common` module so the Jackson 3.x transitive is excluded from the runtime classpath, since the annotators it powers only run at build time [#28010](https://github.com/open-metadata/OpenMetadata/pull/28010).
-- **MED — jsonschema2pojo (CVE-2025-3588):** `jsonschema2pojo` bumped `1.2.2 → 1.3.0` (later aligned to `1.3.1` to resolve a maven-plugin classpath issue) [#27994](https://github.com/open-metadata/OpenMetadata/pull/27994).
-- **MED/LOW — Logback (CVE-2025-11226, CVE-2026-1225):** `logback-core` / `logback-classic` bumped `1.5.19 → 1.5.25` [#27996](https://github.com/open-metadata/OpenMetadata/pull/27996).
-- **Netty:** `netty-bom` bumped `4.1.132 → 4.1.133`. `netty-transport-native-epoll` excluded (Linux-only perf optimization flagged by an overly-broad GHSA range, not used at runtime) [#27994](https://github.com/open-metadata/OpenMetadata/pull/27994) / [#28010](https://github.com/open-metadata/OpenMetadata/pull/28010).
-- **Azure Identity (CVE-2024-35255):** `azure-identity` aligned to `1.15.2` and `azure-keyvault` bumped to remove vulnerable transitives [#27994](https://github.com/open-metadata/OpenMetadata/pull/27994) / [#28010](https://github.com/open-metadata/OpenMetadata/pull/28010).
-- **Reactor Netty & Spring:** `reactor-netty` and `spring` bumped to their current patched lines [#27996](https://github.com/open-metadata/OpenMetadata/pull/27996) / [#28010](https://github.com/open-metadata/OpenMetadata/pull/28010).
-
-**Frontend / UI**
-
-- **axios** upgraded to `1.15.2` to clear reported CVEs in the UI bundle.
-- **postcss** pinned to `8.5.10` with a Yarn `resolutions` override in `openmetadata-ui-core-components` to resolve the Dependabot advisory [#27778](https://github.com/open-metadata/OpenMetadata/pull/27778).
-- **postcss** bumped in the main UI module as well [#27729](https://github.com/open-metadata/OpenMetadata/pull/27729).
-
-**Ingestion / Container Images**
-
-- **ImageMagick purged** from the ingestion image — it was only a transitive of the Airflow base image, was never used by ingestion code, and continued to surface CVEs after Airflow upgrades. Removing it eliminates the surface entirely [#27752](https://github.com/open-metadata/OpenMetadata/pull/27752).
+- **Test-connection workflow authorization** [#28414](https://github.com/open-metadata/OpenMetadata/pull/28414): Test-connection workflow triggers now require proper authorization, closing an unauthenticated execution path.
+- **Snyk high/critical dependency patches in ingestion** [#28340](https://github.com/open-metadata/OpenMetadata/pull/28340): High and critical Snyk findings patched in ingestion dependencies and code paths.
+- **`brace-expansion` lockfile bump to 5.0.6** [#28244](https://github.com/open-metadata/OpenMetadata/pull/28244): Resolves a ReDoS advisory in the transitive `brace-expansion` package.
+- **`js-cookie` bumped** [#28315](https://github.com/open-metadata/OpenMetadata/pull/28315): Frontend dependency bumped to address a Dependabot advisory.
+- **WebSocket Dependabot vulnerability in UI** [#28320](https://github.com/open-metadata/OpenMetadata/pull/28320): Dependency update for a reported WebSocket vulnerability in the UI bundle.
 
 ### 🎨 UI Changes
 
 **Improvements**
 
-- **Approvals show proposed changes inline** [#27201](https://github.com/open-metadata/OpenMetadata/pull/27201): Governance approval task threads now render a *Proposed Changes* section with clickable entity links, so reviewers can see exactly what changed before approving instead of opening the entity in a new tab.
-- **Description added to Advanced Search query builder** [#27913](https://github.com/open-metadata/OpenMetadata/pull/27913): The `description` field is now a first-class searchable attribute with `Contains`, `Not Contains`, `Is Null`, and `Is Not Null` operators. The `descriptionStatus` label was also corrected (previously rendered with the wrong key).
-- **Service documentation panel: admonitions + code copy button** [#27732](https://github.com/open-metadata/OpenMetadata/pull/27732): The in-product service docs now render note/warning/tip admonitions and add a copy button to fenced code blocks.
+- **Data Quality — column selection dropdowns are searchable** [#28376](https://github.com/open-metadata/OpenMetadata/pull/28376): Column selectors in test case forms now include a search box, making it practical to navigate wide tables.
 
 **Fixes**
 
-- **Clipboard works on non-secure (HTTP) contexts** [#28003](https://github.com/open-metadata/OpenMetadata/pull/28003): `CodeBlockComponent` now uses the `useClipboard` hook, which falls back to `document.execCommand` when the modern Clipboard API is unavailable, fixing copy actions for users on self-hosted HTTP deployments.
-- **Custom properties with dots in their name now display** [#27390](https://github.com/open-metadata/OpenMetadata/pull/27390): The UI was treating `.` in custom-property names as a path separator, hiding the property entirely. Names with dots are now rendered correctly.
-- **Tier/Certification tag matching uses FQN prefix, not substring** [#27700](https://github.com/open-metadata/OpenMetadata/pull/27700): Prevents unrelated tags whose FQN happened to *contain* a tier or certification tag's FQN from being mis-classified.
-- **Upvote/Downvote icon retains primary color after blur** [#27898](https://github.com/open-metadata/OpenMetadata/pull/27898): The vote indicator no longer reverts to a neutral color when the entity page loses focus.
-- **AdvancedSearch description option — translations** [#27961](https://github.com/open-metadata/OpenMetadata/pull/27961): Missing/incorrect i18n strings on the new description operator filled in across supported locales.
-- **Rich-text editor migration** [#26887](https://github.com/open-metadata/OpenMetadata/pull/26887): Removed `@toast-ui/react-editor` and migrated remaining usages to the in-house `BlockEditor`, reducing bundle size and eliminating the transitive CVE surface from the abandoned editor package.
-- **ContainerPage tab counts now update reactively**: Added `childrenCount` to the `useMemo` dependency array so tab badges refresh when children load.
+- **Notification links — plural alerts path and Query href** [#27918](https://github.com/open-metadata/OpenMetadata/pull/27918): Notification alert links now route to the correct plural `/alerts` path; Query entity hrefs in notifications are also corrected.
+- **Data Asset Header — permission fix** [#27967](https://github.com/open-metadata/OpenMetadata/pull/27967): Resolved a permission check issue in the Data Asset Header component that prevented certain actions for non-admin users.
+- **Bot name search on Bots page** [#27365](https://github.com/open-metadata/OpenMetadata/pull/27365): Fixed search not returning results when searching for bots by name on the Bots management page.
+- **Column bulk-ops filters use `displayName`** [#28390](https://github.com/open-metadata/OpenMetadata/pull/28390): Service, database, and schema filter dropdowns in the column bulk-operations flow now display `displayName` instead of raw FQN fragments.
+- **Bulk-asset operations enforce `dryRun`** [#28395](https://github.com/open-metadata/OpenMetadata/pull/28395): Tag, glossary, and data-product bulk operations now correctly honour the `dryRun` flag, preventing accidental mutations during preview runs.
+- **Table / dataModel — inline `column.extension` persisted** [#28392](https://github.com/open-metadata/OpenMetadata/pull/28392): Custom extension data attached inline to columns is now saved correctly through `POST`/`PUT` calls.
+- **ServicesPage tab accepts `ServiceCategory` enum values** [#28375](https://github.com/open-metadata/OpenMetadata/pull/28375): The `:tab` route parameter now accepts both the label string and the raw `ServiceCategory` enum value, fixing deep-links that used enum values.
+- **Unknown service category returns 404** [#28372](https://github.com/open-metadata/OpenMetadata/pull/28372): Navigating to an unrecognised service category now returns a proper 404 page instead of an empty fallback.
+- **KPI widget date format** [#28370](https://github.com/open-metadata/OpenMetadata/pull/28370): Added missing space between day and month values in the KPI widget's X-axis date labels.
+- **Bug fix (#27433)** [#28266](https://github.com/open-metadata/OpenMetadata/pull/28266): Backported fix for entity display regression.
 
 ### 🔌 Connectors
 
 **Databases**
 
-- **Databricks — nested column descriptions + SQLAlchemy 2.x** [#27766](https://github.com/open-metadata/OpenMetadata/pull/27766): Descriptions on STRUCT/MAP/ARRAY-typed nested columns are now captured during metadata ingestion. The connector is also compatible with `sqlalchemy-databricks` running on SQLAlchemy 2.x.
-- **Unity Catalog — missing `httpPath`** [#27844](https://github.com/open-metadata/OpenMetadata/pull/27844): The connector no longer hard-fails when `httpPath` is omitted; it now produces a clear configuration error instead of an opaque stack trace.
-- **Athena — Iceberg table properties** [#27715](https://github.com/open-metadata/OpenMetadata/pull/27715): Iceberg-on-Athena tables now ingest table properties from the `$properties` metatable, surfacing Iceberg-specific metadata (format-version, write.target-file-size-bytes, etc.) in OpenMetadata.
-- **PostgreSQL / MSSQL — mutual TLS** [#27104](https://github.com/open-metadata/OpenMetadata/pull/27104): Both connectors now support client-certificate mTLS in addition to server-side SSL, matching enterprise PG/MSSQL hardening requirements.
-- **PostgreSQL — tag_usage seq-scan eliminated** [#27824](https://github.com/open-metadata/OpenMetadata/pull/27824): Backport of #27158. The certification tag query now uses the covering index instead of a sequential scan, removing a multi-second hotspot during Data Insights runs on large catalogs.
-- **SQLAlchemy 2.x row access** [#27643](https://github.com/open-metadata/OpenMetadata/pull/27643): Replaced old-style row indexing that emitted deprecation warnings on SQLAlchemy 2.x.
-
-**Datalake / Object Stores**
-
-- **Datalake — nested arrays of structs in JSON** [#27798](https://github.com/open-metadata/OpenMetadata/pull/27798): Array-typed fields whose elements are nested structures are now parsed correctly and surface as proper nested column schemas.
+- **Databricks / Unity Catalog — valueless tags ingested** [#28294](https://github.com/open-metadata/OpenMetadata/pull/28294): Tags set without an explicit value (valueless) are now ingested correctly from Databricks and Unity Catalog sources.
+- **Snowflake — discovered databases logged with filter reasons** [#28385](https://github.com/open-metadata/OpenMetadata/pull/28385): During schema discovery the Snowflake connector now logs each discovered database alongside the reason when it is filtered out, improving debuggability.
 
 **Pipelines / Dashboards**
 
-- **Power BI — additional lineage logging** [#27970](https://github.com/open-metadata/OpenMetadata/pull/27970): More granular diagnostic logs in the Power BI lineage extractor make customer-side debugging substantially faster.
+- **Bulk sink — charts and dataModels created before dashboards** [#28371](https://github.com/open-metadata/OpenMetadata/pull/28371): Fixed a bulk sink ordering bug where a Dashboard entity could be flushed before its referenced Charts or DashboardDataModels, causing HTTP 400 rejections from the server. Each topology stage now encodes its position so referenced entities are always created first.
+- **Power BI — sink buffer flushed before lineage resolution** [#28308](https://github.com/open-metadata/OpenMetadata/pull/28308): Ensures all Power BI entities are persisted before lineage resolution begins, preventing reference errors during lineage extraction.
+- **Power BI — TSQL dialect for `Sql.Database` M-query lineage** [#28380](https://github.com/open-metadata/OpenMetadata/pull/28380): The Power BI connector now parses `Sql.Database` M-query expressions using the TSQL dialect, fixing lineage extraction failures on SQL Server-backed datasets.
 
 **OpenLineage**
 
-- **AWS Glue, Kusto, and Cosmos DB dataset naming** [#27533](https://github.com/open-metadata/OpenMetadata/pull/27533): Adds dataset-naming support so OpenLineage events from these sources are resolved to the correct OpenMetadata entities.
-- **Namespace-based DB service resolution for `db_table`** [#27005](https://github.com/open-metadata/OpenMetadata/pull/27005): OpenLineage `db_table` lookups now resolve to the right DB service by namespace, fixing cross-service lineage gaps.
-- **Pipeline/job resolution by integration type** [#26821](https://github.com/open-metadata/OpenMetadata/pull/26821): OpenLineage pipelines and jobs are now mapped to their integration type so they show up under the correct pipeline service.
-
-**AI / Vector Embeddings**
-
-- **OpenAI embedding concurrency control** [#26574](https://github.com/open-metadata/OpenMetadata/pull/26574): Adds a configurable concurrency cap on outbound OpenAI embedding HTTP requests, preventing rate-limit storms during bulk reindex.
+- **Resolve table identity from `symlinks` facet** [#28360](https://github.com/open-metadata/OpenMetadata/pull/28360): OpenLineage events that include a `symlinks` facet now resolve the true table identity from the symlink, fixing entity matching for Hive/Iceberg tables exposed under alternate names.
+- **Pipeline as node for single-sided lineage** [#28350](https://github.com/open-metadata/OpenMetadata/pull/28350): OpenLineage pipelines can now appear as a standalone node in the lineage graph when only one side (input or output) is present, instead of being dropped.
 
 **Ingestion Runtime**
 
-- **Bulk sink OOM under persistent flush failures** [#26838](https://github.com/open-metadata/OpenMetadata/pull/26838): The bulk sink no longer accumulates an unbounded retry buffer when downstream flushes keep failing; the buffer is now bounded and drops with a clear error.
-- **CronOMJob tolerations propagated** [#27955](https://github.com/open-metadata/OpenMetadata/pull/27955): Pod tolerations defined on a `CronOMJob` are now copied to the scheduled `OMJob`, so taint-isolated nodes keep working after a restart.
-- **PII recognizer language scoping** [#27919](https://github.com/open-metadata/OpenMetadata/pull/27919): PII recognizers are now included based on the configured language, eliminating false positives from recognizers loaded for unrelated locales.
-- **`dbt-extractor` pinned `>=0.5.0`** [#27777](https://github.com/open-metadata/OpenMetadata/pull/27777): Prevents the ARM-on-pip resolver from falling back to a source distribution that fails to build inside the ingestion container.
+- **Kubernetes client capped below 36.0.0** [#28331](https://github.com/open-metadata/OpenMetadata/pull/28331): Pins the Kubernetes Python client to `<36.0.0` to avoid a breaking API change introduced in that release.
+- **Ingestion-pipeline status preserved during queued-stage failures** [#28382](https://github.com/open-metadata/OpenMetadata/pull/28382): When a queued-stage task fails, the overall pipeline status remains accurate instead of being overwritten with a misleading value.
 
 ### 🛠 API (Backend)
 
 **Improvements**
 
-- **Reindex memory optimization for DatabaseSchema** [#27723](https://github.com/open-metadata/OpenMetadata/pull/27723) / [#28061](https://github.com/open-metadata/OpenMetadata/pull/28061): `DatabaseSchemaIndex` now skips the `tables` fan-out during reindex, reducing memory pressure on catalogs with very large schemas. All other entity indexes hydrate the full field set as before.
-- **SearchUtils consolidated; fuzzy ngram removed** [#27636](https://github.com/open-metadata/OpenMetadata/pull/27636): Merged the duplicated SearchUtils classes into one and dropped the redundant fuzzy match on ngram-tokenized fields (fuzzy + ngram compounded false positives). Adds substantial unit-test coverage.
-- **Certification tag batch query — source filter + indexed hash prefix** [#27847](https://github.com/open-metadata/OpenMetadata/pull/27847): The `TagUsageDAO.getCertTagsInternalBatch` query previously did a `tagFQN LIKE 'Certification.%'` scan and ran ~12s per call on heavy classification hierarchies. With a `source` filter and a hash-prefix predicate it now uses the covering index — eliminating ~19 hours of cumulative DB time per Data Insights run on a representative customer instance.
-- **Container data-model column tags — batched** [#27894](https://github.com/open-metadata/OpenMetadata/pull/27894): Replaces per-column tag lookups with a single batched query.
-- **`IndexResource` logs lowered to debug** [#27588](https://github.com/open-metadata/OpenMetadata/pull/27588): Reduces production log noise; verbose index lifecycle logs are now gated on `DEBUG`.
+- **Workflow field fetches scoped** [#28391](https://github.com/open-metadata/OpenMetadata/pull/28391): Wildcard field fetches in workflow-related queries replaced with scoped field requests, reducing payload size and improving performance.
+- **Data Insights enricher — per-step failure isolation** [#28379](https://github.com/open-metadata/OpenMetadata/pull/28379): Enricher step failures are now isolated per-step with individual error tracking, preventing one bad enricher from aborting the entire Data Insights run.
 
 **Fixes**
 
-- **`DataContract` 400 on entities without `dataProducts`** [#27861](https://github.com/open-metadata/OpenMetadata/pull/27861): The endpoint now handles entities that don't carry a `dataProducts` field, instead of rejecting the request.
-- **`/search` endpoint for Roles** [#27335](https://github.com/open-metadata/OpenMetadata/pull/27335): Adds the missing `GET /v1/roles/search` endpoint and aligns role selectors to use server-side search [#27737](https://github.com/open-metadata/OpenMetadata/pull/27737).
-- **MCP — SSE response when client negotiates `text/event-stream`** [#27917](https://github.com/open-metadata/OpenMetadata/pull/27917): The MCP endpoint now correctly returns an SSE-framed response when the client's `Accept` header asks for `text/event-stream`.
-- **MCP OAuth on Databricks** [#27922](https://github.com/open-metadata/OpenMetadata/pull/27922): Fixes the OAuth callback handling specific to Databricks-backed MCP clients.
-- **Time-series reindex — stale `parentOf` is a warning, not a failure** [#27800](https://github.com/open-metadata/OpenMetadata/pull/27800): During time-series reindex, an orphaned `parentOf` reference no longer aborts the run; it's logged as a warning and the reindex continues.
-- **Column bulk-ops search at scale** [#27216](https://github.com/open-metadata/OpenMetadata/pull/27216): Bulk operations on columns now return results consistently on large indices where the previous code path silently returned an empty set above a query-size threshold.
-- **OpenSearch HC5 transport — recoverable I/O reactor shutdown** [#27698](https://github.com/open-metadata/OpenMetadata/pull/27698): Transient `I/O reactor has been shut down` errors are now recovered automatically instead of leaving the client in a permanently failed state.
-- **Vector embedding healthcheck** [#27616](https://github.com/open-metadata/OpenMetadata/pull/27616): The `/health` probe now correctly reflects vector-embedding subsystem availability instead of always reporting healthy.
-- **CSV import — recursive extension validation + row-count accounting** [#27593](https://github.com/open-metadata/OpenMetadata/pull/27593) / [#27669](https://github.com/open-metadata/OpenMetadata/pull/27669): Recursive imports now validate `entityType` per row correctly and the post-import row counts match the file.
-- **`TableColumnCountToBeBetween` API response** [#27900](https://github.com/open-metadata/OpenMetadata/pull/27900): The Data Quality endpoint now returns the expected response shape for this test.
-- **Hyperlink workflow rules — `.keyword` suffix + Tags/Tier disambiguation** [#27799](https://github.com/open-metadata/OpenMetadata/pull/27799): Workflow rule conditions referencing tags/tier no longer match on the analyzed text field; they bind to `.keyword` so prefix collisions between Tags and Tier are resolved.
+- **Search `search_after` with special characters in sort values** [#28386](https://github.com/open-metadata/OpenMetadata/pull/28386): `search_after` pagination no longer drops entities whose sort-field value contains special characters.
+- **Search — nested children flattened to avoid ES mapping depth limit** [#28387](https://github.com/open-metadata/OpenMetadata/pull/28387): Deeply nested `children` fields are now flattened before indexing to prevent Elasticsearch/OpenSearch from rejecting documents that exceed the default mapping depth limit.
+- **Table certification cascaded to child search documents** [#28229](https://github.com/open-metadata/OpenMetadata/pull/28229): A `PATCH` to a Table's certification tag is now propagated to all child search documents, keeping certification state consistent across the search index.
+- **Search-index reindex jobs no longer marked failed on clean completion** [#28381](https://github.com/open-metadata/OpenMetadata/pull/28381): Fixed a status-tracking bug that incorrectly recorded clean reindex jobs as failed in the job history.
+- **PDTS duplicate preemption and invalid index-mapping recovery** [#28373](https://github.com/open-metadata/OpenMetadata/pull/28373): Migration now preempts duplicate PDTS (Profiler Data Time Series) rows and recovers from invalid search index mappings rather than failing.
+- **MCP — `search_metadata` response capped** [#28383](https://github.com/open-metadata/OpenMetadata/pull/28383): The MCP `search_metadata` tool response is now capped in size to prevent LLM context overflow when the result set is large.
+- **Alert filter functions use strict literal matching** [#28393](https://github.com/open-metadata/OpenMetadata/pull/28393): Alert filter expressions now perform strict literal matching instead of substring matching, preventing false-positive alert triggers.
+- **Test case suite search membership preserved** [#28271](https://github.com/open-metadata/OpenMetadata/pull/28271): Test cases now retain their suite membership in the search index after updates, fixing a regression where suites lost members after re-ingestion.
+- **OMeta SSE transport switched to `requests`** [#28293](https://github.com/open-metadata/OpenMetadata/pull/28293): The OpenMetadata Python client now uses `requests` instead of `httpx` for SSE (Server-Sent Events) transport, resolving compatibility issues in certain deployment environments.
+- **OMeta — resilient transport with keepalive and retry** [#28389](https://github.com/open-metadata/OpenMetadata/pull/28389): The OMeta REST transport now uses keepalive connections and automatic retries on transient failures with a typed `RestTransport` abstraction.
+- **Shutdown logging captures full streamable log tail** [#28396](https://github.com/open-metadata/OpenMetadata/pull/28396): Synchronous shutdown now waits for in-flight streamable log writes to complete, preventing log truncation on graceful shutdown.
 
-**Full Changelog**: [link](https://github.com/open-metadata/OpenMetadata/compare/1.12.7-release...1.12.8-release)
+**Full Changelog**: [link](https://github.com/open-metadata/OpenMetadata/compare/1.12.8-release...1.12.9-release)
 
 </Update>

--- a/v1.12.x/releases/all-releases.mdx
+++ b/v1.12.x/releases/all-releases.mdx
@@ -10,6 +10,7 @@ import ReleaseNotes3 from '/snippets/releases/1.12.4.mdx';
 import ReleaseNotes4 from '/snippets/releases/1.12.5.mdx';
 import ReleaseNotes5 from '/snippets/releases/1.12.6.mdx';
 import ReleaseNotes6 from '/snippets/releases/1.12.7.mdx';
+import ReleaseNotes7 from '/snippets/releases/1.12.8.mdx';
 import ReleaseNotes from '/snippets/releases/latest.mdx';
 
 
@@ -21,11 +22,13 @@ The OpenMetadata community is on a monthly release cadence. At every 4-5 weeks w
 
 <CardGroup>
 <Card icon="party-horn" title="Upgrade OpenMetadata" href="/v1.12.x/deployment/upgrade">
-Learn how to upgrade your OpenMetadata instance to 1.12.8!
+Learn how to upgrade your OpenMetadata instance to 1.12.9!
 </Card>
 </CardGroup>
 
 <ReleaseNotes />
+
+<ReleaseNotes7 />
 
 <ReleaseNotes6 />
 


### PR DESCRIPTION
## Summary

- Archive current `latest.mdx` → new `snippets/releases/1.12.8.mdx`
- Write new `snippets/releases/latest.mdx` for 1.12.9 (OSS-only changes)
- Add `1.12.8.mdx` import to `v1.12.x/releases/all-releases.mdx` and update upgrade card text to 1.12.9

Contains OpenMetadata-only changes (no Collate-specific content).

## Files changed
- `snippets/releases/latest.mdx` — 1.12.9 release notes
- `snippets/releases/1.12.8.mdx` — archived 1.12.8 release notes
- `v1.12.x/releases/all-releases.mdx` — added ReleaseNotes7 import for 1.12.8, upgrade card → 1.12.9

Reference: https://github.com/open-metadata/docs-om/commit/5b48ef2f4400015f71773a101ecee250a94deeb2

🤖 Generated with [Claude Code](https://claude.com/claude-code)