### PR TITLE
Docs: Clarify classificationFilterPattern format and useFqnForFiltering behavior

### DIFF
--- a/v1.12.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
+++ b/v1.12.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
@@ -40,9 +40,35 @@ The Auto Classification Workflow enables automatic tagging of sensitive informat
 - Controls whether sample rows are stored during ingestion.
 - If enabled, the specified number of rows (`sampleDataCount`) will be fetched for each table.
 
+### `classificationFilterPattern`
+
+Use this to scope the auto-classification run to only tables carrying a specific tag.
+
+The value you provide must match the **tag name** or **tag FQN** depending on the `useFqnForFiltering` setting:
+
+- **Default (`useFqnForFiltering: false`)** — match against the **tag name only**. For example, if your tag is `POV.Key Data Asset`, use `key data asset`:
+
+  ```yaml
+  classificationFilterPattern:
+    includes:
+      - "key data asset"
+  ```
+
+- **When `useFqnForFiltering: true`** — match against the full tag FQN in the format `Classification.TagName`:
+
+  ```yaml
+  classificationFilterPattern:
+    includes:
+      - "POV.Key Data Asset"
+  ```
+
+<Warning>
+Passing the FQN format (e.g., `POV.Key Data Asset`) when `useFqnForFiltering` is `false` (the default) will cause the filter to match nothing — all records will be skipped and the run will report 0 classified results.
+</Warning>
+
 ### `useFqnForFiltering`
-- When set to `true`, filtering patterns will be applied to the Fully Qualified Name of a table (e.g., `service_name.db_name.schema_name.table_name`).
-- When set to `false`, filtering applies only to raw table names.
+- When set to `true`, filtering patterns — including `classificationFilterPattern` — are matched against the Fully Qualified Name (e.g., `Classification.TagName`).
+- When set to `false` (default), filtering matches against raw names only (e.g., the tag name without the classification prefix).
 
 ## Auto Classification Workflow Execution
 

--- a/v1.12.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
+++ b/v1.12.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
@@ -63,12 +63,12 @@ The value you provide must match the **tag name** or **tag FQN** depending on th
   ```
 
 <Warning>
-**Important**: Passing the FQN format (e.g., `POV.Key Data Asset`) when `useFqnForFiltering` is `false` (the default) will cause the filter to match nothing — all records will be skipped and the run will report 0 classified results.
+**Important**: Passing the FQN format (for example, `POV.Key Data Asset`) when `useFqnForFiltering` is `false` (the default) will cause the filter to match nothing — all records will be skipped and the run will report zero classified results.
 </Warning>
 
 ### `useFqnForFiltering`
-- When set to `true`, filtering patterns — including `classificationFilterPattern` — are matched against the Fully Qualified Name (e.g., `Classification.TagName`).
-- When set to `false` (default), filtering matches against raw names only (e.g., the tag name without the classification prefix).
+- When set to `true`, filtering patterns — including `classificationFilterPattern` — are matched against the Fully Qualified Name (for example, `Classification.TagName`).
+- When set to `false` (default), filtering matches against raw names only (for example, the tag name without the classification prefix).
 
 ## Auto Classification Workflow Execution
 

--- a/v1.12.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
+++ b/v1.12.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
@@ -63,7 +63,7 @@ The value you provide must match the **tag name** or **tag FQN** depending on th
   ```
 
 <Warning>
-Passing the FQN format (e.g., `POV.Key Data Asset`) when `useFqnForFiltering` is `false` (the default) will cause the filter to match nothing — all records will be skipped and the run will report 0 classified results.
+**Important**: Passing the FQN format (e.g., `POV.Key Data Asset`) when `useFqnForFiltering` is `false` (the default) will cause the filter to match nothing — all records will be skipped and the run will report 0 classified results.
 </Warning>
 
 ### `useFqnForFiltering`

--- a/v1.13.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
+++ b/v1.13.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
@@ -40,9 +40,35 @@ The Auto Classification Workflow enables automatic tagging of sensitive informat
 - Controls whether sample rows are stored during ingestion.
 - If enabled, the specified number of rows (`sampleDataCount`) will be fetched for each table.
 
