### PR TITLE
Docs: Document governance workflow triggers for Data Product fields in v1.12.x and v1.13.x

### DIFF
--- a/v1.12.x/how-to-guides/data-governance/domains-&-data-products/data-products.mdx
+++ b/v1.12.x/how-to-guides/data-governance/domains-&-data-products/data-products.mdx
@@ -32,6 +32,17 @@ This guide will walk you through the steps to add and configure a Data Product i
 
 By following these steps, you can effectively set up and manage data products in Open Metadata, ensuring a well-organized and efficient data architecture.
 
+<Tip>
+**Governance Workflow Triggers for Data Products**
+
+As of 1.12.9, changes to the following Data Product fields now correctly trigger configured governance approval workflows:
+- **Input Ports** — adding or removing assets as input ports
+- **Output Ports** — adding or removing assets as output ports
+- **Glossary Terms** — assigning or removing glossary terms
+
+Previously, these field changes were silently ignored by the event filter and did not fire approval workflows. If you have governance workflows configured to watch Data Product changes, they will now trigger on port and glossary term updates.
+</Tip>
+
 <video
   autoPlay
   muted

--- a/v1.12.x/how-to-guides/data-governance/domains-&-data-products/data-products.mdx
+++ b/v1.12.x/how-to-guides/data-governance/domains-&-data-products/data-products.mdx
@@ -1,12 +1,12 @@
 ---
-title:  How to Use Data Products | Official Documentation
+title: How to Use Data Products
 description: Define and manage data products as part of your governance strategy to track ownership, value, and metadata lineage efficiently.
 sidebarTitle: How to Use Data Products
 ---
 
-# How to Guide to Adding Data Products in Open Metadata
+# How to Add Data Products in OpenMetadata
 
-This guide will walk you through the steps to add and configure a Data Product in Open Metadata. Follow these steps to effectively organize your data assets into data products.
+This guide will walk you through the steps to add and configure a Data Product in OpenMetadata. Follow these steps to effectively organize your data assets into data products.
 
 ## Step 1: Provide a Name & Display Name for the Data Product
 
@@ -30,17 +30,17 @@ This guide will walk you through the steps to add and configure a Data Product i
 
 - **Explore Page**: Use the Explore page to view and filter the data assets added to different data products. This helps in easily locating and accessing data assets within specific data products.
 
-By following these steps, you can effectively set up and manage data products in Open Metadata, ensuring a well-organized and efficient data architecture.
+By following these steps, you can effectively set up and manage data products in OpenMetadata, ensuring a well-organized and efficient data architecture.
 
 <Tip>
 **Governance Workflow Triggers for Data Products**
 
-As of 1.12.9, changes to the following Data Product fields now correctly trigger configured governance approval workflows:
+Changes to the following Data Product fields trigger configured governance approval workflows:
 - **Input Ports** — adding or removing assets as input ports
 - **Output Ports** — adding or removing assets as output ports
 - **Glossary Terms** — assigning or removing glossary terms
 
-Previously, these field changes were silently ignored by the event filter and did not fire approval workflows. If you have governance workflows configured to watch Data Product changes, they will now trigger on port and glossary term updates.
+If you have governance workflows configured to watch Data Product changes, they will trigger on port and glossary term updates.
 </Tip>
 
 <video
@@ -53,7 +53,7 @@ Previously, these field changes were silently ignored by the event filter and di
 ></video>
 
 <CardGroup cols={1}>
-<Card title="How to Use Domains" href="/v1.12.x/how-to-guides/data-governance/domains-&-data-products/domains" >
-    Learn about the Domains.
-  </Card>
+<Card title="How to Use Domains" href="/v1.12.x/how-to-guides/data-governance/domains-&-data-products/domains">
+  Learn about Domains.
+</Card>
 </CardGroup>

--- a/v1.13.x-SNAPSHOT/how-to-guides/data-governance/domains-&-data-products/data-products.mdx
+++ b/v1.13.x-SNAPSHOT/how-to-guides/data-governance/domains-&-data-products/data-products.mdx
@@ -1,12 +1,12 @@
 ---
