### PR TITLE
Docs: Remove SAP Hana from Table Diff supported connectors (all versions)

### DIFF
--- a/v1.11.x/how-to-guides/data-quality-observability/quality/tests-yaml.mdx
+++ b/v1.11.x/how-to-guides/data-quality-observability/quality/tests-yaml.mdx
@@ -469,21 +469,22 @@ Integrity
 ```
 
 ### Compare 2 Tables for Differences
-Compare 2 tables for differences. Allows a user to check for integrity.
-Supports comparing tables across different services.
-For example, you can compare a table in Snowflake with a table in Redshift.
+Compare two tables for differences, letting you check for integrity across different services — for example, a table in Snowflake against a table in Redshift.
+
+<Note>
+Only the connectors listed below are currently supported by the underlying `data-diff` library. Using an unsupported connector will result in a `Scheme '...' currently not supported` error.
+</Note>
 
 Supported connectors:
- - Snowflake
- - BigQuery
- - Athena
- - Redshift
- - Postgres
- - MySQL
- - MSSQL
- - Oracle
- - Trino
- - SAP Hana
+- Snowflake
+- BigQuery
+- Athena
+- Redshift
+- Postgres
+- MySQL
+- MSSQL
+- Oracle
+- Trino
 
 **Dimension**:
 Consistency

--- a/v1.12.x/how-to-guides/data-quality-observability/quality/tests-yaml.mdx
+++ b/v1.12.x/how-to-guides/data-quality-observability/quality/tests-yaml.mdx
@@ -469,21 +469,22 @@ Integrity
 ```
 
 ### Compare 2 Tables for Differences
-Compare 2 tables for differences. Allows a user to check for integrity.
-Supports comparing tables across different services.
-For example, you can compare a table in Snowflake with a table in Redshift.
+Compare two tables for differences, letting you check for integrity across different services — for example, a table in Snowflake against a table in Redshift.
+
+<Note>
+Only the connectors listed below are currently supported by the underlying `data-diff` library. Using an unsupported connector will result in a `Scheme '...' currently not supported` error.
+</Note>
 
 Supported connectors:
- - Snowflake
- - BigQuery
- - Athena
- - Redshift
- - Postgres
- - MySQL
- - MSSQL
- - Oracle
- - Trino
- - SAP Hana
+- Snowflake
+- BigQuery
+- Athena
+- Redshift
+- Postgres
+- MySQL
+- MSSQL
+- Oracle
+- Trino
 
 **Dimension**:
 Consistency

--- a/v1.13.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/tests-yaml.mdx
+++ b/v1.13.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/tests-yaml.mdx
@@ -469,21 +469,22 @@ Integrity
 ```
 
 ### Compare 2 Tables for Differences
-Compare 2 tables for differences. Allows a user to check for integrity.
-Supports comparing tables across different services.
-For example, you can compare a table in Snowflake with a table in Redshift.
+Compare two tables for differences, letting you check for integrity across different services — for example, a table in Snowflake against a table in Redshift.
+
+<Note>
+Only the connectors listed below are currently supported by the underlying `data-diff` library. Using an unsupported connector will result in a `Scheme '...' currently not supported` error.
+</Note>
 
 Supported connectors:
- - Snowflake
- - BigQuery
- - Athena
- - Redshift
- - Postgres
- - MySQL
- - MSSQL
- - Oracle
- - Trino
- - SAP Hana
+- Snowflake
+- BigQuery
+- Athena
+- Redshift
+- Postgres
+- MySQL
+- MSSQL
+- Oracle
+- Trino
 
 **Dimension**:
 Consistency


### PR DESCRIPTION
## Summary
- Removed `SAP Hana` from the supported connectors list in all three versions
  (`v1.11.x`, `v1.12.x`, `v1.13.x-SNAPSHOT`)
- Added a `<Note>` callout clearly stating which connectors are supported and
  what error to expect when using an unsupported one
<img width="2970" height="1524" alt="image" src="https://github.com/user-attachments/assets/26d9fa31-231b-44c8-8e50-a6c258d94366" />
- Rewrote the section description for clarity and consistency across versions
- Fixed list item formatting (removed erroneous leading spaces on bullet points)

## Affected Pages

| Version | File |
|---------|------|
| v1.11.x | `how-to-guides/data-quality-observability/quality/tests-yaml.mdx` |
| v1.12.x | `how-to-guides/data-quality-observability/quality/tests-yaml.mdx` |
| v1.13.x-SNAPSHOT | `how-to-guides/data-quality-observability/quality/tests-yaml.mdx` |
