### PR TITLE
[codex] Fix Iceberg classification docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -7181,11 +7181,6 @@
     {
       "source": "/v1.12.x/connectors/database/iceberg",
       "destination": "/v1.12.x/connectors/database/deltalake"
-    },
-    
-    {
-      "source": "/v1.13.x/connectors/database/iceberg",
-      "destination": "/v1.13.x/connectors/database/deltalake"
     }
   ],
   "api": {

--- a/v1.13.x/connectors/database/iceberg.mdx
+++ b/v1.13.x/connectors/database/iceberg.mdx
@@ -58,7 +58,7 @@ All connectors below surface Iceberg tables through your query engine. Connector
 | [Presto](/connectors/database/presto) | ✅ | ✅ |
 | [StarRocks](/connectors/database/starrocks) | ✅ | ✅ |
 | [Doris](/connectors/database/doris) | ✅ | ✅ |
-| [Databricks](/connectors/database/databricks) | ✅ | ✅ |
+| [Databricks](/connectors/database/databricks) | ✅ | Not yet supported |
 | [ClickHouse](/connectors/database/clickhouse) | ✅ | Not yet supported |
 
 The connector you use to bring in your regular tables also brings in the Iceberg-backed ones. Because those connectors have a live query path back to the engine, data quality tests, profiling, lineage, and usage statistics all work the same way they do for any other table.

--- a/v2.0.x-SNAPSHOT/connectors/database/iceberg.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/iceberg.mdx
@@ -54,7 +54,7 @@ So rather than building a separate integration path for every Iceberg catalog va
 | [Presto](/connectors/database/presto) | ✅ | ✅ |
 | [StarRocks](/connectors/database/starrocks) | ✅ | ✅ |
 | [Doris](/connectors/database/doris) | ✅ | ✅ |
-| [Databricks](/connectors/database/databricks) | ✅ | ✅ |
+| [Databricks](/connectors/database/databricks) | ✅ | Not yet supported |
 | [ClickHouse](/connectors/database/clickhouse) | ✅ | Not yet supported |
 
 The connector you use to bring in your regular tables also brings in the Iceberg-backed ones. Because those connectors have a live query path back to the engine, data quality tests, profiling, lineage, and usage statistics all work the same way they do for any other table.


### PR DESCRIPTION
## Summary
- mark Databricks Iceberg auto-classification as not yet supported in v1.13 and v2.0 docs
- remove the stale v1.13 Iceberg-to-Delta Lake redirect now that the Iceberg doc exists

## Why
The docs claimed Databricks-backed Iceberg tables are auto-classified as `Iceberg`, but the current ingestion implementation does not set that table type for Databricks/Unity Catalog.

## Validation
- `jq empty docs.json`
- `git diff --check`
- targeted `rg` checks for the Databricks row and removed redirect
- `rtk mint broken-links`