-title:  How to Use Data Products | Official Documentation
+title: How to Use Data Products
 description: Define and manage data products as part of your governance strategy to track ownership, value, and metadata lineage efficiently.
 sidebarTitle: How to Use Data Products
 ---
 
-# How to Guide to Adding Data Products in Open Metadata
+# How to Add Data Products in OpenMetadata
 
-This guide will walk you through the steps to add and configure a Data Product in Open Metadata. Follow these steps to effectively organize your data assets into data products.
+This guide will walk you through the steps to add and configure a Data Product in OpenMetadata. Follow these steps to effectively organize your data assets into data products.
 
 ## Step 1: Provide a Name & Display Name for the Data Product
 
@@ -30,17 +30,17 @@ This guide will walk you through the steps to add and configure a Data Product i
 
 - **Explore Page**: Use the Explore page to view and filter the data assets added to different data products. This helps in easily locating and accessing data assets within specific data products.
 
-By following these steps, you can effectively set up and manage data products in Open Metadata, ensuring a well-organized and efficient data architecture.
+By following these steps, you can effectively set up and manage data products in OpenMetadata, ensuring a well-organized and efficient data architecture.
 
 <Tip>
 **Governance Workflow Triggers for Data Products**
 
-As of 1.12.9, changes to the following Data Product fields now correctly trigger configured governance approval workflows:
+Changes to the following Data Product fields trigger configured governance approval workflows:
 - **Input Ports** — adding or removing assets as input ports
 - **Output Ports** — adding or removing assets as output ports
 - **Glossary Terms** — assigning or removing glossary terms
 
-Previously, these field changes were silently ignored by the event filter and did not fire approval workflows. If you have governance workflows configured to watch Data Product changes, they will now trigger on port and glossary term updates.
+If you have governance workflows configured to watch Data Product changes, they will trigger on port and glossary term updates.
 </Tip>
 
 <video
@@ -53,7 +53,7 @@ Previously, these field changes were silently ignored by the event filter and di
 ></video>
 
 <CardGroup cols={1}>
-<Card title="How to Use Domains" href="/v1.13.x-SNAPSHOT/how-to-guides/data-governance/domains-&-data-products/domains" >
-    Learn about the Domains.
-  </Card>
+<Card title="How to Use Domains" href="/v1.13.x-SNAPSHOT/how-to-guides/data-governance/domains-&-data-products/domains">
+  Learn about Domains.
+</Card>
 </CardGroup>

--- a/v1.13.x-SNAPSHOT/how-to-guides/data-governance/domains-&-data-products/data-products.mdx
+++ b/v1.13.x-SNAPSHOT/how-to-guides/data-governance/domains-&-data-products/data-products.mdx
@@ -32,6 +32,17 @@ This guide will walk you through the steps to add and configure a Data Product i
 
 By following these steps, you can effectively set up and manage data products in Open Metadata, ensuring a well-organized and efficient data architecture.
 
+<Tip>
+**Governance Workflow Triggers for Data Products**
+
+As of 1.12.9, changes to the following Data Product fields now correctly trigger configured governance approval workflows:
+- **Input Ports** — adding or removing assets as input ports
+- **Output Ports** — adding or removing assets as output ports
+- **Glossary Terms** — assigning or removing glossary terms
+
+Previously, these field changes were silently ignored by the event filter and did not fire approval workflows. If you have governance workflows configured to watch Data Product changes, they will now trigger on port and glossary term updates.
+</Tip>
+
 <video
   autoPlay
   muted


### PR DESCRIPTION
## Summary

Documents the governance workflow trigger fix for Data Product fields introduced in 1.12.9, and cleans up pre-existing errors in the Data Products how-to guide.

- Adds a `<Tip>` block noting that changes to **Input Ports**, **Output Ports**, and **Glossary Terms** now correctly trigger configured governance approval workflows
<img width="2946" height="1384" alt="image" src="https://github.com/user-attachments/assets/9f8d20c8-e40b-4aec-a2f3-72c1fd40fc36" />

Applied to both `v1.12.x` and `v1.13.x-SNAPSHOT`.

## Test plan

- [ ] Preview renders correctly on `mint dev`
- [ ] No broken links (`mint broken-links`)
