### PR TITLE
Docs: Revises the 1.12.10 release notes to align with TW standards and fix incorrect PR links

### DIFF
--- a/snippets/releases/latest.mdx
+++ b/snippets/releases/latest.mdx
@@ -4,57 +4,57 @@ You can find the GitHub release [here](https://github.com/open-metadata/OpenMeta
 
 ## Changelog
 
-OpenMetadata 1.12.10 is a maintenance release delivering critical security patches, MCP enhancements, and targeted bug fixes across migrations, search, UI, and ingestion runtime.
+OpenMetadata 1.12.10 is a maintenance release delivering critical security patches, Model Context Protocol (MCP) enhancements, and targeted bug fixes across migrations, search, UI, and ingestion runtime.
 
-### 🔒 Security
+### 🔒 Security patches
 
-- **Snyk high/critical dependency patches in ingestion** [#28623](https://github.com/open-metadata/OpenMetadata/pull/28623): High and critical Snyk findings patched across ingestion dependencies to address multiple CVEs.
-- **Jackson-core and CloudFront Snyk high patches** [#28614](https://github.com/open-metadata/OpenMetadata/pull/28614): Resolved Snyk high-severity vulnerabilities in jackson-core 3.0.2 and cloudfront 2.30.19.
-- **Axios version bump for Retire.js vulnerabilities** [#28582](https://github.com/open-metadata/OpenMetadata/pull/28582): Frontend dependency updated to address reported Retire.js vulnerabilities.
-- **XSS security fix with explicit jsonify** [#28574](https://github.com/open-metadata/OpenMetadata/pull/28574): Made jsonify explicit at route level to break XSS taint chains.
-- **CVE fixes in ingestion images** [#28534](https://github.com/open-metadata/OpenMetadata/pull/28534): Closed gnutls, libcap, openssh, and rsync CVEs in ingestion container images.
-- **mlflow-skinny and jsonify security bumps** [#28501](https://github.com/open-metadata/OpenMetadata/pull/28501): Updated mlflow-skinny and surface jsonify in trigger route for security.
-- **Presidio utils XSS false positives fix** [#28535](https://github.com/open-metadata/OpenMetadata/pull/28535): Dropped **kwargs Any from presidio_utils factories to clear XSS false positives.
+- **Snyk high/critical dependency patches in ingestion** [#28623](https://github.com/open-metadata/OpenMetadata/pull/28623): Patches high and critical Snyk findings across ingestion dependencies to address multiple common vulnerabilities and exposures (CVEs).
+- **Jackson-core and CloudFront Snyk high patches** [#28614](https://github.com/open-metadata/OpenMetadata/pull/28614): Resolves Snyk high-severity vulnerabilities in jackson-core 3.0.2 and cloudfront 2.30.19.
+- **Axios version bump for Retire.js vulnerabilities** [#28582](https://github.com/open-metadata/OpenMetadata/pull/28582): Updates the frontend dependency to address reported Retire.js vulnerabilities.
+- **Cross-site scripting (XSS) security fix with explicit jsonify** [#28574](https://github.com/open-metadata/OpenMetadata/pull/28574): Makes jsonify explicit at the route level to break XSS taint chains.
+- **CVE fixes in ingestion images** [#28534](https://github.com/open-metadata/OpenMetadata/pull/28534): Closes gnutls, libcap, openssh, and rsync CVEs in ingestion container images.
+- **mlflow-skinny and jsonify security bumps** [#28501](https://github.com/open-metadata/OpenMetadata/pull/28501): Updates mlflow-skinny and surfaces jsonify in the trigger route for security.
+- **Presidio utils XSS false positives fix** [#28535](https://github.com/open-metadata/OpenMetadata/pull/28535): Drops `**kwargs Any` from presidio_utils factories to clear XSS false positives.
 
-### 🔌 MCP (Model Context Protocol) Enhancements
+### 🔌 MCP enhancements
 
-- **MCP tool error responses mapped to correct HTTP status codes** [#28644](https://github.com/open-metadata/OpenMetadata/pull/28644): Tool errors now properly map to their corresponding HTTP status codes.
-- **New MCP tools added** [#28586](https://github.com/open-metadata/OpenMetadata/pull/28586): Extended MCP tool capabilities with new tools for enhanced functionality.
-- **Optimize get_entity_lineage MCP tool payload** [#28618](https://github.com/open-metadata/OpenMetadata/pull/28618): Reduced payload size of get_entity_lineage tool with slim transform optimization.
-- **MCP custom properties in get_entity_details** [#28570](https://github.com/open-metadata/OpenMetadata/pull/28570): Surface custom extension properties in get_entity_details tool responses.
-- **MCP SAML SSO support in OAuth flow** [#28548](https://github.com/open-metadata/OpenMetadata/pull/28548): Added SAML SSO support for MCP OAuth authentication flow.
-- **MCP client secret handling for public clients** [#28552](https://github.com/open-metadata/OpenMetadata/pull/28552): Fixed to not issue client secret to public clients.
-- **MCP prefer application/json over SSE** [#28558](https://github.com/open-metadata/OpenMetadata/pull/28558): MCP now prefers application/json response format when client accepts both JSON and SSE.
-- **MCP Tool Usage improvements** [#28352](https://github.com/open-metadata/OpenMetadata/pull/28352): Enhanced MCP tool usage tracking and execution capabilities.
+- **MCP tool errors mapped to correct HTTP status codes** [#28644](https://github.com/open-metadata/OpenMetadata/pull/28644): MCP now maps tool errors to the correct HTTP status codes.
+- **New MCP tools added** [#28586](https://github.com/open-metadata/OpenMetadata/pull/28586): Extends MCP tool capabilities with new tools for enhanced functionality.
+- **Optimized get_entity_lineage MCP tool payload** [#28618](https://github.com/open-metadata/OpenMetadata/pull/28618): Reduces the payload size of the get_entity_lineage tool with a slim transform optimization.
+- **MCP custom properties in get_entity_details** [#28594](https://github.com/open-metadata/OpenMetadata/pull/28594): Surfaces custom extension properties in get_entity_details tool responses.
+- **MCP single sign-on (SSO) support in OAuth flow** [#28548](https://github.com/open-metadata/OpenMetadata/pull/28548): Adds SAML SSO support for the MCP OAuth authentication flow.
+- **MCP client secret handling for public clients** [#28552](https://github.com/open-metadata/OpenMetadata/pull/28552): Fixes client secret issuance to no longer send secrets to public clients.
+- **MCP prefers application/json over SSE** [#28558](https://github.com/open-metadata/OpenMetadata/pull/28558): MCP now prefers the application/json response format when a client accepts both JSON and SSE.
+- **MCP tool usage improvements** [#28352](https://github.com/open-metadata/OpenMetadata/pull/28352): Enhances MCP tool usage tracking and execution capabilities.
 
-### 🛠 API & Migration Fixes
+### 🛠 API and migration fixes
 
-- **Migration heal stuck PG certification** [#28635](https://github.com/open-metadata/OpenMetadata/pull/28635): Fixed migration to heal stuck PostgreSQL certification records stranded by v1125 update.
-- **Migration cast :metadata to json on PG tag_usage** [#28504](https://github.com/open-metadata/OpenMetadata/pull/28504): Corrected metadata field casting in PostgreSQL tag_usage insert statements.
+- **Migration heals stuck PostgreSQL certification** [#28635](https://github.com/open-metadata/OpenMetadata/pull/28635): Fixes migration to heal stuck PostgreSQL certification records stranded by the v1.12.5 update.
+- **Migration casts :metadata to JSON on PostgreSQL tag_usage** [#28504](https://github.com/open-metadata/OpenMetadata/pull/28504): Corrects metadata field casting in PostgreSQL tag_usage insert statements.
 
-### 🔍 Search & Indexing Fixes
+### 🔍 Search and indexing fixes
 
-- **Fix search by nested field names for topics and API endpoints** [#28610](https://github.com/open-metadata/OpenMetadata/pull/28610): Resolved issue where nested field name searches failed for topics and API endpoints.
-- **Scrub stale file extension aggregation on upgrade** [#28565](https://github.com/open-metadata/OpenMetadata/pull/28565): Prevented file search 500 errors by cleaning up stale file extension aggregation data during upgrade.
-- **Backport immense-term children mapping fix** [#28572](https://github.com/open-metadata/OpenMetadata/pull/28572): Applied fix for deeply nested children fields that were causing search mapping issues.
-- **Stop orphan test cases from breaking search indexing** [#28159](https://github.com/open-metadata/OpenMetadata/pull/28159): Prevented orphaned test cases from causing search index failures.
+- **Search by nested field names for topics and API endpoints** [#28610](https://github.com/open-metadata/OpenMetadata/pull/28610): Resolves an issue where nested field name searches failed for topics and API endpoints.
+- **Stale file extension aggregation scrubbed on upgrade** [#28565](https://github.com/open-metadata/OpenMetadata/pull/28565): Prevents file search 500 errors by cleaning up stale file extension aggregation data during upgrade.
+- **Backport of immense-term children mapping fix** [#28572](https://github.com/open-metadata/OpenMetadata/pull/28572): Applies a fix for deeply nested children fields that were causing search mapping issues.
+- **Orphan test cases no longer break search indexing** [#28159](https://github.com/open-metadata/OpenMetadata/pull/28159): Prevents orphaned test cases from causing search index failures.
 
-### 🎨 UI & UX Fixes
+### 🎨 UI and UX fixes
 
-- **Fix entity type filter update button click** [#28573](https://github.com/open-metadata/OpenMetadata/pull/28573): Corrected entity type filter interaction where update button click was not being registered.
-- **Translation fixes for ru-ru and ko-kr locales** [#28584](https://github.com/open-metadata/OpenMetadata/pull/28584): Corrected translation values for Russian and Korean language packs.
-- **Test suite pre-select every test case already in suite** [#28400](https://github.com/open-metadata/OpenMetadata/pull/28400): Fixed test case selection logic to pre-select all test cases already added to a suite.
+- **Entity type filter update button click fixed** [#28573](https://github.com/open-metadata/OpenMetadata/pull/28573): Corrects the entity type filter interaction where the update button click was not being registered.
+- **Translation fixes for ru-RU and ko-KR locales** [#28584](https://github.com/open-metadata/OpenMetadata/pull/28584): Corrects translation values for Russian and Korean language packs.
+- **Test suite pre-selects every test case already in suite** [#28543](https://github.com/open-metadata/OpenMetadata/pull/28543): Fixes test case selection logic to pre-select all test cases already added to a suite.
 
-### 🐛 General Bug Fixes
+### 🐛 General bug fixes
 
-- **Fixed classification visit method** [#28636](https://github.com/open-metadata/OpenMetadata/pull/28636): Corrected the visit method for classification entity traversal.
-- **Fix flaky domain & data product rename** [#28580](https://github.com/open-metadata/OpenMetadata/pull/28580): Improved stability of domain and data product rename operations by handling search version conflicts.
-- **Fix fasturi dependency** [#28139](https://github.com/open-metadata/OpenMetadata/pull/28139): Updated fasturi dependency to resolve compatibility issues.
+- **Classification visit method fixed** [#28636](https://github.com/open-metadata/OpenMetadata/pull/28636): Corrects the visit method for classification entity traversal.
+- **Flaky domain and data product rename fixed** [#28580](https://github.com/open-metadata/OpenMetadata/pull/28580): Improves stability of domain and data product rename operations by handling search version conflicts.
+- **fasturi dependency fix** [#28139](https://github.com/open-metadata/OpenMetadata/pull/28139): Updates the fasturi dependency to resolve compatibility issues.
 
-### 📦 Dependencies & Infrastructure
+### 📦 Dependencies and infrastructure
 
-- **Kubernetes client pinned below 36.0.0** (from v1.12.9): Maintained compatibility by capping Kubernetes Python client to avoid breaking API changes.
+- **Kubernetes client pinned below 36.0.0** (from v1.12.9): Maintains compatibility by capping the Kubernetes Python client to avoid breaking API changes.
 
-**Full Changelog**: [link](https://github.com/open-metadata/OpenMetadata/compare/1.12.9-release...1.12.10-release)
+**[View the full changelog](https://github.com/open-metadata/OpenMetadata/compare/1.12.9-release...1.12.10-release)**
 
 </Update>

--- a/v1.13.x-SNAPSHOT/releases/all-releases.mdx
+++ b/v1.13.x-SNAPSHOT/releases/all-releases.mdx
@@ -9,6 +9,9 @@ import ReleaseNotes2 from '/snippets/releases/1.12.3.mdx';
 import ReleaseNotes3 from '/snippets/releases/1.12.4.mdx';
 import ReleaseNotes4 from '/snippets/releases/1.12.5.mdx';
 import ReleaseNotes5 from '/snippets/releases/1.12.6.mdx';
+import ReleaseNotes6 from '/snippets/releases/1.12.7.mdx';
+import ReleaseNotes7 from '/snippets/releases/1.12.8.mdx';
+import ReleaseNotes8 from '/snippets/releases/1.12.9.mdx';
 import ReleaseNotes from '/snippets/releases/latest.mdx';
 
 
@@ -25,6 +28,12 @@ Learn how to upgrade your OpenMetadata instance to the latest stable release.
 </CardGroup>
 
 <ReleaseNotes />
+
+<ReleaseNotes8 />
+
+<ReleaseNotes7 />
+
+<ReleaseNotes6 />
 
 <ReleaseNotes5 />
 


### PR DESCRIPTION
## Summary

Done the following changes:
- Switched all verbs to present tense (`fixes`, `resolves`, `adds`)
- Expanded abbreviations on first use: MCP, CVE, XSS, SSO
- Standardized all section headings to parallel noun-phrase structure
- Replaced `&` with `and` in headings
- Updated descriptive link text for the full changelog link
- Minor punctuation and formatting clean-up throughout
- `#28570` → `#28594` for MCP custom properties in `get_entity_details`
- `#28400` → `#28543` for test suite pre-select existing test cases fix

Both original PR numbers returned 404 on GitHub.

## Test plan

- [ ] Verify both PR links resolve correctly on GitHub
