### PR TITLE
Docs: Update PostgreSQL minimum version to 17.6 across all versions

### DIFF
--- a/snippets/components/VersionMatrix/versionMatrixData.mdx
+++ b/snippets/components/VersionMatrix/versionMatrixData.mdx
@@ -1,7 +1,7 @@
 export const VERSION_MATRIX_DATA = [
   { service: "Java", version: "21" },
   { service: "Mysql", version: "8.0.42" },
-  { service: "Postgres", version: "1.15.0" },
+  { service: "Postgres", version: "17.6" },
   { service: "OpenSearch", version: "3.2.0" },
   { service: "ElasticSearch", version: "9.3.0" },
 ];
@@ -9,7 +9,7 @@ export const VERSION_MATRIX_DATA = [
 export const VERSION_MATRIX_DATA_WITH_UPDATES = [
   { service: "Java", version: "21" },
   { service: "Mysql", version: "8.0.42" },
-  { service: "Postgres", version: "1.15.0" },
+  { service: "Postgres", version: "17.6" },
   { service: "OpenSearch", version: "3.2.0", updated: true },
   { service: "ElasticSearch", version: "9.3.0", updated: true },
 ];

--- a/v1.11.x/deployment/bare-metal.mdx
+++ b/v1.11.x/deployment/bare-metal.mdx
@@ -24,7 +24,7 @@ java --version
 To install Java or upgrade to Java 21, see the instructions for your operating system at [How do I install
 Java?](https://java.com/en/download/help/download_options.html#mac).
 
-## MySQL (version 8.0.0 or higher)
+## MySQL (version 8.0.42 or higher)
 
 To install MySQL see the instructions for your operating system (OS) at [Installing and Upgrading MySQL](https://dev.mysql.com/doc/mysql-installation-excerpt/8.0/en/installing.html)
 or visit one of the following OS-specific guides.
@@ -41,7 +41,7 @@ You can refer a sample script [here](https://github.com/open-metadata/OpenMetada
 
 </Tip>
 
-## Postgres (version 12.0 or higher)
+## Postgres (version 17.6 or higher)
 
 To install Postgres see the instructions for your operating system (OS) at [Postgres Download](https://www.postgresql.org/download/)
 <Tip>
@@ -172,9 +172,9 @@ If you are running OpenMetadata in AWS, it is recommended to use [Amazon RDS](ht
 
 We support
 
-- Amazon RDS (MySQL) engine version 8 or higher
-- Amazon OpenSearch (ElasticSearch) engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
-- Amazon RDS (PostgreSQL) engine version between 12 or higher
+- Amazon RDS for MySQL engine version 8.0.42 or higher
+- Amazon OpenSearch  for ElasticSearch engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
+- Amazon RDS for PostgreSQL engine version 17.6 or higher
 
 For Production Systems, we recommend Amazon RDS to be in Multiple Availability Zones. For Amazon OpenSearch (or ElasticSearch) Service, we recommend Multiple Availability Zones with minimum 3 Master Nodes.
 

--- a/v1.11.x/deployment/configuration.mdx
+++ b/v1.11.x/deployment/configuration.mdx
@@ -113,7 +113,7 @@ database:
 
 ### PostgreSQL Configuration
 
-OpenMetadata uses stored generated columns which is supported in Postgres 12 and later. Ensure you have Postgres 12 or higher. We recommend you create a Postgres user with a strong password and update this section accordingly.
+OpenMetadata uses stored generated columns which is supported in Postgres 17.6 and later. Ensure you have Postgres 17.6 or higher. We recommend you create a Postgres user with a strong password and update this section accordingly.
 
 | Parameter | Description | Default Value |
 |-----------|-------------|---------------|

--- a/v1.11.x/deployment/docker/advanced.mdx
+++ b/v1.11.x/deployment/docker/advanced.mdx
@@ -55,9 +55,9 @@ If you are running OpenMetadata in AWS, it is recommended to use [Amazon RDS](ht
 
 We support
 
-- Amazon RDS (MySQL) engine version 8 or higher
-- Amazon OpenSearch (ElasticSearch) engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
-- Amazon RDS (PostgreSQL) engine version 12 or higher
+- Amazon RDS for MySQL engine version 8.0.42 or higher
+- Amazon OpenSearch for ElasticSearch engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
+- Amazon RDS for PostgreSQL engine version 17.6 or higher
 
 Note:-
 When using AWS Services the SearchType Configuration for elastic search should be `opensearch`, for both cases ElasticSearch and OpenSearch,

--- a/v1.11.x/deployment/kubernetes/aks.mdx
+++ b/v1.11.x/deployment/kubernetes/aks.mdx
@@ -16,8 +16,8 @@ It is recommended to use [Azure SQL](https://azure.microsoft.com/en-in/products/
 
 We support
 
-- Azure SQL (MySQL) engine version 8 or higher
-- Azure SQL (PostgreSQL) engine version 12 or higher
+- Azure Database for MySQL engine version 8.0.42 or higher
+- Azure Database for PostgreSQL engine version 17.6 or higher
 - Elastic Cloud (ElasticSearch version 8.11.4)
 
 Once you have the Azure SQL and Elastic Cloud on Azure configured, you can update the environment variables below for OpenMetadata kubernetes deployments to connect with Database and ElasticSearch.

--- a/v1.11.x/deployment/kubernetes/eks.mdx
+++ b/v1.11.x/deployment/kubernetes/eks.mdx
@@ -25,8 +25,8 @@ It is recommended to use [Amazon RDS](https://docs.aws.amazon.com/rds/index.html
 
 We support
 
-- Amazon RDS (MySQL) engine version 8 or higher
-- Amazon RDS (PostgreSQL) engine version 12 or higher
+- Amazon RDS for MySQL engine version 8.0.42 or higher
+- Amazon RDS for PostgreSQL engine version 17.6 or higher
 - Amazon OpenSearch engine version 2.X (upto 2.19)
 
 <Tip>

--- a/v1.11.x/deployment/kubernetes/gke.mdx
+++ b/v1.11.x/deployment/kubernetes/gke.mdx
@@ -30,8 +30,8 @@ All the code snippets in this section assume the `default` namespace for kuberne
 It is recommended to use GCP [Cloud SQL](https://cloud.google.com/sql/) services for Database and [Elastic Cloud GCP](https://www.elastic.co/partners/google-cloud) for Search Engine for Production.
 
 We support -
-- Cloud SQL (MySQL) engine version 8 or higher
-- Cloud SQL (postgreSQL) engine version 12 or higher
+- Cloud Database for MySQL engine version 8.0.42 or higher
+- Cloud Database for PostgreSQL engine version 17.6 or higher
 - ElasticSearch Engine version 8.X (upto 8.10.X)
 
 We recommend -

--- a/v1.11.x/deployment/kubernetes/on-prem.mdx
+++ b/v1.11.x/deployment/kubernetes/on-prem.mdx
@@ -23,7 +23,7 @@ This guide presumes you have an on premises Kubernetes cluster setup, and you ar
 We support
 
 - MySQL engine version 8 or higher
-- PostgreSQL engine version 12 or higher
+- PostgreSQL engine version 17.6 or higher
 - ElasticSearch version 8.X (upto 8.11.4) or OpenSearch Version 2.X (upto 2.19)
 
 Once you have the External Database and Search Engine configured, you can update the environment variables below for OpenMetadata kubernetes deployments to connect with Database and ElasticSearch.

--- a/v1.11.x/deployment/minimum-requirements.mdx
+++ b/v1.11.x/deployment/minimum-requirements.mdx
@@ -32,8 +32,8 @@ These settings apply as well when using managed instances, such as AWS RDS or GC
 
 OpenMetadata currently supports -
 
-- MySQL version 8.0.0 or higher
-- PostgreSQL version 12.0 or higher
+- MySQL version 8.0.42 or higher
+- PostgreSQL version 17.6 or higher
 
 ## ElasticSearch or OpenSearch as Search Instance
 

--- a/v1.12.x/deployment/bare-metal.mdx
+++ b/v1.12.x/deployment/bare-metal.mdx
@@ -41,7 +41,7 @@ You can refer a sample script [here](https://github.com/open-metadata/OpenMetada
 
 </Tip>
 
-## Postgres (version 12.0 or higher)
+## Postgres (version 17.6 or higher)
 
 To install Postgres see the instructions for your operating system (OS) at [Postgres Download](https://www.postgresql.org/download/)
 <Tip>
@@ -172,9 +172,9 @@ If you are running OpenMetadata in AWS, it is recommended to use [Amazon RDS](ht
 
 We support
 
-- Amazon RDS (MySQL) engine version 8 or higher
-- Amazon OpenSearch (ElasticSearch) engine version 9.x (minimum 9.0.0, recommended 9.3.0) or Amazon OpenSearch engine version 3.x (minimum 3.0.0, recommended 3.3.0)
-- Amazon RDS (PostgreSQL) engine version between 12 or higher
+- Amazon RDS for MySQL engine version 8.0.42 or higher
+- Amazon OpenSearch for ElasticSearch engine version 9.x (minimum 9.0.0, recommended 9.3.0) or Amazon OpenSearch engine version 3.x (minimum 3.0.0, recommended 3.3.0)
+- Amazon RDS for PostgreSQL engine version 17.6 or higher
 
 For Production Systems, we recommend Amazon RDS to be in Multiple Availability Zones. For Amazon OpenSearch (or ElasticSearch) Service, we recommend Multiple Availability Zones with minimum 3 Master Nodes.
 

--- a/v1.12.x/deployment/configuration.mdx
+++ b/v1.12.x/deployment/configuration.mdx
@@ -113,7 +113,7 @@ database:
 
 ### PostgreSQL Configuration
 
-OpenMetadata uses stored generated columns which is supported in Postgres 12 and later. Ensure you have Postgres 12 or higher. We recommend you create a Postgres user with a strong password and update this section accordingly.
+OpenMetadata uses stored generated columns which is supported in Postgres 17.6 and later. Ensure you have Postgres 17.6 or higher. We recommend you create a Postgres user with a strong password and update this section accordingly.
 
 | Parameter | Description | Default Value |
 |-----------|-------------|---------------|

--- a/v1.12.x/deployment/docker/advanced.mdx
+++ b/v1.12.x/deployment/docker/advanced.mdx
@@ -55,9 +55,9 @@ If you are running OpenMetadata in AWS, it is recommended to use [Amazon RDS](ht
 
 We support
 
-- Amazon RDS (MySQL) engine version 8 or higher
-- Amazon OpenSearch (ElasticSearch) engine version 9.x (minimum 9.0.0, recommended 9.3.0) or Amazon OpenSearch engine version 3.x (minimum 3.0.0, recommended 3.3.0)
-- Amazon RDS (PostgreSQL) engine version 12 or higher
+- Amazon RDS for MySQL engine version 8.0.42 or higher
+- Amazon OpenSearch for ElasticSearch engine version 9.x (minimum 9.0.0, recommended 9.3.0) or Amazon OpenSearch engine version 3.x (minimum 3.0.0, recommended 3.3.0)
+- Amazon RDS for PostgreSQL engine version 17.6 or higher
 
 Note:-
 When using AWS Services the SearchType Configuration for elastic search should be `opensearch`, for both cases ElasticSearch and OpenSearch,

--- a/v1.12.x/deployment/kubernetes/aks.mdx
+++ b/v1.12.x/deployment/kubernetes/aks.mdx
@@ -16,8 +16,8 @@ OpenMetadata can be deployed on Azure Kubernetes Service. This guide covers both
 It is recommended to use [Azure SQL](https://azure.microsoft.com/en-in/products/azure-sql/database) and [Elastic Cloud on Azure](https://www.elastic.co/partners/microsoft-azure) for Production Deployments.
 
 We support:
-- Azure SQL (MySQL) engine version 8 or higher
-- Azure SQL (PostgreSQL) engine version 12 or higher
+- Azure Database for MySQL engine version 8.0.42 or higher
+- Azure Database for PostgreSQL engine version 17.6 or higher
 - Elastic Cloud (ElasticSearch version 9.x, minimum 9.0.0, recommended 9.3.0)
 
 We recommend:

--- a/v1.12.x/deployment/kubernetes/eks.mdx
+++ b/v1.12.x/deployment/kubernetes/eks.mdx
@@ -25,8 +25,8 @@ It is recommended to use [Amazon RDS](https://docs.aws.amazon.com/rds/index.html
 
 We support
 
-- Amazon RDS (MySQL) engine version 8 or higher
-- Amazon RDS (PostgreSQL) engine version 12 or higher
+- Amazon RDS for MySQL engine version 8.0.42 or higher
+- Amazon RDS for PostgreSQL engine version 17.6 or higher
 - Amazon OpenSearch engine version 3.x (minimum 3.0.0, recommended 3.3.0)
 
 <Tip>

--- a/v1.12.x/deployment/kubernetes/gke.mdx
+++ b/v1.12.x/deployment/kubernetes/gke.mdx
@@ -32,8 +32,8 @@ All the code snippets in this section assume the `default` namespace for kuberne
 It is recommended to use GCP [Cloud SQL](https://cloud.google.com/sql/) services for Database and [Elastic Cloud GCP](https://www.elastic.co/partners/google-cloud) for Search Engine for Production.
 
 We support -
-- Cloud SQL (MySQL) engine version 8 or higher
-- Cloud SQL (postgreSQL) engine version 12 or higher
+- Cloud Database for MySQL engine version 8 or higher
+- Cloud Database for PostgreSQL engine version 17.6 or higher
 - ElasticSearch version 9.x (minimum 9.0.0, recommended 9.3.0)
 
 We recommend -

--- a/v1.12.x/deployment/kubernetes/on-prem.mdx
+++ b/v1.12.x/deployment/kubernetes/on-prem.mdx
@@ -22,8 +22,8 @@ This guide presumes you have an on premises Kubernetes cluster setup, and you ar
 
 We support
 
-- MySQL engine version 8 or higher
-- PostgreSQL engine version 12 or higher
+- MySQL engine version 8.0.42 or higher
+- PostgreSQL engine version 17.6 or higher
 - ElasticSearch version 9.x (minimum 9.0.0, recommended 9.3.0) or OpenSearch version 3.x (minimum 3.0.0, recommended 3.3.0)
 
 Once you have the External Database and Search Engine configured, you can update the environment variables below for OpenMetadata kubernetes deployments to connect with Database and ElasticSearch.

--- a/v1.12.x/deployment/minimum-requirements.mdx
+++ b/v1.12.x/deployment/minimum-requirements.mdx
@@ -33,7 +33,7 @@ These settings apply as well when using managed instances, such as AWS RDS or GC
 OpenMetadata currently supports -
 
 - MySQL version 8.0.42 or higher
-- PostgreSQL version 12.0 or higher
+- PostgreSQL version 17.6 or higher
 
 ## ElasticSearch or OpenSearch as Search Instance
 

--- a/v1.13.x-SNAPSHOT/deployment/bare-metal.mdx
+++ b/v1.13.x-SNAPSHOT/deployment/bare-metal.mdx
@@ -41,7 +41,7 @@ You can refer a sample script [here](https://github.com/open-metadata/OpenMetada
 
 </Tip>
 
-## Postgres (version 12.0 or higher)
+## Postgres (version 17.6 or higher)
 
 To install Postgres see the instructions for your operating system (OS) at [Postgres Download](https://www.postgresql.org/download/)
 <Tip>
@@ -172,9 +172,9 @@ If you are running OpenMetadata in AWS, it is recommended to use [Amazon RDS](ht
 
 We support
 
-- Amazon RDS (MySQL) engine version 8 or higher
-- Amazon OpenSearch (ElasticSearch) engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
-- Amazon RDS (PostgreSQL) engine version between 12 or higher
+- Amazon RDS for MySQL engine version 8.0.42 or higher
+- Amazon OpenSearch for ElasticSearch engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
+- Amazon RDS for PostgreSQL engine version 17.6 or higher
 
 For Production Systems, we recommend Amazon RDS to be in Multiple Availability Zones. For Amazon OpenSearch (or ElasticSearch) Service, we recommend Multiple Availability Zones with minimum 3 Master Nodes.
 

--- a/v1.13.x-SNAPSHOT/deployment/configuration.mdx
+++ b/v1.13.x-SNAPSHOT/deployment/configuration.mdx
@@ -113,7 +113,7 @@ database:
 
 ### PostgreSQL Configuration
 
-OpenMetadata uses stored generated columns which is supported in Postgres 12 and later. Ensure you have Postgres 12 or higher. We recommend you create a Postgres user with a strong password and update this section accordingly.
+OpenMetadata uses stored generated columns which is supported in Postgres 17.6 and later. Ensure you have Postgres 17.6 or higher. We recommend you create a Postgres user with a strong password and update this section accordingly.
 
 | Parameter | Description | Default Value |
 |-----------|-------------|---------------|

--- a/v1.13.x-SNAPSHOT/deployment/docker/advanced.mdx
+++ b/v1.13.x-SNAPSHOT/deployment/docker/advanced.mdx
@@ -55,9 +55,9 @@ If you are running OpenMetadata in AWS, it is recommended to use [Amazon RDS](ht
 
 We support
 
-- Amazon RDS (MySQL) engine version 8 or higher
-- Amazon OpenSearch (ElasticSearch) engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
-- Amazon RDS (PostgreSQL) engine version 12 or higher
+- Amazon RDS for MySQL engine version 8.0.42 or higher
+- Amazon OpenSearch for ElasticSearch engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
+- Amazon RDS for PostgreSQL engine version 17.6 or higher
 
 Note:-
 When using AWS Services the SearchType Configuration for elastic search should be `opensearch`, for both cases ElasticSearch and OpenSearch,

--- a/v1.13.x-SNAPSHOT/deployment/kubernetes/aks.mdx
+++ b/v1.13.x-SNAPSHOT/deployment/kubernetes/aks.mdx
@@ -16,8 +16,8 @@ OpenMetadata can be deployed on Azure Kubernetes Service. This guide covers both
 It is recommended to use [Azure SQL](https://azure.microsoft.com/en-in/products/azure-sql/database) and [Elastic Cloud on Azure](https://www.elastic.co/partners/microsoft-azure) for Production Deployments.
 
 We support:
-- Azure SQL (MySQL) engine version 8 or higher
-- Azure SQL (PostgreSQL) engine version 12 or higher
+- Azure Database for MySQL engine version 8.0.42 or higher
+- Azure Database for PostgreSQL engine version 17.6 or higher
 - Elastic Cloud (ElasticSearch version 9.x, minimum 9.0.0, recommended 9.3.0)
 
 We recommend:

--- a/v1.13.x-SNAPSHOT/deployment/kubernetes/eks.mdx
+++ b/v1.13.x-SNAPSHOT/deployment/kubernetes/eks.mdx
@@ -25,8 +25,8 @@ It is recommended to use [Amazon RDS](https://docs.aws.amazon.com/rds/index.html
 
 We support
 
-- Amazon RDS (MySQL) engine version 8 or higher
-- Amazon RDS (PostgreSQL) engine version 12 or higher
+- Amazon RDS for MySQL engine version 8.0.42 or higher
+- Amazon RDS for PostgreSQL engine version 17.6 or higher
 - Amazon OpenSearch engine version 2.X (upto 2.19)
 
 <Tip>

--- a/v1.13.x-SNAPSHOT/deployment/kubernetes/gke.mdx
+++ b/v1.13.x-SNAPSHOT/deployment/kubernetes/gke.mdx
@@ -32,8 +32,8 @@ All the code snippets in this section assume the `default` namespace for kuberne
 It is recommended to use GCP [Cloud SQL](https://cloud.google.com/sql/) services for Database and [Elastic Cloud GCP](https://www.elastic.co/partners/google-cloud) for Search Engine for Production.
 
 We support -
-- Cloud SQL (MySQL) engine version 8 or higher
-- Cloud SQL (postgreSQL) engine version 12 or higher
+- Cloud Database for MySQL engine version 8.0.42 or higher
+- Cloud Database for PostgreSQL engine version 17.6 or higher
 - ElasticSearch Engine version 8.X (upto 8.10.X)
 
 We recommend -

--- a/v1.13.x-SNAPSHOT/deployment/kubernetes/on-prem.mdx
+++ b/v1.13.x-SNAPSHOT/deployment/kubernetes/on-prem.mdx
@@ -22,8 +22,8 @@ This guide presumes you have an on premises Kubernetes cluster setup, and you ar
 
 We support
 
-- MySQL engine version 8 or higher
-- PostgreSQL engine version 12 or higher
+- MySQL engine version 8.0.42 or higher
+- PostgreSQL engine version 17.6 or higher
 - ElasticSearch version 8.X (upto 8.11.4) or OpenSearch Version 2.X (upto 2.19)
 
 Once you have the External Database and Search Engine configured, you can update the environment variables below for OpenMetadata kubernetes deployments to connect with Database and ElasticSearch.

--- a/v1.13.x-SNAPSHOT/deployment/minimum-requirements.mdx
+++ b/v1.13.x-SNAPSHOT/deployment/minimum-requirements.mdx
@@ -33,7 +33,7 @@ These settings apply as well when using managed instances, such as AWS RDS or GC
 OpenMetadata currently supports -
 
 - MySQL version 8.0.42 or higher
-- PostgreSQL version 12.0 or higher
+- PostgreSQL version 17.6 or higher
 
 ## ElasticSearch or OpenSearch as Search Instance
 


### PR DESCRIPTION
## Summary

Updates the minimum required PostgreSQL version from **12** to **17.6**
across all deployment documentation and the version matrix component.

## Changes

- Updated minimum PostgreSQL version requirement to **17.6 or higher**
  in all deployment guides across `v1.11.x`, `v1.12.x`, and `v1.13.x-SNAPSHOT`
- Updated version matrix component (`versionMatrixData.mdx`) to reflect 17.6
- Fixed a pre-existing typo: `"foor"` → `"for"` in `v1.11.x/deployment/kubernetes/eks.mdx`

## Affected Files (25 total)

| File | Versions |
|------|----------|
| `deployment/bare-metal.mdx` | v1.11.x, v1.12.x, v1.13.x-SNAPSHOT |
| `deployment/configuration.mdx` | v1.11.x, v1.12.x, v1.13.x-SNAPSHOT |
| `deployment/minimum-requirements.mdx` | v1.11.x, v1.12.x, v1.13.x-SNAPSHOT |
| `deployment/docker/advanced.mdx` | v1.11.x, v1.12.x, v1.13.x-SNAPSHOT |
| `deployment/kubernetes/aks.mdx` | v1.11.x, v1.12.x, v1.13.x-SNAPSHOT |
| `deployment/kubernetes/eks.mdx` | v1.11.x, v1.12.x, v1.13.x-SNAPSHOT |
| `deployment/kubernetes/gke.mdx` | v1.11.x, v1.12.x, v1.13.x-SNAPSHOT |
| `deployment/kubernetes/on-prem.mdx` | v1.11.x, v1.12.x, v1.13.x-SNAPSHOT |
| `snippets/components/VersionMatrix/versionMatrixData.mdx` | shared |