+### `classificationFilterPattern`
+
+Use this to scope the auto-classification run to only tables carrying a specific tag.
+
+The value you provide must match the **tag name** or **tag FQN** depending on the `useFqnForFiltering` setting:
+
+- **Default (`useFqnForFiltering: false`)** — match against the **tag name only**. For example, if your tag is `POV.Key Data Asset`, use `key data asset`:
+
+  ```yaml
+  classificationFilterPattern:
+    includes:
+      - "key data asset"
+  ```
+
+- **When `useFqnForFiltering: true`** — match against the full tag FQN in the format `Classification.TagName`:
+
+  ```yaml
+  classificationFilterPattern:
+    includes:
+      - "POV.Key Data Asset"
+  ```
+
+<Warning>
+Passing the FQN format (e.g., `POV.Key Data Asset`) when `useFqnForFiltering` is `false` (the default) will cause the filter to match nothing — all records will be skipped and the run will report 0 classified results.
+</Warning>
+
 ### `useFqnForFiltering`
-- When set to `true`, filtering patterns will be applied to the Fully Qualified Name of a table (e.g., `service_name.db_name.schema_name.table_name`).
-- When set to `false`, filtering applies only to raw table names.
+- When set to `true`, filtering patterns — including `classificationFilterPattern` — are matched against the Fully Qualified Name (e.g., `Classification.TagName`).
+- When set to `false` (default), filtering matches against raw names only (e.g., the tag name without the classification prefix).
 
 ## Auto Classification Workflow Execution
 

--- a/v1.13.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
+++ b/v1.13.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
@@ -63,12 +63,12 @@ The value you provide must match the **tag name** or **tag FQN** depending on th
   ```
 
 <Warning>
-**Important**: Passing the FQN format (e.g., `POV.Key Data Asset`) when `useFqnForFiltering` is `false` (the default) will cause the filter to match nothing — all records will be skipped and the run will report 0 classified results.
+**Important**: Passing the FQN format (for example, `POV.Key Data Asset`) when `useFqnForFiltering` is `false` (the default) will cause the filter to match nothing — all records will be skipped and the run will report zero classified results.
 </Warning>
 
 ### `useFqnForFiltering`
-- When set to `true`, filtering patterns — including `classificationFilterPattern` — are matched against the Fully Qualified Name (e.g., `Classification.TagName`).
-- When set to `false` (default), filtering matches against raw names only (e.g., the tag name without the classification prefix).
+- When set to `true`, filtering patterns — including `classificationFilterPattern` — are matched against the Fully Qualified Name (for example, `Classification.TagName`).
+- When set to `false` (default), filtering matches against raw names only (for example, the tag name without the classification prefix).
 
 ## Auto Classification Workflow Execution
 

--- a/v1.13.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
+++ b/v1.13.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
@@ -63,7 +63,7 @@ The value you provide must match the **tag name** or **tag FQN** depending on th
   ```
 
 <Warning>
-Passing the FQN format (e.g., `POV.Key Data Asset`) when `useFqnForFiltering` is `false` (the default) will cause the filter to match nothing — all records will be skipped and the run will report 0 classified results.
+**Important**: Passing the FQN format (e.g., `POV.Key Data Asset`) when `useFqnForFiltering` is `false` (the default) will cause the filter to match nothing — all records will be skipped and the run will report 0 classified results.
 </Warning>
 
 ### `useFqnForFiltering`

--- a/v2.0.x-SNAPSHOT/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
@@ -40,9 +40,35 @@ The Auto Classification Workflow enables automatic tagging of sensitive informat
 - Controls whether sample rows are stored during ingestion.
 - If enabled, the specified number of rows (`sampleDataCount`) will be fetched for each table.
 
