### PR TITLE
Docs: Remove Microsoft Fabric from 1.13.0 new connectors table

### DIFF
--- a/snippets/releases/1.13.0.mdx
+++ b/snippets/releases/1.13.0.mdx
@@ -79,7 +79,6 @@ New relation types: `relatedTo`, `synonym`, `antonym`, `broader`, `narrower`, `p
 
 | Connector | Type | Highlights |
 |-----------|------|-----------|
-| Microsoft Fabric | Database & Pipeline | Lineage, usage, and profiler |
 | Google Drive | Storage | Ingestion connector and example workflow |
 | Pub/Sub | Messaging | Test-connection support |
 | QuestDB | Database | — |

--- a/snippets/releases/latest.mdx
+++ b/snippets/releases/latest.mdx
@@ -79,7 +79,6 @@ New relation types: `relatedTo`, `synonym`, `antonym`, `broader`, `narrower`, `p
 
 | Connector | Type | Highlights |
 |-----------|------|-----------|
-| Microsoft Fabric | Database & Pipeline | Lineage, usage, and profiler |
 | Google Drive | Storage | Ingestion connector and example workflow |
 | Pub/Sub | Messaging | Test-connection support |
 | QuestDB | Database | — |


### PR DESCRIPTION
## Summary

- Removes the Microsoft Fabric row from the new connectors table in the 1.13.0 release notes
- Applied to both `snippets/releases/1.13.0.mdx` and `snippets/releases/latest.mdx`

## Test plan

- [ ] Verify the connectors table in 1.13.0 release notes renders correctly without the Microsoft Fabric row
