### PR TITLE
Docs: Update Metabase connector — API Token auth, Owners feature, auth callout

### DIFF
--- a/v1.12.x/connectors/dashboard/metabase.mdx
+++ b/v1.12.x/connectors/dashboard/metabase.mdx
@@ -14,16 +14,26 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
   icon='/public/images/connectors/metabase.webp'
 name="Metabase"
   stage="PROD"
-availableFeatures={["Dashboards", "Charts", "Lineage", "Projects"]}
-  unavailableFeatures={["Owners", "Tags", "Datamodels"]} />
+availableFeatures={["Dashboards", "Charts", "Lineage", "Projects", "Owners"]}
+  unavailableFeatures={["Tags", "Datamodels"]} />
 In this section, we provide guides and references to use the Metabase connector.
+
+<Info>
+**Supported Authentication Types:**
+- **Basic Auth** — Connect using a Metabase account email and password. The connector obtains a session token automatically.
+- **API Token** — Connect using a Metabase API key. Recommended when basic authentication is disabled (e.g., SSO-enforced environments).
+</Info>
+
 Configure and schedule Metabase metadata and profiler workflows from the OpenMetadata UI:
 - [Requirements](#requirements)
 - [Metadata Ingestion](#metadata-ingestion)
 - [Lineage](#lineage)
 - [Troubleshooting](/v1.12.x/connectors/dashboard/metabase/troubleshooting)
 ## Requirements
-The service account must have view access to all dashboards and charts that need to be ingested. Without view access, the connector cannot retrieve those objects.
+The Metabase account or API key used to connect must have view access to all dashboards and charts you want to ingest.
+
+To ingest **owner information**, the account must also have visibility of Metabase user profiles. This is available to admin accounts and accounts in groups with the appropriate permissions.
+
 **Note:** We have tested Metabase with Versions `0.42.4` and `0.43.4`.
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"Metabase"} selectServicePath={"/public/images/connectors/metabase/select-service.png"} addNewServicePath={"/public/images/connectors/metabase/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/metabase/service-connection.png"} />
@@ -38,9 +48,17 @@ password: secret:/my/database/password
 This applies **only to fields marked as secrets** in the connection form (these typically mask input and show a visibility toggle icon).
 For a complete guide on managing secrets in hybrid setups, see the [Hybrid Ingestion Runner Secret Management Guide](https://docs.getcollate.io/getting-started/day-1/hybrid-saas/hybrid-ingestion-runner#3.-manage-secrets-securely).
 </Tip>
-- **Host and Port**: The hostPort parameter specifies the host and port of the Metabase instance. This should be specified as a string in the format `http://hostname:port` or `https://hostname:port`. For example, you might set the hostPort parameter to `https://org.metabase.com:3000`.
-- **Username**: Username to connect to Metabase, for ex. `user@organization.com`. This user should have access to relevant dashboards and charts in Metabase to fetch the metadata.
-- **Password**: Password of the user account to connect with Metabase.
+- **Host and Port**: URL of your Metabase instance, in the format `http://hostname:port` or `https://hostname:port`. For example: `https://org.metabase.com:3000`.
+
+Metabase supports two authentication methods. Provide credentials for **one** of the following:
+
+**Option 1 — Basic Authentication**
+- **Username**: Email address of the Metabase account, for example `user@organization.com`. The account must have view access to the dashboards and charts you want to ingest.
+- **Password**: Password for the Metabase account.
+
+**Option 2 — API Token**
+- **API Token**: API key for Metabase. Use this instead of username and password when basic authentication is disabled, for example in SSO-enforced environments. Generate the key in the Metabase Admin panel under **Settings > Authentication > API Keys**.
+
 </Step>
 <TestConnection />
 <ConfigureIngestion />

--- a/v1.12.x/connectors/dashboard/metabase/yaml.mdx
+++ b/v1.12.x/connectors/dashboard/metabase/yaml.mdx
@@ -20,16 +20,27 @@ import ExternalIngestionDeployment from '/snippets/v1.12.x/connectors/external-i
   icon='/public/images/connectors/metabase.webp'
 name="Metabase"
   stage="PROD"
-availableFeatures={["Dashboards", "Charts", "Lineage", "Projects"]}
-  unavailableFeatures={["Owners", "Tags", "Datamodels"]} />
+availableFeatures={["Dashboards", "Charts", "Lineage", "Projects", "Owners"]}
+  unavailableFeatures={["Tags", "Datamodels"]} />
 In this section, we provide guides and references to use the Metabase connector.
+
+<Info>
+**Supported Authentication Types:**
+- **Basic Auth** — Connect using a Metabase account email and password. The connector obtains a session token automatically.
+- **API Token** — Connect using a Metabase API key. Recommended when basic authentication is disabled (e.g., SSO-enforced environments).
+</Info>
+
 Configure and schedule Metabase metadata and profiler workflows from the OpenMetadata UI:
 - [Requirements](#requirements)
 - [Metadata Ingestion](#metadata-ingestion)
 <ExternalIngestionDeployment />
 ## Requirements
-The service account must have view access to all dashboards and charts that need to be ingested. Without view access, the connector cannot retrieve those objects.
-**Note:** We have tested Metabase with Versions `0.42.4` and `0.43.4`.
+The Metabase account or API key used to connect must have view access to all dashboards and charts you want to ingest.
+
+To ingest **owner information**, the account must also have visibility of Metabase user profiles. This is available to admin accounts and accounts in groups with the appropriate permissions.
+
+**Note:** Collate has been tested with Metabase versions 0.42.4 and 0.43.4.
+
 ### Python Requirements
 <PythonRequirements />
 To run the Metabase ingestion, you will need to install:
@@ -60,35 +71,41 @@ Configure the source type and service name for your Metabase connector.
 
 <ContentSection id={2} title="Username" lines="7">
 
-**username**: Username to connect to Metabase, for ex. `user@organization.com`. This user should have access to relevant dashboards and charts in Metabase to fetch the metadata.
+**username**: Email address of the Metabase account, for example `user@organization.com`. The account must have view access to the dashboards and charts you want to ingest. Required for Basic Authentication — leave blank if using an API Token.
 
 </ContentSection>
 
 <ContentSection id={3} title="Password" lines="8">
 
-**password**: Password of the user account to connect with Metabase.
+**password**: Password of the user account to connect with Metabase. Required for Basic Authentication — leave blank if using an API Token.
 
 </ContentSection>
 
-<ContentSection id={4} title="Host Port" lines="9">
+<ContentSection id={4} title="API Token" lines="9">
+
+**apiKey**: API key for Metabase. Use this instead of username and password when basic authentication is disabled (e.g., SSO-enforced environments). Generate the key in the Metabase Admin panel under **Settings > Authentication > API Keys**.
+
+</ContentSection>
+
+<ContentSection id={5} title="Host Port" lines="10">
 
 **hostPort**: The hostPort parameter specifies the host and port of the Metabase instance. This should be specified as a string in the format `http://hostname:port` or `https://hostname:port`. For example, you might set the hostPort parameter to `https://org.metabase.com:3000`.
 
 </ContentSection>
 
-<ContentSection id={5} title="Source Config" lines="10-52">
+<ContentSection id={6} title="Source Config" lines="11-53">
 
 <SourceConfigDef />
 
 </ContentSection>
 
-<ContentSection id={6} title="Sink Configuration" lines="53-55">
+<ContentSection id={7} title="Sink Configuration" lines="54-56">
 
 <IngestionSinkDef />
 
 </ContentSection>
 
-<ContentSection id={7} title="Workflow Configuration" lines="56-72">
+<ContentSection id={8} title="Workflow Configuration" lines="57-73">
 
 <WorkflowConfigDef />
 
@@ -107,6 +124,7 @@ source:
       type: Metabase
       username: <username>
       password: <password>
+      apiKey: <api-token>
       hostPort: <hostPort>
 ```
 

--- a/v1.13.x-SNAPSHOT/connectors/dashboard/metabase.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/dashboard/metabase.mdx
@@ -14,16 +14,26 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
   icon='/public/images/connectors/metabase.webp'
 name="Metabase"
   stage="PROD"
-availableFeatures={["Dashboards", "Charts", "Lineage", "Projects"]}
-  unavailableFeatures={["Owners", "Tags", "Datamodels"]} />
+availableFeatures={["Dashboards", "Charts", "Lineage", "Projects", "Owners"]}
+  unavailableFeatures={["Tags", "Datamodels"]} />
 In this section, we provide guides and references to use the Metabase connector.
+
+<Info>
+**Supported Authentication Types:**
+- **Basic Auth** — Connect using a Metabase account email and password. The connector obtains a session token automatically.
+- **API Token** — Connect using a Metabase API key. Recommended when basic authentication is disabled (e.g., SSO-enforced environments).
+</Info>
+
 Configure and schedule Metabase metadata and profiler workflows from the OpenMetadata UI:
 - [Requirements](#requirements)
 - [Metadata Ingestion](#metadata-ingestion)
 - [Lineage](#lineage)
 - [Troubleshooting](/v1.13.x-SNAPSHOT/connectors/dashboard/metabase/troubleshooting)
 ## Requirements
-The service account must have view access to all dashboards and charts that need to be ingested. Without view access, the connector cannot retrieve those objects.
+The Metabase account or API key used to connect must have view access to all dashboards and charts you want to ingest.
+
+To ingest **owner information**, the account must also have visibility of Metabase user profiles. This is available to admin accounts and accounts in groups with the appropriate permissions.
+
 **Note:** We have tested Metabase with Versions `0.42.4` and `0.43.4`.
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"Metabase"} selectServicePath={"/public/images/connectors/metabase/select-service.png"} addNewServicePath={"/public/images/connectors/metabase/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/metabase/service-connection.png"} />
@@ -38,9 +48,16 @@ password: secret:/my/database/password
 This applies **only to fields marked as secrets** in the connection form (these typically mask input and show a visibility toggle icon).
 For a complete guide on managing secrets in hybrid setups, see the [Hybrid Ingestion Runner Secret Management Guide](https://docs.getcollate.io/getting-started/day-1/hybrid-saas/hybrid-ingestion-runner#3.-manage-secrets-securely).
 </Tip>
-- **Host and Port**: The hostPort parameter specifies the host and port of the Metabase instance. This should be specified as a string in the format `http://hostname:port` or `https://hostname:port`. For example, you might set the hostPort parameter to `https://org.metabase.com:3000`.
-- **Username**: Username to connect to Metabase, for ex. `user@organization.com`. This user should have access to relevant dashboards and charts in Metabase to fetch the metadata.
-- **Password**: Password of the user account to connect with Metabase.
+- **Host and Port**: URL of your Metabase instance, in the format `http://hostname:port` or `https://hostname:port`. For example: `https://org.metabase.com:3000`.
+
+Metabase supports two authentication methods. Provide credentials for **one** of the following:
+
+**Option 1 — Basic Authentication**
+- **Username**: Email address of the Metabase account, for example `user@organization.com`. The account must have view access to the dashboards and charts you want to ingest.
+- **Password**: Password for the Metabase account.
+
+**Option 2 — API Token**
+- **API Token**: API key for Metabase. Use this instead of username and password when basic authentication is disabled, for example in SSO-enforced environments. Generate the key in the Metabase Admin panel under **Settings > Authentication > API Keys**.
 </Step>
 <TestConnection />
 <ConfigureIngestion />

--- a/v1.13.x-SNAPSHOT/connectors/dashboard/metabase/yaml.mdx
+++ b/v1.13.x-SNAPSHOT/connectors/dashboard/metabase/yaml.mdx
@@ -20,16 +20,27 @@ import ExternalIngestionDeployment from '/snippets/v1.13.x/connectors/external-i
   icon='/public/images/connectors/metabase.webp'
 name="Metabase"
   stage="PROD"
-availableFeatures={["Dashboards", "Charts", "Lineage", "Projects"]}
-  unavailableFeatures={["Owners", "Tags", "Datamodels"]} />
+availableFeatures={["Dashboards", "Charts", "Lineage", "Projects", "Owners"]}
+  unavailableFeatures={["Tags", "Datamodels"]} />
 In this section, we provide guides and references to use the Metabase connector.
+
+<Info>
+**Supported Authentication Types:**
+- **Basic Auth** — Connect using a Metabase account email and password. The connector obtains a session token automatically.
+- **API Token** — Connect using a Metabase API key. Recommended when basic authentication is disabled (e.g., SSO-enforced environments).
+</Info>
+
 Configure and schedule Metabase metadata and profiler workflows from the OpenMetadata UI:
 - [Requirements](#requirements)
 - [Metadata Ingestion](#metadata-ingestion)
 <ExternalIngestionDeployment />
 ## Requirements
-The service account must have view access to all dashboards and charts that need to be ingested. Without view access, the connector cannot retrieve those objects.
+The Metabase account or API key used to connect must have view access to all dashboards and charts you want to ingest.
+
+To ingest **owner information**, the account must also have visibility of Metabase user profiles. This is available to admin accounts and accounts in groups with the appropriate permissions.
+
 **Note:** We have tested Metabase with Versions `0.42.4` and `0.43.4`.
+
 ### Python Requirements
 <PythonRequirements />
 To run the Metabase ingestion, you will need to install:
@@ -60,35 +71,41 @@ Configure the source type and service name for your Metabase connector.
 
 <ContentSection id={2} title="Username" lines="7">
 
-**username**: Username to connect to Metabase, for ex. `user@organization.com`. This user should have access to relevant dashboards and charts in Metabase to fetch the metadata.
+**username**: Email address of the Metabase account, for example `user@organization.com`. The account must have view access to the dashboards and charts you want to ingest. Required for Basic Authentication — leave blank if using an API Token.
 
 </ContentSection>
 
 <ContentSection id={3} title="Password" lines="8">
 
-**password**: Password of the user account to connect with Metabase.
+**password**: Password of the user account to connect with Metabase. Required for Basic Authentication — leave blank if using an API Token.
 
 </ContentSection>
 
-<ContentSection id={4} title="Host Port" lines="9">
+<ContentSection id={4} title="API Token" lines="9">
+
+**apiKey**: API key for Metabase. Use this instead of username and password when basic authentication is disabled (e.g., SSO-enforced environments). Generate the key in the Metabase Admin panel under **Settings > Authentication > API Keys**.
+
+</ContentSection>
+
+<ContentSection id={5} title="Host Port" lines="10">
 
 **hostPort**: The hostPort parameter specifies the host and port of the Metabase instance. This should be specified as a string in the format `http://hostname:port` or `https://hostname:port`. For example, you might set the hostPort parameter to `https://org.metabase.com:3000`.
 
 </ContentSection>
 
-<ContentSection id={5} title="Source Config" lines="10-52">
+<ContentSection id={6} title="Source Config" lines="11-53">
 
 <SourceConfigDef />
 
 </ContentSection>
 
-<ContentSection id={6} title="Sink Configuration" lines="53-55">
+<ContentSection id={7} title="Sink Configuration" lines="54-56">
 
 <IngestionSinkDef />
 
 </ContentSection>
 
-<ContentSection id={7} title="Workflow Configuration" lines="56-72">
+<ContentSection id={8} title="Workflow Configuration" lines="57-73">
 
 <WorkflowConfigDef />
 
@@ -107,6 +124,7 @@ source:
       type: Metabase
       username: <username>
       password: <password>
+      apiKey: <api-token>
       hostPort: <hostPort>
 ```
 


### PR DESCRIPTION
## Summary

- Documents API Token authentication as an alternative to Basic Auth, addressing [#17628](https://github.com/open-metadata/OpenMetadata/issues/17628) (fixed by OpenMetadata PR [#23436](https://github.com/open-metadata/OpenMetadata/pull/23436))
- Corrects `availableFeatures`: moves `"Owners"` from unavailable to available — `get_owner_ref()` is implemented in the connector source
- Adds `<Info>` callout listing supported authentication types (Basic Auth + API Token) at the top of all pages
- Expands Requirements section to cover permissions needed for owner ingestion
- Aligns terminology and field descriptions across `metabase.mdx` and `yaml.mdx`

<img width="1482" height="752" alt="image" src="https://github.com/user-attachments/assets/27903dd7-2cd7-4934-88e9-efce3108ee86" />


**Versions updated:** v1.12.x, v1.13.x-SNAPSHOT

## Test plan

- [ ] Verify connection details section renders correctly with both auth options
- [ ] Verify `<Info>` auth callout appears at the top of the page
- [ ] Verify `ConnectorDetailsHeader` shows Owners as available on both overview and yaml pages
- [ ] Verify YAML example displays `apiKey` field alongside `username`/`password`