### PR TITLE
Docs: Add queryHistoryTable support to MySQL connector documentation (v1.12.9)

### DIFF
--- a/v1.12.x/connectors/database/mysql/yaml.mdx
+++ b/v1.12.x/connectors/database/mysql/yaml.mdx
@@ -70,6 +70,9 @@ GRANT SELECT ON mysql.general_log TO '<username>'@'<host>';
 SET GLOBAL slow_query_log='ON';
 SET GLOBAL log_output='table';
 GRANT SELECT ON mysql.slow_log TO '<username>'@'<host>';
+
+-- Optional: if using a custom `queryHistoryTable`
+GRANT SELECT ON <custom_db>.<custom_table> TO '<username>'@'<host>';
 ```
 ### 1. Define the YAML Config
 This is a sample config for MySQL Lineage:
@@ -113,6 +116,9 @@ You can find all the definitions and types for the  `sourceConfig` [here](https:
 </Step>
 <Step title="processStoredProcedureLineage">
 **processStoredProcedureLineage**: Set the 'Process Stored ProcedureLog Lineage' toggle to control whether to process stored procedure lineage.
+</Step>
+<Step title="queryHistoryTable">
+**queryHistoryTable**: Optional. Specify a custom table to use as the query history source for usage and lineage extraction (e.g. `audit_db.my_query_log`). When set, this replaces the default `mysql.general_log` (or `mysql.slow_log` when `useSlowLogs: true`). The custom table must expose compatible columns. The connection user needs `SELECT` on this table.
 </Step>
 <Step title="threads">
 **threads**: Number of Threads to use in order to parallelize lineage ingestion.
@@ -318,6 +324,7 @@ source:
       databaseSchema: schema  # Optional: restrict to single schema
       databaseName: database_name  # Optional: custom name in OpenMetadata
       useSlowLogs: false  # Optional: use slow logs for lineage (default: false)
+      # queryHistoryTable: audit_db.my_query_log  # Optional: custom query history table
       # connectionOptions:
       #   key: value
       # connectionArguments:

--- a/v1.12.x/connectors/database/mysql/yaml.mdx
+++ b/v1.12.x/connectors/database/mysql/yaml.mdx
@@ -117,9 +117,6 @@ You can find all the definitions and types for the  `sourceConfig` [here](https:
 <Step title="processStoredProcedureLineage">
 **processStoredProcedureLineage**: Set the 'Process Stored ProcedureLog Lineage' toggle to control whether to process stored procedure lineage.
 </Step>
-<Step title="queryHistoryTable">
-**queryHistoryTable**: Optional. Specify a custom table to use as the query history source for usage and lineage extraction (e.g. `audit_db.my_query_log`). When set, this replaces the default `mysql.general_log` (or `mysql.slow_log` when `useSlowLogs: true`). The custom table must expose columns compatible with the chosen log format — `argument` and `event_time` when `useSlowLogs: false` (general log schema), or `sql_text` and `start_time` when `useSlowLogs: true` (slow log schema). The connection user needs `SELECT` on this table. This table is also used by the test connection probe when verifying connectivity.
-</Step>
 <Step title="threads">
 **threads**: Number of Threads to use in order to parallelize lineage ingestion.
 </Step>
@@ -271,7 +268,7 @@ Find more information about [Source Identity](https://docs.aws.amazon.com/STS/la
 
 The custom table must expose columns compatible with the selected log format:
 
-- **General log**: `argument`, `event_time`
+- **General log**: `argument`, `event_time`, `command_type`
 - **Slow log**: `sql_text`, `start_time`
 
 The connection user requires `SELECT` on this table.

--- a/v1.12.x/connectors/database/mysql/yaml.mdx
+++ b/v1.12.x/connectors/database/mysql/yaml.mdx
@@ -71,7 +71,7 @@ SET GLOBAL slow_query_log='ON';
 SET GLOBAL log_output='table';
 GRANT SELECT ON mysql.slow_log TO '<username>'@'<host>';
 
--- Optional: if using a custom `queryHistoryTable`
+-- Optional: if using a custom `queryHistoryTable` (e.g. audit_db.my_query_log)
 GRANT SELECT ON <custom_db>.<custom_table> TO '<username>'@'<host>';
 ```
 ### 1. Define the YAML Config