+### `classificationFilterPattern`
+
+Use this to scope the auto-classification run to only tables carrying a specific tag.
+
+The value you provide must match the **tag name** or **tag FQN** depending on the `useFqnForFiltering` setting:
+
+- **Default (`useFqnForFiltering: false`)** — match against the **tag name only**. For example, if your tag is `POV.Key Data Asset`, use `key data asset`:
+
+  ```yaml
+  classificationFilterPattern:
+    includes:
+      - "key data asset"
+  ```
+
+- **When `useFqnForFiltering: true`** — match against the full tag FQN in the format `Classification.TagName`:
+
+  ```yaml
+  classificationFilterPattern:
+    includes:
+      - "POV.Key Data Asset"
+  ```
+
+<Warning>
+Passing the FQN format (e.g., `POV.Key Data Asset`) when `useFqnForFiltering` is `false` (the default) will cause the filter to match nothing — all records will be skipped and the run will report 0 classified results.
+</Warning>
+
 ### `useFqnForFiltering`
-- When set to `true`, filtering patterns will be applied to the Fully Qualified Name of a table (e.g., `service_name.db_name.schema_name.table_name`).
-- When set to `false`, filtering applies only to raw table names.
+- When set to `true`, filtering patterns — including `classificationFilterPattern` — are matched against the Fully Qualified Name (e.g., `Classification.TagName`).
+- When set to `false` (default), filtering matches against raw names only (e.g., the tag name without the classification prefix).
 
 ## Auto Classification Workflow Execution
 

--- a/v2.0.x-SNAPSHOT/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
@@ -63,12 +63,12 @@ The value you provide must match the **tag name** or **tag FQN** depending on th
   ```
 
 <Warning>
-**Important**: Passing the FQN format (e.g., `POV.Key Data Asset`) when `useFqnForFiltering` is `false` (the default) will cause the filter to match nothing — all records will be skipped and the run will report 0 classified results.
+**Important**: Passing the FQN format (for example, `POV.Key Data Asset`) when `useFqnForFiltering` is `false` (the default) will cause the filter to match nothing — all records will be skipped and the run will report zero classified results.
 </Warning>
 
 ### `useFqnForFiltering`
-- When set to `true`, filtering patterns — including `classificationFilterPattern` — are matched against the Fully Qualified Name (e.g., `Classification.TagName`).
-- When set to `false` (default), filtering matches against raw names only (e.g., the tag name without the classification prefix).
+- When set to `true`, filtering patterns — including `classificationFilterPattern` — are matched against the Fully Qualified Name (for example, `Classification.TagName`).
+- When set to `false` (default), filtering matches against raw names only (for example, the tag name without the classification prefix).
 
 ## Auto Classification Workflow Execution
 

--- a/v2.0.x-SNAPSHOT/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
@@ -63,7 +63,7 @@ The value you provide must match the **tag name** or **tag FQN** depending on th
   ```
 
 <Warning>
-Passing the FQN format (e.g., `POV.Key Data Asset`) when `useFqnForFiltering` is `false` (the default) will cause the filter to match nothing — all records will be skipped and the run will report 0 classified results.
+**Important**: Passing the FQN format (e.g., `POV.Key Data Asset`) when `useFqnForFiltering` is `false` (the default) will cause the filter to match nothing — all records will be skipped and the run will report 0 classified results.
 </Warning>
 
 ### `useFqnForFiltering`


### PR DESCRIPTION
## Summary

- Added a dedicated `classificationFilterPattern` section to the Auto Classification external workflow page for v1.12.x, v1.13.x, and v2.0.x-SNAPSHOT
<img width="2978" height="1680" alt="image" src="https://github.com/user-attachments/assets/068f4755-edd8-44c1-9d19-0f2c24e15bab" />

- Clarifies that by default (`useFqnForFiltering: false`), the filter value must be the **tag name only** (e.g., `key data asset`), not the FQN (e.g., `POV.Key Data Asset`)
- Adds a `<Warning>` callout explaining that passing the FQN format when `useFqnForFiltering` is `false` will silently filter out all records and return 0 classified results
- Updated `useFqnForFiltering` description to cross-reference `classificationFilterPattern`

## Related

Surfaced from customer issue where auto-classification ran successfully but processed 0 records because the classification filter pattern was set to the FQN format instead of the tag name.

## Test plan

- [ ] Verify the new section renders correctly in all three versions
- [ ] Confirm YAML examples display properly
- [ ] Confirm Warning block renders correctly
