### PR TITLE
chore(release): Update release notes for v1.12.10

### DIFF
--- a/snippets/releases/1.12.9.mdx
+++ b/snippets/releases/1.12.9.mdx
@@ -1,0 +1,89 @@
+<Update label="1.12.9 Release - Archived" description="28th May 2026">
+
+You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.9-release).
+
+## Changelog
+
+OpenMetadata 1.12.9 is a maintenance release delivering new connector capabilities, performance improvements for workflow execution, and targeted bug fixes across search, ingestion, UI, and the OpenMetadata Python client.
+
+### ✨ New Features
+
+- **Unity Catalog — incremental metadata extraction** [#28380](https://github.com/open-metadata/OpenMetadata/pull/28380): Unity Catalog connector now detects changed tables via `information_schema.tables.last_altered` and only re-ingests modified entities. Delete detection uses exact catalog matching (preventing wildcard misfires on catalog names containing underscores). Catalog names are validated against an allowlist before SQL interpolation.
+- **Task domains backfilled + stamped on approval** [#28402](https://github.com/open-metadata/OpenMetadata/pull/28402): Approval task threads now inherit the domain of the entity being approved, and a migration backfills domains on existing tasks.
+- **Workflow entity extended fields** [#28398](https://github.com/open-metadata/OpenMetadata/pull/28398): `Workflow` entities now support `inputPorts`, `outputPorts`, and `glossaryTerms` fields, bringing them to parity with pipeline and data-flow entities.
+- **MySQL — custom `queryHistoryTable`** [#28388](https://github.com/open-metadata/OpenMetadata/pull/28388): MySQL connector accepts a configurable `queryHistoryTable` for usage and lineage extraction, enabling use-cases where query history is stored in a non-default location.
+
+### 🔒 Security
+
+- **Test-connection workflow authorization** [#28414](https://github.com/open-metadata/OpenMetadata/pull/28414): Test-connection workflow triggers now require proper authorization, closing an unauthenticated execution path.
+- **Snyk high/critical dependency patches in ingestion** [#28340](https://github.com/open-metadata/OpenMetadata/pull/28340): High and critical Snyk findings patched in ingestion dependencies and code paths.
+- **`brace-expansion` lockfile bump to 5.0.6** [#28244](https://github.com/open-metadata/OpenMetadata/pull/28244): Resolves a ReDoS advisory in the transitive `brace-expansion` package.
+- **`js-cookie` bumped** [#28315](https://github.com/open-metadata/OpenMetadata/pull/28315): Frontend dependency bumped to address a Dependabot advisory.
+- **WebSocket Dependabot vulnerability in UI** [#28320](https://github.com/open-metadata/OpenMetadata/pull/28320): Dependency update for a reported WebSocket vulnerability in the UI bundle.
+
+### 🎨 UI Changes
+
+**Improvements**
+
+- **Data Quality — column selection dropdowns are searchable** [#28376](https://github.com/open-metadata/OpenMetadata/pull/28376): Column selectors in test case forms now include a search box, making it practical to navigate wide tables.
+
+**Fixes**
+
+- **Notification links — plural alerts path and Query href** [#27918](https://github.com/open-metadata/OpenMetadata/pull/27918): Notification alert links now route to the correct plural `/alerts` path; Query entity hrefs in notifications are also corrected.
+- **Data Asset Header — permission fix** [#27967](https://github.com/open-metadata/OpenMetadata/pull/27967): Resolved a permission check issue in the Data Asset Header component that prevented certain actions for non-admin users.
+- **Bot name search on Bots page** [#27365](https://github.com/open-metadata/OpenMetadata/pull/27365): Fixed search not returning results when searching for bots by name on the Bots management page.
+- **Column bulk-ops filters use `displayName`** [#28390](https://github.com/open-metadata/OpenMetadata/pull/28390): Service, database, and schema filter dropdowns in the column bulk-operations flow now display `displayName` instead of raw FQN fragments.
+- **Bulk-asset operations enforce `dryRun`** [#28395](https://github.com/open-metadata/OpenMetadata/pull/28395): Tag, glossary, and data-product bulk operations now correctly honour the `dryRun` flag, preventing accidental mutations during preview runs.
+- **Table / dataModel — inline `column.extension` persisted** [#28392](https://github.com/open-metadata/OpenMetadata/pull/28392): Custom extension data attached inline to columns is now saved correctly through `POST`/`PUT` calls.
+- **ServicesPage tab accepts `ServiceCategory` enum values** [#28375](https://github.com/open-metadata/OpenMetadata/pull/28375): The `:tab` route parameter now accepts both the label string and the raw `ServiceCategory` enum value, fixing deep-links that used enum values.
+- **Unknown service category returns 404** [#28372](https://github.com/open-metadata/OpenMetadata/pull/28372): Navigating to an unrecognised service category now returns a proper 404 page instead of an empty fallback.
+- **KPI widget date format** [#28370](https://github.com/open-metadata/OpenMetadata/pull/28370): Added missing space between day and month values in the KPI widget's X-axis date labels.
+- **Bug fix (#27433)** [#28266](https://github.com/open-metadata/OpenMetadata/pull/28266): Backported fix for entity display regression.
+
+### 🔌 Connectors
+
+**Databases**
+
+- **Databricks / Unity Catalog — valueless tags ingested** [#28294](https://github.com/open-metadata/OpenMetadata/pull/28294): Tags set without an explicit value (valueless) are now ingested correctly from Databricks and Unity Catalog sources.
+- **Snowflake — discovered databases logged with filter reasons** [#28385](https://github.com/open-metadata/OpenMetadata/pull/28385): During schema discovery the Snowflake connector now logs each discovered database alongside the reason when it is filtered out, improving debuggability.
+
+**Pipelines / Dashboards**
+
+- **Bulk sink — charts and dataModels created before dashboards** [#28371](https://github.com/open-metadata/OpenMetadata/pull/28371): Fixed a bulk sink ordering bug where a Dashboard entity could be flushed before its referenced Charts or DashboardDataModels, causing HTTP 400 rejections from the server. Each topology stage now encodes its position so referenced entities are always created first.
+- **Power BI — sink buffer flushed before lineage resolution** [#28308](https://github.com/open-metadata/OpenMetadata/pull/28308): Ensures all Power BI entities are persisted before lineage resolution begins, preventing reference errors during lineage extraction.
+- **Power BI — TSQL dialect for `Sql.Database` M-query lineage** [#28380](https://github.com/open-metadata/OpenMetadata/pull/28380): The Power BI connector now parses `Sql.Database` M-query expressions using the TSQL dialect, fixing lineage extraction failures on SQL Server-backed datasets.
+
+**OpenLineage**
+
+- **Resolve table identity from `symlinks` facet** [#28360](https://github.com/open-metadata/OpenMetadata/pull/28360): OpenLineage events that include a `symlinks` facet now resolve the true table identity from the symlink, fixing entity matching for Hive/Iceberg tables exposed under alternate names.
+- **Pipeline as node for single-sided lineage** [#28350](https://github.com/open-metadata/OpenMetadata/pull/28350): OpenLineage pipelines can now appear as a standalone node in the lineage graph when only one side (input or output) is present, instead of being dropped.
+
+**Ingestion Runtime**
+
+- **Kubernetes client capped below 36.0.0** [#28331](https://github.com/open-metadata/OpenMetadata/pull/28331): Pins the Kubernetes Python client to `<36.0.0` to avoid a breaking API change introduced in that release.
+- **Ingestion-pipeline status preserved during queued-stage failures** [#28382](https://github.com/open-metadata/OpenMetadata/pull/28382): When a queued-stage task fails, the overall pipeline status remains accurate instead of being overwritten with a misleading value.
+
+### 🛠 API (Backend)
+
+**Improvements**
+
+- **Workflow field fetches scoped** [#28391](https://github.com/open-metadata/OpenMetadata/pull/28391): Wildcard field fetches in workflow-related queries replaced with scoped field requests, reducing payload size and improving performance.
+- **Data Insights enricher — per-step failure isolation** [#28379](https://github.com/open-metadata/OpenMetadata/pull/28379): Enricher step failures are now isolated per-step with individual error tracking, preventing one bad enricher from aborting the entire Data Insights run.
+
+**Fixes**
+
+- **Search `search_after` with special characters in sort values** [#28386](https://github.com/open-metadata/OpenMetadata/pull/28386): `search_after` pagination no longer drops entities whose sort-field value contains special characters.
+- **Search — nested children flattened to avoid ES mapping depth limit** [#28387](https://github.com/open-metadata/OpenMetadata/pull/28387): Deeply nested `children` fields are now flattened before indexing to prevent Elasticsearch/OpenSearch from rejecting documents that exceed the default mapping depth limit.
+- **Table certification cascaded to child search documents** [#28229](https://github.com/open-metadata/OpenMetadata/pull/28229): A `PATCH` to a Table's certification tag is now propagated to all child search documents, keeping certification state consistent across the search index.
+- **Search-index reindex jobs no longer marked failed on clean completion** [#28381](https://github.com/open-metadata/OpenMetadata/pull/28381): Fixed a status-tracking bug that incorrectly recorded clean reindex jobs as failed in the job history.
+- **PDTS duplicate preemption and invalid index-mapping recovery** [#28373](https://github.com/open-metadata/OpenMetadata/pull/28373): Migration now preempts duplicate PDTS (Profiler Data Time Series) rows and recovers from invalid search index mappings rather than failing.
+- **MCP — `search_metadata` response capped** [#28383](https://github.com/open-metadata/OpenMetadata/pull/28383): The MCP `search_metadata` tool response is now capped in size to prevent LLM context overflow when the result set is large.
+- **Alert filter functions use strict literal matching** [#28393](https://github.com/open-metadata/OpenMetadata/pull/28393): Alert filter expressions now perform strict literal matching instead of substring matching, preventing false-positive alert triggers.
+- **Test case suite search membership preserved** [#28271](https://github.com/open-metadata/OpenMetadata/pull/28271): Test cases now retain their suite membership in the search index after updates, fixing a regression where suites lost members after re-ingestion.
+- **OMeta SSE transport switched to `requests`** [#28293](https://github.com/open-metadata/OpenMetadata/pull/28293): The OpenMetadata Python client now uses `requests` instead of `httpx` for SSE (Server-Sent Events) transport, resolving compatibility issues in certain deployment environments.
+- **OMeta — resilient transport with keepalive and retry** [#28389](https://github.com/open-metadata/OpenMetadata/pull/28389): The OMeta REST transport now uses keepalive connections and automatic retries on transient failures with a typed `RestTransport` abstraction.
+- **Shutdown logging captures full streamable log tail** [#28396](https://github.com/open-metadata/OpenMetadata/pull/28396): Synchronous shutdown now waits for in-flight streamable log writes to complete, preventing log truncation on graceful shutdown.
+
+**Full Changelog**: [link](https://github.com/open-metadata/OpenMetadata/compare/1.12.8-release...1.12.9-release)
+
+</Update>

--- a/snippets/releases/latest.mdx
+++ b/snippets/releases/latest.mdx
@@ -1,89 +1,63 @@
-<Update label="1.12.9 Release" description="28th May 2026">
+<Update label="1.12.10 Release" description="2nd June 2026">
 
-You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.9-release).
+You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.10-release).
 
 ## Changelog
 
-OpenMetadata 1.12.9 is a maintenance release delivering new connector capabilities, performance improvements for workflow execution, and targeted bug fixes across search, ingestion, UI, and the OpenMetadata Python client.
-
-### ✨ New Features
-
-- **Unity Catalog — incremental metadata extraction** [#28380](https://github.com/open-metadata/OpenMetadata/pull/28380): Unity Catalog connector now detects changed tables via `information_schema.tables.last_altered` and only re-ingests modified entities. Delete detection uses exact catalog matching (preventing wildcard misfires on catalog names containing underscores). Catalog names are validated against an allowlist before SQL interpolation.
-- **Task domains backfilled + stamped on approval** [#28402](https://github.com/open-metadata/OpenMetadata/pull/28402): Approval task threads now inherit the domain of the entity being approved, and a migration backfills domains on existing tasks.
-- **Workflow entity extended fields** [#28398](https://github.com/open-metadata/OpenMetadata/pull/28398): `Workflow` entities now support `inputPorts`, `outputPorts`, and `glossaryTerms` fields, bringing them to parity with pipeline and data-flow entities.
-- **MySQL — custom `queryHistoryTable`** [#28388](https://github.com/open-metadata/OpenMetadata/pull/28388): MySQL connector accepts a configurable `queryHistoryTable` for usage and lineage extraction, enabling use-cases where query history is stored in a non-default location.
+OpenMetadata 1.12.10 is a maintenance release delivering critical security patches, MCP enhancements, and targeted bug fixes across migrations, search, UI, and ingestion runtime.
 
 ### 🔒 Security
 
-- **Test-connection workflow authorization** [#28414](https://github.com/open-metadata/OpenMetadata/pull/28414): Test-connection workflow triggers now require proper authorization, closing an unauthenticated execution path.
-- **Snyk high/critical dependency patches in ingestion** [#28340](https://github.com/open-metadata/OpenMetadata/pull/28340): High and critical Snyk findings patched in ingestion dependencies and code paths.
-- **`brace-expansion` lockfile bump to 5.0.6** [#28244](https://github.com/open-metadata/OpenMetadata/pull/28244): Resolves a ReDoS advisory in the transitive `brace-expansion` package.
-- **`js-cookie` bumped** [#28315](https://github.com/open-metadata/OpenMetadata/pull/28315): Frontend dependency bumped to address a Dependabot advisory.
-- **WebSocket Dependabot vulnerability in UI** [#28320](https://github.com/open-metadata/OpenMetadata/pull/28320): Dependency update for a reported WebSocket vulnerability in the UI bundle.
+- **Snyk high/critical dependency patches in ingestion** [#28623](https://github.com/open-metadata/OpenMetadata/pull/28623): High and critical Snyk findings patched across ingestion dependencies to address multiple CVEs.
+- **Jackson-core and CloudFront Snyk high patches** [#28614](https://github.com/open-metadata/OpenMetadata/pull/28614): Resolved Snyk high-severity vulnerabilities in jackson-core 3.0.2 and cloudfront 2.30.19.
+- **Axios version bump for Retire.js vulnerabilities** [#28582](https://github.com/open-metadata/OpenMetadata/pull/28582): Frontend dependency updated to address reported Retire.js vulnerabilities.
+- **XSS security fix with explicit jsonify** [#28574](https://github.com/open-metadata/OpenMetadata/pull/28574): Made jsonify explicit at route level to break XSS taint chains.
+- **CVE fixes in ingestion images** [#28534](https://github.com/open-metadata/OpenMetadata/pull/28534): Closed gnutls, libcap, openssh, and rsync CVEs in ingestion container images.
+- **mlflow-skinny and jsonify security bumps** [#28501](https://github.com/open-metadata/OpenMetadata/pull/28501): Updated mlflow-skinny and surface jsonify in trigger route for security.
+- **Presidio utils XSS false positives fix** [#28535](https://github.com/open-metadata/OpenMetadata/pull/28535): Dropped **kwargs Any from presidio_utils factories to clear XSS false positives.
 
-### 🎨 UI Changes
+### 🔌 MCP (Model Context Protocol) Enhancements
 
-**Improvements**
+- **MCP tool error responses mapped to correct HTTP status codes** [#28644](https://github.com/open-metadata/OpenMetadata/pull/28644): Tool errors now properly map to their corresponding HTTP status codes.
+- **New MCP tools added** [#28586](https://github.com/open-metadata/OpenMetadata/pull/28586): Extended MCP tool capabilities with new tools for enhanced functionality.
+- **Optimize get_entity_lineage MCP tool payload** [#28618](https://github.com/open-metadata/OpenMetadata/pull/28618): Reduced payload size of get_entity_lineage tool with slim transform optimization.
+- **MCP custom properties in get_entity_details** [#28570](https://github.com/open-metadata/OpenMetadata/pull/28570): Surface custom extension properties in get_entity_details tool responses.
+- **MCP SAML SSO support in OAuth flow** [#28548](https://github.com/open-metadata/OpenMetadata/pull/28548): Added SAML SSO support for MCP OAuth authentication flow.
+- **MCP client secret handling for public clients** [#28552](https://github.com/open-metadata/OpenMetadata/pull/28552): Fixed to not issue client secret to public clients.
+- **MCP prefer application/json over SSE** [#28558](https://github.com/open-metadata/OpenMetadata/pull/28558): MCP now prefers application/json response format when client accepts both JSON and SSE.
+- **MCP Tool Usage improvements** [#28352](https://github.com/open-metadata/OpenMetadata/pull/28352): Enhanced MCP tool usage tracking and execution capabilities.
 
-- **Data Quality — column selection dropdowns are searchable** [#28376](https://github.com/open-metadata/OpenMetadata/pull/28376): Column selectors in test case forms now include a search box, making it practical to navigate wide tables.
+### 🛠 API & Migration Fixes
 
-**Fixes**
+- **Migration heal stuck PG certification** [#28635](https://github.com/open-metadata/OpenMetadata/pull/28635): Fixed migration to heal stuck PostgreSQL certification records stranded by v1125 update.
+- **Migration cast :metadata to json on PG tag_usage** [#28504](https://github.com/open-metadata/OpenMetadata/pull/28504): Corrected metadata field casting in PostgreSQL tag_usage insert statements.
 
-- **Notification links — plural alerts path and Query href** [#27918](https://github.com/open-metadata/OpenMetadata/pull/27918): Notification alert links now route to the correct plural `/alerts` path; Query entity hrefs in notifications are also corrected.
-- **Data Asset Header — permission fix** [#27967](https://github.com/open-metadata/OpenMetadata/pull/27967): Resolved a permission check issue in the Data Asset Header component that prevented certain actions for non-admin users.
-- **Bot name search on Bots page** [#27365](https://github.com/open-metadata/OpenMetadata/pull/27365): Fixed search not returning results when searching for bots by name on the Bots management page.
-- **Column bulk-ops filters use `displayName`** [#28390](https://github.com/open-metadata/OpenMetadata/pull/28390): Service, database, and schema filter dropdowns in the column bulk-operations flow now display `displayName` instead of raw FQN fragments.
-- **Bulk-asset operations enforce `dryRun`** [#28395](https://github.com/open-metadata/OpenMetadata/pull/28395): Tag, glossary, and data-product bulk operations now correctly honour the `dryRun` flag, preventing accidental mutations during preview runs.
-- **Table / dataModel — inline `column.extension` persisted** [#28392](https://github.com/open-metadata/OpenMetadata/pull/28392): Custom extension data attached inline to columns is now saved correctly through `POST`/`PUT` calls.
-- **ServicesPage tab accepts `ServiceCategory` enum values** [#28375](https://github.com/open-metadata/OpenMetadata/pull/28375): The `:tab` route parameter now accepts both the label string and the raw `ServiceCategory` enum value, fixing deep-links that used enum values.
-- **Unknown service category returns 404** [#28372](https://github.com/open-metadata/OpenMetadata/pull/28372): Navigating to an unrecognised service category now returns a proper 404 page instead of an empty fallback.
-- **KPI widget date format** [#28370](https://github.com/open-metadata/OpenMetadata/pull/28370): Added missing space between day and month values in the KPI widget's X-axis date labels.
-- **Bug fix (#27433)** [#28266](https://github.com/open-metadata/OpenMetadata/pull/28266): Backported fix for entity display regression.
+### 🔍 Search & Indexing Fixes
 
-### 🔌 Connectors
+- **Fix search by nested field names for topics and API endpoints** [#28610](https://github.com/open-metadata/OpenMetadata/pull/28610): Resolved issue where nested field name searches failed for topics and API endpoints.
+- **Scrub stale file extension aggregation on upgrade** [#28565](https://github.com/open-metadata/OpenMetadata/pull/28565): Prevented file search 500 errors by cleaning up stale file extension aggregation data during upgrade.
+- **Backport immense-term children mapping fix** [#28572](https://github.com/open-metadata/OpenMetadata/pull/28572): Applied fix for deeply nested children fields that were causing search mapping issues.
+- **Stop orphan test cases from breaking search indexing** [#28159](https://github.com/open-metadata/OpenMetadata/pull/28159): Prevented orphaned test cases from causing search index failures.
 
-**Databases**
+### 🎨 UI & UX Fixes
 
-- **Databricks / Unity Catalog — valueless tags ingested** [#28294](https://github.com/open-metadata/OpenMetadata/pull/28294): Tags set without an explicit value (valueless) are now ingested correctly from Databricks and Unity Catalog sources.
-- **Snowflake — discovered databases logged with filter reasons** [#28385](https://github.com/open-metadata/OpenMetadata/pull/28385): During schema discovery the Snowflake connector now logs each discovered database alongside the reason when it is filtered out, improving debuggability.
+- **Fix entity type filter update button click** [#28573](https://github.com/open-metadata/OpenMetadata/pull/28573): Corrected entity type filter interaction where update button click was not being registered.
+- **Fix Teams drag-and-drop Playwright timeout** [#28607](https://github.com/open-metadata/OpenMetadata/pull/28607): Resolved Teams component drag-and-drop interaction timeouts in UI tests.
+- **Translation fixes for ru-ru and ko-kr locales** [#28584](https://github.com/open-metadata/OpenMetadata/pull/28584): Corrected translation values for Russian and Korean language packs.
+- **Fix flaky toast assertion in tests** [#28566](https://github.com/open-metadata/OpenMetadata/pull/28566): Improved test reliability for toast notification assertions.
+- **Test suite pre-select every test case already in suite** [#28400](https://github.com/open-metadata/OpenMetadata/pull/28400): Fixed test case selection logic to pre-select all test cases already added to a suite.
+- **Fix Playwright data mismatch from migration testing** [#28496](https://github.com/open-metadata/OpenMetadata/pull/28496): Corrected Playwright test data mismatches introduced by migration testing.
 
-**Pipelines / Dashboards**
+### 🐛 General Bug Fixes
 
-- **Bulk sink — charts and dataModels created before dashboards** [#28371](https://github.com/open-metadata/OpenMetadata/pull/28371): Fixed a bulk sink ordering bug where a Dashboard entity could be flushed before its referenced Charts or DashboardDataModels, causing HTTP 400 rejections from the server. Each topology stage now encodes its position so referenced entities are always created first.
-- **Power BI — sink buffer flushed before lineage resolution** [#28308](https://github.com/open-metadata/OpenMetadata/pull/28308): Ensures all Power BI entities are persisted before lineage resolution begins, preventing reference errors during lineage extraction.
-- **Power BI — TSQL dialect for `Sql.Database` M-query lineage** [#28380](https://github.com/open-metadata/OpenMetadata/pull/28380): The Power BI connector now parses `Sql.Database` M-query expressions using the TSQL dialect, fixing lineage extraction failures on SQL Server-backed datasets.
+- **Fixed classification visit method** [#28636](https://github.com/open-metadata/OpenMetadata/pull/28636): Corrected the visit method for classification entity traversal.
+- **Fix flaky domain & data product rename** [#28580](https://github.com/open-metadata/OpenMetadata/pull/28580): Improved stability of domain and data product rename operations by handling search version conflicts.
+- **Fix fasturi dependency** [#28139](https://github.com/open-metadata/OpenMetadata/pull/28139): Updated fasturi dependency to resolve compatibility issues.
 
-**OpenLineage**
+### 📦 Dependencies & Infrastructure
 
-- **Resolve table identity from `symlinks` facet** [#28360](https://github.com/open-metadata/OpenMetadata/pull/28360): OpenLineage events that include a `symlinks` facet now resolve the true table identity from the symlink, fixing entity matching for Hive/Iceberg tables exposed under alternate names.
-- **Pipeline as node for single-sided lineage** [#28350](https://github.com/open-metadata/OpenMetadata/pull/28350): OpenLineage pipelines can now appear as a standalone node in the lineage graph when only one side (input or output) is present, instead of being dropped.
+- **Kubernetes client pinned below 36.0.0** (from v1.12.9): Maintained compatibility by capping Kubernetes Python client to avoid breaking API changes.
 
-**Ingestion Runtime**
-
-- **Kubernetes client capped below 36.0.0** [#28331](https://github.com/open-metadata/OpenMetadata/pull/28331): Pins the Kubernetes Python client to `<36.0.0` to avoid a breaking API change introduced in that release.
-- **Ingestion-pipeline status preserved during queued-stage failures** [#28382](https://github.com/open-metadata/OpenMetadata/pull/28382): When a queued-stage task fails, the overall pipeline status remains accurate instead of being overwritten with a misleading value.
-
-### 🛠 API (Backend)
-
-**Improvements**
-
-- **Workflow field fetches scoped** [#28391](https://github.com/open-metadata/OpenMetadata/pull/28391): Wildcard field fetches in workflow-related queries replaced with scoped field requests, reducing payload size and improving performance.
-- **Data Insights enricher — per-step failure isolation** [#28379](https://github.com/open-metadata/OpenMetadata/pull/28379): Enricher step failures are now isolated per-step with individual error tracking, preventing one bad enricher from aborting the entire Data Insights run.
-
-**Fixes**
-
-- **Search `search_after` with special characters in sort values** [#28386](https://github.com/open-metadata/OpenMetadata/pull/28386): `search_after` pagination no longer drops entities whose sort-field value contains special characters.
-- **Search — nested children flattened to avoid ES mapping depth limit** [#28387](https://github.com/open-metadata/OpenMetadata/pull/28387): Deeply nested `children` fields are now flattened before indexing to prevent Elasticsearch/OpenSearch from rejecting documents that exceed the default mapping depth limit.
-- **Table certification cascaded to child search documents** [#28229](https://github.com/open-metadata/OpenMetadata/pull/28229): A `PATCH` to a Table's certification tag is now propagated to all child search documents, keeping certification state consistent across the search index.
-- **Search-index reindex jobs no longer marked failed on clean completion** [#28381](https://github.com/open-metadata/OpenMetadata/pull/28381): Fixed a status-tracking bug that incorrectly recorded clean reindex jobs as failed in the job history.
-- **PDTS duplicate preemption and invalid index-mapping recovery** [#28373](https://github.com/open-metadata/OpenMetadata/pull/28373): Migration now preempts duplicate PDTS (Profiler Data Time Series) rows and recovers from invalid search index mappings rather than failing.
-- **MCP — `search_metadata` response capped** [#28383](https://github.com/open-metadata/OpenMetadata/pull/28383): The MCP `search_metadata` tool response is now capped in size to prevent LLM context overflow when the result set is large.
-- **Alert filter functions use strict literal matching** [#28393](https://github.com/open-metadata/OpenMetadata/pull/28393): Alert filter expressions now perform strict literal matching instead of substring matching, preventing false-positive alert triggers.
-- **Test case suite search membership preserved** [#28271](https://github.com/open-metadata/OpenMetadata/pull/28271): Test cases now retain their suite membership in the search index after updates, fixing a regression where suites lost members after re-ingestion.
-- **OMeta SSE transport switched to `requests`** [#28293](https://github.com/open-metadata/OpenMetadata/pull/28293): The OpenMetadata Python client now uses `requests` instead of `httpx` for SSE (Server-Sent Events) transport, resolving compatibility issues in certain deployment environments.
-- **OMeta — resilient transport with keepalive and retry** [#28389](https://github.com/open-metadata/OpenMetadata/pull/28389): The OMeta REST transport now uses keepalive connections and automatic retries on transient failures with a typed `RestTransport` abstraction.
-- **Shutdown logging captures full streamable log tail** [#28396](https://github.com/open-metadata/OpenMetadata/pull/28396): Synchronous shutdown now waits for in-flight streamable log writes to complete, preventing log truncation on graceful shutdown.
-
-**Full Changelog**: [link](https://github.com/open-metadata/OpenMetadata/compare/1.12.8-release...1.12.9-release)
+**Full Changelog**: [link](https://github.com/open-metadata/OpenMetadata/compare/1.12.9-release...1.12.10-release)
 
 </Update>

--- a/snippets/releases/latest.mdx
+++ b/snippets/releases/latest.mdx
@@ -1,4 +1,4 @@
-<Update label="1.12.10 Release" description="2nd June 2026">
+<Update label="1.12.10 Release" description="3nd June 2026">
 
 You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.10-release).
 

--- a/snippets/releases/latest.mdx
+++ b/snippets/releases/latest.mdx
@@ -1,4 +1,4 @@
-<Update label="1.12.10 Release" description="3nd June 2026">
+<Update label="1.12.10 Release" description="3rd June 2026">
 
 You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.10-release).
 
@@ -42,11 +42,8 @@ OpenMetadata 1.12.10 is a maintenance release delivering critical security patch
 ### 🎨 UI & UX Fixes
 
 - **Fix entity type filter update button click** [#28573](https://github.com/open-metadata/OpenMetadata/pull/28573): Corrected entity type filter interaction where update button click was not being registered.
-- **Fix Teams drag-and-drop Playwright timeout** [#28607](https://github.com/open-metadata/OpenMetadata/pull/28607): Resolved Teams component drag-and-drop interaction timeouts in UI tests.
 - **Translation fixes for ru-ru and ko-kr locales** [#28584](https://github.com/open-metadata/OpenMetadata/pull/28584): Corrected translation values for Russian and Korean language packs.
-- **Fix flaky toast assertion in tests** [#28566](https://github.com/open-metadata/OpenMetadata/pull/28566): Improved test reliability for toast notification assertions.
 - **Test suite pre-select every test case already in suite** [#28400](https://github.com/open-metadata/OpenMetadata/pull/28400): Fixed test case selection logic to pre-select all test cases already added to a suite.
-- **Fix Playwright data mismatch from migration testing** [#28496](https://github.com/open-metadata/OpenMetadata/pull/28496): Corrected Playwright test data mismatches introduced by migration testing.
 
 ### 🐛 General Bug Fixes
 

--- a/v1.12.x/releases/all-releases.mdx
+++ b/v1.12.x/releases/all-releases.mdx
@@ -11,6 +11,7 @@ import ReleaseNotes4 from '/snippets/releases/1.12.5.mdx';
 import ReleaseNotes5 from '/snippets/releases/1.12.6.mdx';
 import ReleaseNotes6 from '/snippets/releases/1.12.7.mdx';
 import ReleaseNotes7 from '/snippets/releases/1.12.8.mdx';
+import ReleaseNotes8 from '/snippets/releases/1.12.9.mdx';
 import ReleaseNotes from '/snippets/releases/latest.mdx';
 
 
@@ -22,11 +23,13 @@ The OpenMetadata community is on a monthly release cadence. At every 4-5 weeks w
 
 <CardGroup>
 <Card icon="party-horn" title="Upgrade OpenMetadata" href="/v1.12.x/deployment/upgrade">
-Learn how to upgrade your OpenMetadata instance to 1.12.9!
+Learn how to upgrade your OpenMetadata instance to 1.12.10!
 </Card>
 </CardGroup>
 
 <ReleaseNotes />
+
+<ReleaseNotes8 />
 
 <ReleaseNotes7 />
 


### PR DESCRIPTION
Archive current `latest.mdx` → new `snippets/releases/1.12.9.mdx`

Write new `snippets/releases/latest.mdx` for 1.12.10 (OSS-only changes)

Add `1.12.9.mdx` import to `v1.12.x/releases/all-releases.mdx` and update upgrade card text to 1.12.10

Contains OpenMetadata-only changes (no Collate-specific content).