@@ -118,7 +118,7 @@ You can find all the definitions and types for the  `sourceConfig` [here](https:
 **processStoredProcedureLineage**: Set the 'Process Stored ProcedureLog Lineage' toggle to control whether to process stored procedure lineage.
 </Step>
 <Step title="queryHistoryTable">
-**queryHistoryTable**: Optional. Specify a custom table to use as the query history source for usage and lineage extraction (e.g. `audit_db.my_query_log`). When set, this replaces the default `mysql.general_log` (or `mysql.slow_log` when `useSlowLogs: true`). The custom table must expose compatible columns. The connection user needs `SELECT` on this table.
+**queryHistoryTable**: Optional. Specify a custom table to use as the query history source for usage and lineage extraction (e.g. `audit_db.my_query_log`). When set, this replaces the default `mysql.general_log` (or `mysql.slow_log` when `useSlowLogs: true`). The custom table must expose columns compatible with the chosen log format — `argument` and `event_time` when `useSlowLogs: false` (general log schema), or `sql_text` and `start_time` when `useSlowLogs: true` (slow log schema). The connection user needs `SELECT` on this table. This table is also used by the test connection probe when verifying connectivity.
 </Step>
 <Step title="threads">
 **threads**: Number of Threads to use in order to parallelize lineage ingestion.
@@ -239,13 +239,11 @@ Find more information about [Source Identity](https://docs.aws.amazon.com/STS/la
 
 <ContentSection id={5} title="Azure Auth" lines="15-20">
 
-#### Azure Auth
+- **scopes**: Required. Provide the scope or comma-separated scopes used to fetch the Azure access token, for example `https://ossrdbms-aad.database.windows.net/.default`.
 
-**scopes**: Required. Provide the scope or comma-separated scopes used to fetch the Azure access token, for example `https://ossrdbms-aad.database.windows.net/.default`.
+- **clientId**, **clientSecret**, and **tenantId**: Optional when using a service principal. If omitted, OpenMetadata falls back to `DefaultAzureCredential` from the runtime environment.
 
-**clientId**, **clientSecret**, and **tenantId**: Optional when using a service principal. If omitted, OpenMetadata falls back to `DefaultAzureCredential` from the runtime environment.
-
-**accountName** and **vaultName**: Part of the shared Azure credentials schema, but not required for MySQL token-based authentication.
+- **accountName** and **vaultName**: Part of the shared Azure credentials schema, but not required for MySQL token-based authentication.
 
 </ContentSection>
 
@@ -261,7 +259,26 @@ Find more information about [Source Identity](https://docs.aws.amazon.com/STS/la
 
 </ContentSection>
 
-<ContentSection id={8} title="Connection Options" lines="25-26">
+<ContentSection id={7.1} title="useSlowLogs" lines="24">
+
+**useSlowLogs**: When set to `true`, OpenMetadata reads query history from `mysql.slow_log` instead of the default `mysql.general_log`. Requires slow query logging to be enabled on the MySQL server (`SET GLOBAL slow_query_log='ON'`).
+
+</ContentSection>
+
+<ContentSection id={7.2} title="queryHistoryTable" lines="25">
+
+**queryHistoryTable**: Optional. Specify a fully qualified custom table (`<db>.<table>`) to use as the query history source for usage and lineage extraction. If set, this replaces the default `mysql.general_log` (or `mysql.slow_log` when `useSlowLogs: true`).<br/><br/>
+
+The custom table must expose columns compatible with the selected log format:
+
+- **General log**: `argument`, `event_time`
+- **Slow log**: `sql_text`, `start_time`
+
+The connection user requires `SELECT` on this table.
+
+</ContentSection>
+
+<ContentSection id={8} title="Connection Options" lines="26-27">
 
 #### Advanced Configuration
 
@@ -269,7 +286,7 @@ Find more information about [Source Identity](https://docs.aws.amazon.com/STS/la
 
 </ContentSection>
 
-<ContentSection id={9} title="Connection Arguments" lines="27-28">
+<ContentSection id={9} title="Connection Arguments" lines="28-29">
 
 **Connection Arguments (Optional)**: Enter the details for any additional connection arguments such as security or protocol configs that can be sent to database during the connection. These details must be added as Key-Value pairs.
 
@@ -277,19 +294,19 @@ Find more information about [Source Identity](https://docs.aws.amazon.com/STS/la
 
 </ContentSection>
 
-<ContentSection id={10} title="Source Config" lines="29-72">
+<ContentSection id={10} title="Source Config" lines="30-73">
 
 <SourceConfigDef />
 
 </ContentSection>
 
-<ContentSection id={11} title="Sink Configuration" lines="73-75">
+<ContentSection id={11} title="Sink Configuration" lines="74-76">
 
 <IngestionSinkDef />
 
 </ContentSection>
 
-<ContentSection id={12} title="Workflow Configuration" lines="76-92">
+<ContentSection id={12} title="Workflow Configuration" lines="77-93">
 
 <WorkflowConfigDef />
 

--- a/v1.13.x-SNAPSHOT/connectors/database/mysql/yaml.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/database/mysql/yaml.mdx
@@ -70,6 +70,9 @@ GRANT SELECT ON mysql.general_log TO '<username>'@'<host>';
 SET GLOBAL slow_query_log='ON';
 SET GLOBAL log_output='table';
 GRANT SELECT ON mysql.slow_log TO '<username>'@'<host>';
+
+-- Optional: if using a custom `queryHistoryTable`
+GRANT SELECT ON <custom_db>.<custom_table> TO '<username>'@'<host>';
 ```
 ### 1. Define the YAML Config
 This is a sample config for MySQL Lineage:
@@ -113,6 +116,9 @@ You can find all the definitions and types for the  `sourceConfig` [here](https:
 </Step>
 <Step title="processStoredProcedureLineage">
 **processStoredProcedureLineage**: Set the 'Process Stored ProcedureLog Lineage' toggle to control whether to process stored procedure lineage.
+</Step>
+<Step title="queryHistoryTable">
+**queryHistoryTable**: Optional. Specify a custom table to use as the query history source for usage and lineage extraction (e.g. `audit_db.my_query_log`). When set, this replaces the default `mysql.general_log` (or `mysql.slow_log` when `useSlowLogs: true`). The custom table must expose compatible columns. The connection user needs `SELECT` on this table.
 </Step>
 <Step title="threads">
 **threads**: Number of Threads to use in order to parallelize lineage ingestion.
@@ -318,6 +324,7 @@ source:
       databaseSchema: schema  # Optional: restrict to single schema
       databaseName: database_name  # Optional: custom name in OpenMetadata
       useSlowLogs: false  # Optional: use slow logs for lineage (default: false)
+      # queryHistoryTable: audit_db.my_query_log  # Optional: custom query history table
       # connectionOptions:
       #   key: value
       # connectionArguments:

--- a/v1.13.x-SNAPSHOT/connectors/database/mysql/yaml.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/database/mysql/yaml.mdx
@@ -117,9 +117,6 @@ You can find all the definitions and types for the  `sourceConfig` [here](https:
 <Step title="processStoredProcedureLineage">
 **processStoredProcedureLineage**: Set the 'Process Stored ProcedureLog Lineage' toggle to control whether to process stored procedure lineage.
 </Step>
-<Step title="queryHistoryTable">
-**queryHistoryTable**: Optional. Specify a custom table to use as the query history source for usage and lineage extraction (e.g. `audit_db.my_query_log`). When set, this replaces the default `mysql.general_log` (or `mysql.slow_log` when `useSlowLogs: true`). The custom table must expose columns compatible with the chosen log format — `argument` and `event_time` when `useSlowLogs: false` (general log schema), or `sql_text` and `start_time` when `useSlowLogs: true` (slow log schema). The connection user needs `SELECT` on this table. This table is also used by the test connection probe when verifying connectivity.
-</Step>
 <Step title="threads">
 **threads**: Number of Threads to use in order to parallelize lineage ingestion.
 </Step>
@@ -271,7 +268,7 @@ Find more information about [Source Identity](https://docs.aws.amazon.com/STS/la
 
 The custom table must expose columns compatible with the selected log format:
 
-- **General log**: `argument`, `event_time`
+- **General log**: `argument`, `event_time`, `command_type`
 - **Slow log**: `sql_text`, `start_time`
 
 The connection user requires `SELECT` on this table.

--- a/v1.13.x-SNAPSHOT/connectors/database/mysql/yaml.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/database/mysql/yaml.mdx
@@ -71,7 +71,7 @@ SET GLOBAL slow_query_log='ON';
 SET GLOBAL log_output='table';
 GRANT SELECT ON mysql.slow_log TO '<username>'@'<host>';
 
--- Optional: if using a custom `queryHistoryTable`
+-- Optional: if using a custom `queryHistoryTable` (e.g. audit_db.my_query_log)
 GRANT SELECT ON <custom_db>.<custom_table> TO '<username>'@'<host>';
 ```
 ### 1. Define the YAML Config
@@ -118,7 +118,7 @@ You can find all the definitions and types for the  `sourceConfig` [here](https:
 **processStoredProcedureLineage**: Set the 'Process Stored ProcedureLog Lineage' toggle to control whether to process stored procedure lineage.
 </Step>
 <Step title="queryHistoryTable">
-**queryHistoryTable**: Optional. Specify a custom table to use as the query history source for usage and lineage extraction (e.g. `audit_db.my_query_log`). When set, this replaces the default `mysql.general_log` (or `mysql.slow_log` when `useSlowLogs: true`). The custom table must expose compatible columns. The connection user needs `SELECT` on this table.
+**queryHistoryTable**: Optional. Specify a custom table to use as the query history source for usage and lineage extraction (e.g. `audit_db.my_query_log`). When set, this replaces the default `mysql.general_log` (or `mysql.slow_log` when `useSlowLogs: true`). The custom table must expose columns compatible with the chosen log format — `argument` and `event_time` when `useSlowLogs: false` (general log schema), or `sql_text` and `start_time` when `useSlowLogs: true` (slow log schema). The connection user needs `SELECT` on this table. This table is also used by the test connection probe when verifying connectivity.
 </Step>
 <Step title="threads">
 **threads**: Number of Threads to use in order to parallelize lineage ingestion.
@@ -239,13 +239,11 @@ Find more information about [Source Identity](https://docs.aws.amazon.com/STS/la
 
 <ContentSection id={5} title="Azure Auth" lines="15-20">
 
-#### Azure Auth
+- **scopes**: Required. Provide the scope or comma-separated scopes used to fetch the Azure access token, for example `https://ossrdbms-aad.database.windows.net/.default`.
 
-**scopes**: Required. Provide the scope or comma-separated scopes used to fetch the Azure access token, for example `https://ossrdbms-aad.database.windows.net/.default`.
+- **clientId**, **clientSecret**, and **tenantId**: Optional when using a service principal. If omitted, OpenMetadata falls back to `DefaultAzureCredential` from the runtime environment.
 
-**clientId**, **clientSecret**, and **tenantId**: Optional when using a service principal. If omitted, OpenMetadata falls back to `DefaultAzureCredential` from the runtime environment.
-
-**accountName** and **vaultName**: Part of the shared Azure credentials schema, but not required for MySQL token-based authentication.
+- **accountName** and **vaultName**: Part of the shared Azure credentials schema, but not required for MySQL token-based authentication.
 
 </ContentSection>
 
@@ -261,7 +259,26 @@ Find more information about [Source Identity](https://docs.aws.amazon.com/STS/la
 
 </ContentSection>
 
-<ContentSection id={8} title="Connection Options" lines="25-26">
+<ContentSection id={7.1} title="useSlowLogs" lines="24">
+
+**useSlowLogs**: When set to `true`, OpenMetadata reads query history from `mysql.slow_log` instead of the default `mysql.general_log`. Requires slow query logging to be enabled on the MySQL server (`SET GLOBAL slow_query_log='ON'`).
+
+</ContentSection>
+
+<ContentSection id={7.2} title="queryHistoryTable" lines="25">
+
+**queryHistoryTable**: Optional. Specify a fully qualified custom table (`<db>.<table>`) to use as the query history source for usage and lineage extraction. If set, this replaces the default `mysql.general_log` (or `mysql.slow_log` when `useSlowLogs: true`).<br/><br/>
+
+The custom table must expose columns compatible with the selected log format:
+
+- **General log**: `argument`, `event_time`
+- **Slow log**: `sql_text`, `start_time`
+
+The connection user requires `SELECT` on this table.
+
+</ContentSection>
+
+<ContentSection id={8} title="Connection Options" lines="26-27">
 
 #### Advanced Configuration
 
@@ -269,7 +286,7 @@ Find more information about [Source Identity](https://docs.aws.amazon.com/STS/la
 
 </ContentSection>
 
-<ContentSection id={9} title="Connection Arguments" lines="27-28">
+<ContentSection id={9} title="Connection Arguments" lines="28-29">
 
 **Connection Arguments (Optional)**: Enter the details for any additional connection arguments such as security or protocol configs that can be sent to database during the connection. These details must be added as Key-Value pairs.
 
@@ -277,19 +294,19 @@ Find more information about [Source Identity](https://docs.aws.amazon.com/STS/la
 
 </ContentSection>
 
-<ContentSection id={10} title="Source Config" lines="29-72">
+<ContentSection id={10} title="Source Config" lines="30-73">
 
 <SourceConfigDef />
 
 </ContentSection>
 
-<ContentSection id={11} title="Sink Configuration" lines="73-75">
+<ContentSection id={11} title="Sink Configuration" lines="74-76">
 
 <IngestionSinkDef />
 
 </ContentSection>
 
-<ContentSection id={12} title="Workflow Configuration" lines="76-92">
+<ContentSection id={12} title="Workflow Configuration" lines="77-93">
 
 <WorkflowConfigDef />
 


### PR DESCRIPTION
## Summary

Documents the new `queryHistoryTable` configuration option introduced in the MySQL connector in OpenMetadata 1.12.9
([open-metadata/OpenMetadata#28260](https://github.com/open-metadata/OpenMetadata/pull/28260)).

This option allows users to configure a custom table as the query history source for usage and lineage extraction, replacing the default `mysql.general_log` or `mysql.slow_log`.

## Changes

### New configuration option — `queryHistoryTable`

Added documentation for the `queryHistoryTable` field across both `v1.12.x` and `v1.13.x-SNAPSHOT`:

- **Permissions** — Added the required `GRANT SELECT` statement for the custom   table in the Lineage & Usage requirements block
- **Config step** — Added a new `<Step>` in the Lineage YAML config section describing the field, its effect on `useSlowLogs` behavior, required column compatibility, and its use by the test connection probe
- **YAML example** — Added a commented-out example (`queryHistoryTable: audit_db.my_query_log`) in the service connection config block
- **Interactive panel** — Added `<ContentSection>` entries for both `useSlowLogs` and `queryHistoryTable` in the CodePreview panel, with corrected line references for all downstream sections
<img width="2940" height="1704" alt="image" src="https://github.com/user-attachments/assets/854b8e9a-b9ce-4203-8a25-f0c41e88478d" />

## Affected Files

| File | Versions |
|------|----------|
| `connectors/database/mysql/yaml.mdx` | v1.12.x, v1.13.x-SNAPSHOT |

## Related

- OpenMetadata PR: [feat(mysql): support custom queryHistoryTable for usage & lineage #28260](https://github.com/open-metadata/OpenMetadata/pull/28260)
- Fixes: [#28089](https://github.com/open-metadata/OpenMetadata/issues/28089)
