### PR TITLE
Docs: Update 1.13 supported version references

### DIFF
--- a/snippets/deployment/faqs.mdx
+++ b/snippets/deployment/faqs.mdx
@@ -45,7 +45,7 @@ WORKDIR /home/
 COPY <my-organization-certs> .
 RUN update-ca-certificates
 ```
-where `docker.open-metadata.org/openmetadata/server:x.y.z` needs to point to the same version of the OpenMetadata server, for example `docker.open-metadata.org/openmetadata/server:1.3.1`.
+where `docker.open-metadata.org/openmetadata/server:x.y.z` needs to point to the same version of the OpenMetadata server, for example `docker.open-metadata.org/openmetadata/server:1.13.0`.
 This image needs to be built and published to the container registry of your choice.
 
 ### 2. Update your openmetadata helm values yaml
@@ -92,7 +92,7 @@ COPY setup.py .
 RUN pip install --no-deps .
 ```
 
-where `docker.open-metadata.org/openmetadata/ingestion:x.y.z` needs to point to the same version of the OpenMetadata server, for example `docker.open-metadata.org/openmetadata/ingestion:1.3.1`.
+where `docker.open-metadata.org/openmetadata/ingestion:x.y.z` needs to point to the same version of the OpenMetadata server, for example `docker.open-metadata.org/openmetadata/ingestion:1.13.0`.
 This image needs to be built and published to the container registry of your choice.
 
 ### 2. Update the airflow in openmetadata dependencies values YAML
@@ -106,7 +106,7 @@ airflow:
   airflow:
     image:
       repository: <your repository>  # by default, openmetadata/ingestion
-      tag: <your tag>  # by default, the version you are deploying, e.g., 1.1.0
+      tag: <your tag>  # by default, the version you are deploying, e.g., 1.13.0
       pullPolicy: "IfNotPresent"
 ```
 

--- a/snippets/deployment/faqs.mdx
+++ b/snippets/deployment/faqs.mdx
@@ -202,9 +202,9 @@ helm upgrade --install openmetadata open-metadata/openmetadata --values <<path-t
 
 Our OpenMetadata Dependencies Helm Charts are internally depends on three sub-charts -
 
-- [Bitnami MySQL](https://artifacthub.io/packages/helm/bitnami/mysql/9.7.2) (helm chart version 9.7.2)
-- [OpenSearch](https://artifacthub.io/packages/helm/opensearch-project-helm-charts/opensearch/2.12.2) (helm chart version 2.12.2)
-- [Airflow](https://artifacthub.io/packages/helm/airflow-helm/airflow/8.8.0) (helm chart version 8.8.0)
+- [Bitnami MySQL](https://artifacthub.io/packages/helm/bitnami/mysql/14.0.2) (helm chart version 14.0.2)
+- [OpenSearch](https://artifacthub.io/packages/helm/opensearch-project-helm-charts/opensearch/3.3.2) (helm chart version 3.3.2)
+- [Airflow](https://artifacthub.io/packages/helm/apache-airflow/airflow/1.18.0) (helm chart version 1.18.0)
 
 If you are looking to customize the deployments of any of the above dependencies, please refer to the above links for customizations of helm values for further references.
 

--- a/v1.13.x/api-reference/sdk/python.mdx
+++ b/v1.13.x/api-reference/sdk/python.mdx
@@ -15,10 +15,10 @@ We are now going to present a high-level Python API as a type-safe and gentle wr
 - The Python SDK is part of the `openmetadata-ingestion` base package. You can install it from [PyPI](https://pypi.org/project/openmetadata-ingestion/).
 
 - Make sure to use the same `openmetadata-ingestion` version as your server version. For example, if you have the OpenMetadata
-server at version 1.12.6, you will need to install:
+server at version 1.13.0, you will need to install:
 
 ```python
-pip install "openmetadata-ingestion~=1.12.6.0"
+pip install "openmetadata-ingestion~=1.13.0.0"
 ```
 
 </div>

--- a/v1.13.x/connectors/database/db2.mdx
+++ b/v1.13.x/connectors/database/db2.mdx
@@ -26,7 +26,7 @@ docker exec -it openmetadata_ingestion pip install '.[db2]'
 ```
 Using python pip, Please make sure you provide appropriate version of ingestion in below command
 ```code
- pip install 'openmetadata-ingestion[db2]==1.2.4.0'
+ pip install 'openmetadata-ingestion[db2]==1.13.0.0'
 ```
 </Warning>
 In this section, we provide guides and references to use the DB2 connector.

--- a/v1.13.x/connectors/drive/custom-drive.mdx
+++ b/v1.13.x/connectors/drive/custom-drive.mdx
@@ -148,7 +148,7 @@ To run your Custom Drive Connector inside Docker (e.g., with Airflow or directly
 
 ```Dockerfile
 
-FROM openmetadata/ingestion:1.10.0
+FROM openmetadata/ingestion:1.13.0
 
 WORKDIR ingestion
 USER airflow

--- a/v1.13.x/connectors/pipeline/airflow/gcp-composer.mdx
+++ b/v1.13.x/connectors/pipeline/airflow/gcp-composer.mdx
@@ -7,11 +7,9 @@ sidebarTitle: GCP Composer
 
 ## Requirements
 
-This approach has been last tested against:
-- Composer version 2.5.4
-- Airflow version 3.1.5
+Use a Cloud Composer environment that supports the Airflow version required by your OpenMetadata release. For OpenMetadata 1.13, the bundled ingestion image uses Airflow 3.2.1.
 
-It also requires the ingestion package to be at least `openmetadata-ingestion==1.2.4.3`.
+It also requires the ingestion package to match your OpenMetadata server version. For OpenMetadata 1.13, install `openmetadata-ingestion~=1.13.0.0`.
 
 There are 2 main approaches we can follow here to extract metadata from GCS. Both of them involve creating a DAG
 directly in your Composer instance, but the requirements and the steps to follow are going to be slightly different.
@@ -32,7 +30,7 @@ In any case, once the requirements are there, preparing the DAG is super straigh
 
 In your environment you will need to install the following packages:
 
-- `openmetadata-ingestion==x.y.z`, (e.g., `openmetadata-ingestion==1.2.4`).
+- `openmetadata-ingestion==x.y.z.w`, (for example, `openmetadata-ingestion==1.13.0.0`).
 - `sqlalchemy==1.4.27`: This is needed to align OpenMetadata version with the Composer internal requirements.
 
 **Note:** Make sure to use the `openmetadata-ingestion` version that matches the server version
@@ -214,7 +212,7 @@ with models.DAG(
         task_id="ingest",
         name="ingest",
         cmds=["python", "main.py"],
-        image="openmetadata/ingestion-base:0.13.2",
+        image="openmetadata/ingestion-base:1.13.0",
         namespace='default',
         env_vars={"config": config, "pipelineType": "metadata"},
         dag=dag,
@@ -229,8 +227,8 @@ You can name the task as you want (`task_id` and `name`). The important points h
 be changed, and the `env_vars`. The `main.py` script that gets shipped within the image will load the env vars
 as they are shown, so only modify the content of the config YAML, but not this dictionary.
 
-Note that the example uses the image `openmetadata/ingestion-base:0.13.2`. Update that accordingly for higher version
-once they are released. Also, the image version should be aligned with your OpenMetadata server version to avoid
+Note that the example uses the image `openmetadata/ingestion-base:1.13.0`. Update that accordingly for higher versions
+once they are released. The image version should be aligned with your OpenMetadata server version to avoid
 incompatibilities.
 
 ```python
@@ -238,7 +236,7 @@ KubernetesPodOperator(
     task_id="ingest",
     name="ingest",
     cmds=["python", "main.py"],
-    image="openmetadata/ingestion-base:0.13.2",
+    image="openmetadata/ingestion-base:1.13.0",
     namespace='default',
     env_vars={"config": config, "pipelineType": "metadata"},
     dag=dag,

--- a/v1.13.x/connectors/pipeline/airflow/lineage-backend.mdx
+++ b/v1.13.x/connectors/pipeline/airflow/lineage-backend.mdx
@@ -125,7 +125,7 @@ t2 and t3 as downstream tasks.
 
 ### Adding Lineage
 
-Airflow [Operators](https://airflow.apache.org/docs/apache-airflow/1.10.4/_api/airflow/models/baseoperator/index.html)
+Airflow [Operators](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/baseoperator/index.html)
 contain the attributes `inlets` and `outlets`. When creating our tasks, we can pass any of these two
 parameters as follows:
 

--- a/v1.13.x/deployment/bare-metal.mdx
+++ b/v1.13.x/deployment/bare-metal.mdx
@@ -53,21 +53,19 @@ You can refer a sample script [here](https://github.com/open-metadata/OpenMetada
 </Tip>
 
 
-## Elasticsearch (version 8.X)
+## Elasticsearch (version 9.x)
 
-OpenMetadata supports ElasticSearch version up to 8.11.4. To install or upgrade Elasticsearch to a supported version please see the instructions for your operating system at
+OpenMetadata supports ElasticSearch version 9.x. To install or upgrade Elasticsearch to a supported version, see the instructions for your operating system at
 [Installing ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html).
 
-Please follow the instructions here to [install ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/setup.html).
-
-If you are using AWS OpenSearch Service, OpenMetadata Supports AWS OpenSearch Service engine version up to 2.19. For more information on AWS OpenSearch Service, please visit the official docs [here](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html).
+If you are using AWS OpenSearch Service, OpenMetadata supports OpenSearch 3.x engine versions. For more information on AWS OpenSearch Service, see the official docs [here](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html).
 
 ## Airflow or other workflow schedulers
 
 OpenMetadata performs metadata ingestion using the Ingestion Framework. Learn more about how to deploy and manage
 the ingestion workflows [here](/v1.13.x/deployment/ingestion).
 
-OpenMetadata versions have specific Airflow compatibility requirements to ensure seamless metadata ingestion. OpenMetadata 1.5 supports Airflow 2.9, 1.6.4 supports Airflow 2.9.3, and 1.6.5 supports Airflow 2.10.5. Ensure that your Airflow version aligns with your OpenMetadata deployment to maintain stability and functionality.
+OpenMetadata versions have specific Airflow compatibility requirements to ensure seamless metadata ingestion. OpenMetadata 1.13 uses Airflow 3.2.1 for the bundled ingestion image. Ensure that your Airflow version aligns with your OpenMetadata deployment to maintain stability and functionality.
 
 ## Minimum Sizing Requirements
 
@@ -173,7 +171,7 @@ If you are running OpenMetadata in AWS, it is recommended to use [Amazon RDS](ht
 We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
-- Amazon OpenSearch (ElasticSearch) engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
+- Amazon OpenSearch Service engine version 3.x
 - Amazon RDS (PostgreSQL) engine version between 12 or higher
 
 For Production Systems, we recommend Amazon RDS to be in Multiple Availability Zones. For Amazon OpenSearch (or ElasticSearch) Service, we recommend Multiple Availability Zones with minimum 3 Master Nodes.

--- a/v1.13.x/deployment/docker.mdx
+++ b/v1.13.x/deployment/docker.mdx
@@ -104,7 +104,7 @@ This docker compose file contains only the docker compose services for OpenMetad
 You can also run the below command to fetch the docker compose file directly from the terminal -
 
 ```bash
-wget https://github.com/open-metadata/OpenMetadata/releases/download/1.12.6-release/docker-compose-openmetadata.yml
+wget https://github.com/open-metadata/OpenMetadata/releases/download/1.13.0-release/docker-compose-openmetadata.yml
 ```
 
 ### 3. Update Environment Variables required for OpenMetadata Dependencies
@@ -198,7 +198,7 @@ You can validate that all containers are up by running with command `docker ps`.
 ```commandline
 ❯ docker ps
 CONTAINER ID   IMAGE                                                  COMMAND                  CREATED          STATUS                    PORTS                                                            NAMES
-470cc8149826   openmetadata/server:1.12.6                              "./openmetadata-star…"   45 seconds ago   Up 43 seconds             3306/tcp, 9200/tcp, 9300/tcp, 0.0.0.0:8585-8586->8585-8586/tcp   openmetadata_server
+470cc8149826   openmetadata/server:1.13.0                             "./openmetadata-star…"   45 seconds ago   Up 43 seconds             3306/tcp, 9200/tcp, 9300/tcp, 0.0.0.0:8585-8586->8585-8586/tcp   openmetadata_server
 ```
 
 In a few seconds, you should be able to access the OpenMetadata UI at [http://localhost:8585](http://localhost:8585)

--- a/v1.13.x/deployment/docker/advanced.mdx
+++ b/v1.13.x/deployment/docker/advanced.mdx
@@ -56,7 +56,7 @@ If you are running OpenMetadata in AWS, it is recommended to use [Amazon RDS](ht
 We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
-- Amazon OpenSearch (ElasticSearch) engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
+- Amazon OpenSearch Service engine version 3.x
 - Amazon RDS (PostgreSQL) engine version 12 or higher
 
 Note:-

--- a/v1.13.x/deployment/ingestion/external/airflow-docker-virtualenv.mdx
+++ b/v1.13.x/deployment/ingestion/external/airflow-docker-virtualenv.mdx
@@ -48,7 +48,7 @@ with models.DAG(
 ) as dag:
     DockerOperator(
         command="python main.py",
-        image="openmetadata/ingestion-base:0.13.2",
+        image="openmetadata/ingestion-base:1.13.0",
         environment={"config": config, "pipelineType": "metadata"},
         docker_url="unix://var/run/docker.sock",  # To allow to start Docker. Needs chmod 666 permissions
         tty=True,
@@ -79,7 +79,7 @@ This ensures that Airflow uses the system timezone, which is particularly import
 
 ### Key Notes
 
-- **Image Version**: Ensure the Docker image version matches your OpenMetadata server version (e.g., `openmetadata/ingestion-base:0.13.2`).
+- **Image Version**: Ensure the Docker image version matches your OpenMetadata server version (for example, `openmetadata/ingestion-base:1.13.0`).
 - **Pipeline Types**: Set the `pipelineType` to `metadata`, `usage`, `lineage`, `profiler`, or other supported values.
 - **No Installation Required**: The `DockerOperator` eliminates the need to install dependencies directly on the Airflow host.
 
@@ -177,7 +177,7 @@ with DAG(
     ingest_task = PythonVirtualenvOperator(
         task_id="ingest_using_recipe",
         requirements=[
-            'openmetadata-ingestion[mysql]~=1.3.0',  # Specify any additional Python package dependencies
+            'openmetadata-ingestion[mysql]~=1.13.0.0',  # Specify any additional Python package dependencies
         ],
         system_site_packages=False,  # Set to True if you want to include system site-packages in the virtual environment
         python_version="3.9",  # Remove if necessary

--- a/v1.13.x/deployment/ingestion/external/airflow.mdx
+++ b/v1.13.x/deployment/ingestion/external/airflow.mdx
@@ -27,14 +27,14 @@ Install the `openmetadata-ingestion` package in your Airflow environment. This a
 #### Installation Command:
 
 ```
-pip3 install openmetadata-ingestion[&lt;plugin&gt;]==x.y.z
+pip3 install openmetadata-ingestion[&lt;plugin&gt;]==x.y.z.w
 ```
--Replace [&lt;plugin&gt;](https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/setup.py) with the sources to ingest, such as mysql, snowflake, or s3.
--Replace x.y.z with the OpenMetadata version matching your server (e.g., 1.6.1).
+- Replace [&lt;plugin&gt;](https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/setup.py) with the sources to ingest, such as mysql, snowflake, or s3.
+- Replace `x.y.z.w` with the OpenMetadata ingestion package version matching your server. For OpenMetadata 1.13.0, use 1.13.0.0.
 
 ### Example
 ```
-pip3 install openmetadata-ingestion[mysql,snowflake,s3]==1.6.1
+pip3 install openmetadata-ingestion[mysql,snowflake,s3]==1.13.0.0
 ```
 ### Example DAG
 

--- a/v1.13.x/deployment/ingestion/external/gcp-composer.mdx
+++ b/v1.13.x/deployment/ingestion/external/gcp-composer.mdx
@@ -14,11 +14,9 @@ import RunConnectorsClass from '/snippets/deployment/run-connectors-class.mdx'
 
 ## Requirements
 
-This approach has been last tested against:
-- Composer version 2.5.4
-- Airflow version 2.6.3
+Use a Cloud Composer environment that supports the Airflow version required by your OpenMetadata release. For OpenMetadata 1.13, the bundled ingestion image uses Airflow 3.2.1.
 
-It also requires the ingestion package to be at least `openmetadata-ingestion==1.3.1.0`.
+It also requires the ingestion package to match your OpenMetadata server version. For OpenMetadata 1.13, install `openmetadata-ingestion~=1.13.0.0`.
 
 ## Using the Python Operator
 
@@ -29,12 +27,12 @@ it will require you to install the packages and plugins directly on the host.
 
 In your environment you will need to install the following packages:
 
-- `openmetadata-ingestion[<plugins>]==x.y.z`.
+- `openmetadata-ingestion[<plugins>]==x.y.z.w`.
 - `sqlalchemy==1.4.27`: This is needed to align OpenMetadata version with the Composer internal requirements.
 
-Where `x.y.z` is the version of the OpenMetadata ingestion package. Note that the version needs to match the server version. If we are using the server at 1.1.0, then the ingestion package needs to also be 1.1.0.
+Where `x.y.z.w` is the version of the OpenMetadata ingestion package. The version needs to match the server version. For OpenMetadata 1.13.0, use 1.13.0.0.
 
-The plugin parameter is a list of the sources that we want to ingest. An example would look like this `openmetadata-ingestion[mysql,snowflake,s3]==1.1.0`.
+The plugin parameter is a list of the sources that we want to ingest. An example would look like this `openmetadata-ingestion[mysql,snowflake,s3]==1.13.0.0`.
 
 ### Prepare the DAG!
 
@@ -134,7 +132,7 @@ with models.DAG(
         task_id="ingest",
         name="ingest",
         cmds=["python", "main.py"],
-        image="openmetadata/ingestion-base:0.13.2",
+        image="openmetadata/ingestion-base:1.13.0",
         namespace='default',
         env_vars={"config": CONFIG, "pipelineType": "metadata"},
         dag=dag,
@@ -149,8 +147,8 @@ You can name the task as you want (`task_id` and `name`). The important points h
 be changed, and the `env_vars`. The `main.py` script that gets shipped within the image will load the env vars
 as they are shown, so only modify the content of the config YAML, but not this dictionary.
 
-Note that the example uses the image `openmetadata/ingestion-base:0.13.2`. Update that accordingly for higher version
-once they are released. Also, the image version should be aligned with your OpenMetadata server version to avoid
+Note that the example uses the image `openmetadata/ingestion-base:1.13.0`. Update that accordingly for higher versions
+once they are released. The image version should be aligned with your OpenMetadata server version to avoid
 incompatibilities.
 
 ```python
@@ -158,7 +156,7 @@ KubernetesPodOperator(
     task_id="ingest",
     name="ingest",
     cmds=["python", "main.py"],
-    image="openmetadata/ingestion-base:0.13.2",
+    image="openmetadata/ingestion-base:1.13.0",
     namespace='default',
     env_vars={"config": config, "pipelineType": "metadata"},
     dag=dag,

--- a/v1.13.x/deployment/ingestion/external/github-actions.mdx
+++ b/v1.13.x/deployment/ingestion/external/github-actions.mdx
@@ -120,7 +120,7 @@ jobs:
       run: |
         python -m venv env
         source env/bin/activate
-        pip install "openmetadata-ingestion[snowflake]==1.0.2.0"
+        pip install "openmetadata-ingestion[snowflake]==1.13.0.0"
 
     - name: Run Ingestion
       run: |

--- a/v1.13.x/deployment/ingestion/external/mwaa.mdx
+++ b/v1.13.x/deployment/ingestion/external/mwaa.mdx
@@ -42,12 +42,12 @@ OpenMetadata does not support using Amazon MWAA (Managed Workflows for Apache Ai
 To install the package, we need to update the `requirements.txt` file from the MWAA environment to add the following line:
 
 ```
-openmetadata-ingestion[<plugin>]==x.y.z
+openmetadata-ingestion[<plugin>]==x.y.z.w
 ```
 
-Where `x.y.z` is the version of the OpenMetadata ingestion package. Note that the version needs to match the server version. If we are using the server at 1.3.1, then the ingestion package needs to also be 1.3.1.
+Where `x.y.z.w` is the version of the OpenMetadata ingestion package. The version needs to match the server version. For OpenMetadata 1.13.0, use 1.13.0.0.
 
-The plugin parameter is a list of the sources that we want to ingest. An example would look like this `openmetadata-ingestion[mysql,snowflake,s3]==1.3.1`.
+The plugin parameter is a list of the sources that we want to ingest. An example would look like this `openmetadata-ingestion[mysql,snowflake,s3]==1.13.0.0`.
 
 A DAG deployed using a Python Operator would then look like follows
 
@@ -119,7 +119,7 @@ We will now describe the steps, following the official AWS documentation.
 
 - The cluster needs a task to run in `FARGATE` mode.
 - The required image is `docker.open-metadata.org/openmetadata/ingestion-base:x.y.z`
-  - The same logic as above applies. The `x.y.z` version needs to match the server version. For example, `docker.open-metadata.org/openmetadata/ingestion-base:1.3.1`
+  - The same logic as above applies. The `x.y.z` version needs to match the server version. For example, `docker.open-metadata.org/openmetadata/ingestion-base:1.13.0`
 
 We have tested this process with a Task Memory of 512MB and Task CPU (unit) of 256. This can be tuned depending on the amount of metadata that needs to be ingested.
 

--- a/v1.13.x/deployment/ingestion/external/mwaa/virtualenv.mdx
+++ b/v1.13.x/deployment/ingestion/external/mwaa/virtualenv.mdx
@@ -117,8 +117,8 @@ with DAG(
         task_id="ingest_redshift",
         python_callable=metadata_ingestion_workflow,
         requirements=['openmetadata-ingestion[redshift]~=1.13.0',
-            'apache-airflow==2.4.3',  # note, v2.4.3 is the first version that does not conflict with OpenMetadata's 'tabulate' requirements
-            'apache-airflow-providers-amazon==6.0.0',  # Amazon Airflow provider is necessary for MWAA
+            'apache-airflow==3.2.1',  # Match this to your MWAA Airflow version.
+            'apache-airflow-providers-amazon==9.25.0',  # Amazon Airflow provider is necessary for MWAA
             'watchtower',],
         system_site_packages=False,
         dag=dag,
@@ -129,7 +129,7 @@ Where you can update the YAML configuration and workflow classes accordingly. Fu
 run the ingestion can be found on the documentation (e.g., [Snowflake](/v1.13.x/connectors/database/snowflake)).
 
 You will also need to determine the OpenMetadata ingestion extras and Airflow providers you need. The OpenMetadata ingestion package should match your server minor version. For example, use a `1.13.x` ingestion package with a `1.13.x` server, and include the connector extras required by your YAML, such as `openmetadata-ingestion[mysql,snowflake,s3]~=1.13.0`.
-For Airflow providers, you will want to pull the provider versions from [the matching constraints file](https://raw.githubusercontent.com/apache/airflow/constraints-2.4.3/constraints-3.7.txt). Since this example installs Airflow Providers v2.4.3 on Python 3.7, we use that constraints file.
+For Airflow providers, pull the provider versions from [the matching constraints file](https://raw.githubusercontent.com/apache/airflow/constraints-3.2.1/constraints-3.12.txt). Since this example installs Airflow 3.2.1 on Python 3.12, we use that constraints file.
 
 Also note that the ingestion workflow function must be entirely self-contained as it will run by itself in the virtualenv. Any imports it needs, including the configuration, must exist within the function itself.
 

--- a/v1.13.x/deployment/ingestion/kubernetes.mdx
+++ b/v1.13.x/deployment/ingestion/kubernetes.mdx
@@ -94,7 +94,7 @@ omjobOperator:
   enabled: true
   image:
     repository: docker.getcollate.io/openmetadata/omjob-operator
-    tag: "1.12.0"
+    tag: "1.13.0"
     pullPolicy: IfNotPresent
   resources:
     requests:
@@ -116,7 +116,7 @@ openmetadata:
         useOMJobOperator: true
         
         # Container image for ingestion jobs
-        ingestionImage: "docker.getcollate.io/openmetadata/ingestion-base:1.12.0"
+        ingestionImage: "docker.getcollate.io/openmetadata/ingestion-base:1.13.0"
         imagePullPolicy: "IfNotPresent"
         imagePullSecrets: ""
         
@@ -224,7 +224,7 @@ openmetadata:
         useOMJobOperator: false
         
         # Container image for ingestion jobs
-        ingestionImage: "docker.getcollate.io/openmetadata/ingestion-base:1.12.0"
+        ingestionImage: "docker.getcollate.io/openmetadata/ingestion-base:1.13.0"
         imagePullPolicy: "IfNotPresent"
         imagePullSecrets: ""
         

--- a/v1.13.x/deployment/ingestion/openmetadata.mdx
+++ b/v1.13.x/deployment/ingestion/openmetadata.mdx
@@ -136,8 +136,8 @@ openmetadata:
 ## Custom Airflow Installation
 
 <Tip>
-- Note that the `openmetadata-ingestion` only supports Python versions 3.9, 3,10, and 3.11.
-- - The supported Airflow versions for OpenMetadata include 2.3, 2.4, 2.5, 2.6, and 2.7. Starting from release 1.6, OpenMetadata supports compatibility with Airflow versions up to 2.10.5. Specifically, OpenMetadata 1.5 supports Airflow 2.9, 1.6.4 supports Airflow 2.9.3, and 1.6.5 supports Airflow 2.10.5. Ensure that your Airflow version aligns with your OpenMetadata deployment for optimal performance.
+- Note that the `openmetadata-ingestion` package supports Python versions 3.9, 3.10, and 3.11.
+- For OpenMetadata 1.13, use Airflow 3.2.1 and install `openmetadata-ingestion` and `openmetadata-managed-apis` versions that match your OpenMetadata server.
 </Tip>
 
 You will need to follow three steps:

--- a/v1.13.x/deployment/ingestion/openmetadata/troubleshooting.mdx
+++ b/v1.13.x/deployment/ingestion/openmetadata/troubleshooting.mdx
@@ -131,9 +131,8 @@ We have specific instructions on how to set up the shared volumes in Kubernetes 
 
 The main root cause here is a version mismatch between the server and the client. Make sure that the `openmetadata-ingestion`
 python package you installed on the Airflow host has the same version as the OpenMetadata server. For example, to set up
-OpenMetadata server 0.13.2 you will need to install `openmetadata-ingestion~=0.13.2`. Note that we are validating
-the version as in `x.y.z`. Any differences after the PATCH versioning are not taken into account, as they are usually
-small bugfixes on existing functionalities.
+OpenMetadata server 1.13.0 you will need to install `openmetadata-ingestion~=1.13.0.0`. We validate compatibility at
+the OpenMetadata server version (`x.y.z`); the ingestion package uses a fourth build segment (`x.y.z.w`) for package releases.
 
 ### 401 Unauthorized
 

--- a/v1.13.x/deployment/kubernetes/aks-airflow.mdx
+++ b/v1.13.x/deployment/kubernetes/aks-airflow.mdx
@@ -208,7 +208,7 @@ openmetadata:
           secretKey: postgresql-password
 
 image:
-  tag: "1.12.0"
+  tag: "1.13.0"
 ```
 
 ```azure-cli

--- a/v1.13.x/deployment/kubernetes/aks.mdx
+++ b/v1.13.x/deployment/kubernetes/aks.mdx
@@ -132,7 +132,7 @@ openmetadata:
       metadataApiEndpoint: http://openmetadata.openmetadata.svc.cluster.local:8585/api
 
       k8s:
-        ingestionImage: "docker.getcollate.io/openmetadata/ingestion-base:1.12.0"
+        ingestionImage: "docker.getcollate.io/openmetadata/ingestion-base:1.13.0"
         useOMJobOperator: true
 
 # Enable the OMJob Operator (recommended for production)
@@ -140,10 +140,10 @@ omjobOperator:
   enabled: true
   image:
     repository: docker.getcollate.io/openmetadata/omjob-operator
-    tag: "1.12.0"
+    tag: "1.13.0"
 
 image:
-  tag: "1.12.0"
+  tag: "1.13.0"
 ```
 
 <Info>

--- a/v1.13.x/deployment/kubernetes/eks.mdx
+++ b/v1.13.x/deployment/kubernetes/eks.mdx
@@ -27,7 +27,7 @@ We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
 - Amazon RDS (PostgreSQL) engine version 12 or higher
-- Amazon OpenSearch engine version 2.X (upto 2.19)
+- Amazon OpenSearch engine version 3.x (minimum 3.0.0, recommended 3.4.0)
 
 <Tip>
 When using AWS Services the SearchType Configuration for elastic search should be `opensearch`, for both cases ElasticSearch and OpenSearch, as you can see in the ElasticSearch configuration example below.
@@ -97,7 +97,7 @@ openmetadata:
       metadataApiEndpoint: http://openmetadata:8585/api
 
       k8s:
-        ingestionImage: "docker.getcollate.io/openmetadata/ingestion-base:1.12.0"
+        ingestionImage: "docker.getcollate.io/openmetadata/ingestion-base:1.13.0"
         useOMJobOperator: true
 
 # Enable the OMJob Operator (recommended for production)
@@ -105,7 +105,7 @@ omjobOperator:
   enabled: true
   image:
     repository: docker.getcollate.io/openmetadata/omjob-operator
-    tag: "1.12.0"
+    tag: "1.13.0"
 ```
 
 <Info>

--- a/v1.13.x/deployment/kubernetes/gke.mdx
+++ b/v1.13.x/deployment/kubernetes/gke.mdx
@@ -34,7 +34,7 @@ It is recommended to use GCP [Cloud SQL](https://cloud.google.com/sql/) services
 We support -
 - Cloud SQL (MySQL) engine version 8 or higher
 - Cloud SQL (postgreSQL) engine version 12 or higher
-- ElasticSearch Engine version 8.X (upto 8.10.X)
+- ElasticSearch engine version 9.x (minimum 9.0.0, recommended 9.3.0)
 
 We recommend -
 - CloudSQL to be Multi Zone Available

--- a/v1.13.x/deployment/kubernetes/gke/airflow.mdx
+++ b/v1.13.x/deployment/kubernetes/gke/airflow.mdx
@@ -273,7 +273,7 @@ airflow:
 ```
 <Tip>
 
-For more information on airflow helm chart values, please refer to [airflow-helm](https://artifacthub.io/packages/helm/airflow-helm/airflow/8.8.0).
+For more information on airflow helm chart values, please refer to [airflow-helm](https://artifacthub.io/packages/helm/apache-airflow/airflow/1.18.0).
 
 When deploying openmeteadata dependencies helm chart, use the below command -
 

--- a/v1.13.x/deployment/kubernetes/on-prem.mdx
+++ b/v1.13.x/deployment/kubernetes/on-prem.mdx
@@ -24,7 +24,7 @@ We support
 
 - MySQL engine version 8 or higher
 - PostgreSQL engine version 12 or higher
-- ElasticSearch version 8.X (upto 8.11.4) or OpenSearch Version 2.X (upto 2.19)
+- ElasticSearch version 9.x (minimum 9.0.0) or OpenSearch version 3.x (minimum 3.0.0, recommended 3.4.0)
 
 Once you have the External Database and Search Engine configured, you can update the environment variables below for OpenMetadata kubernetes deployments to connect with Database and ElasticSearch.
 

--- a/v1.13.x/deployment/kubernetes/on-prem/airflow.mdx
+++ b/v1.13.x/deployment/kubernetes/on-prem/airflow.mdx
@@ -148,7 +148,7 @@ airflow:
       enabled: false
 ```
 
-For more information on airflow helm chart values, please refer to [airflow-helm](https://artifacthub.io/packages/helm/airflow-helm/airflow/8.8.0).
+For more information on airflow helm chart values, please refer to [airflow-helm](https://artifacthub.io/packages/helm/apache-airflow/airflow/1.18.0).
 
 When deploying openmetadata dependencies helm chart, use the below command -
 

--- a/v1.13.x/deployment/kubernetes/values.mdx
+++ b/v1.13.x/deployment/kubernetes/values.mdx
@@ -211,7 +211,7 @@ The OMJob Operator provides guaranteed exit handler execution. Required when `k8
 |-----|------|---------|-------------|
 | omjobOperator.enabled | bool | `false` | Install OMJob CRD and operator |
 | omjobOperator.image.repository | string | `docker.getcollate.io/openmetadata/omjob-operator` | Operator image |
-| omjobOperator.image.tag | string | `1.12.0-SNAPSHOT` | Operator image tag |
+| omjobOperator.image.tag | string | `1.13.0` | Operator image tag |
 | omjobOperator.image.pullPolicy | string | `IfNotPresent` | Image pull policy |
 | omjobOperator.resources.requests.cpu | string | `100m` | CPU request |
 | omjobOperator.resources.requests.memory | string | `128Mi` | Memory request |

--- a/v1.13.x/deployment/minimum-requirements.mdx
+++ b/v1.13.x/deployment/minimum-requirements.mdx
@@ -47,8 +47,8 @@ Our minimum specs recommendation for ElasticSearch / OpenSearch deployment is
 
 OpenMetadata currently supports -
 
-- ElasticSearch version 8.X till 8.11.4
-- OpenSearch version 2.19
+- ElasticSearch version 9.x (minimum 9.0.0, recommended 9.3.0)
+- OpenSearch version 3.x (minimum 3.0.0, recommended 3.4.0)
 
 These settings apply as well when using managed instances, such as AWS OpenSearch Service or Elastic Cloud on GCP, AWS, Azure.
 
@@ -62,6 +62,6 @@ Our minimum specs recommendation for Apache Airflow is
 ### Software Requirements
 
 OpenMetadata currently supports -
-- Airflow version 2.10.5
+- Airflow version 3.2.1
 
 Learn more about how to deploy and manage the ingestion workflows [here](/v1.13.x/deployment/ingestion).

--- a/v1.13.x/deployment/security/ldap/docker.mdx
+++ b/v1.13.x/deployment/security/ldap/docker.mdx
@@ -26,7 +26,7 @@ In `docker/docker-compose-quickstart/docker-compose.yml` file configure the volu
 For docker container to access cacerts, copy the cacerts to `docker/ldap/config` and add the path in volumes.
 ```shell
     volumes:
-      - docker/ldap/config/cacerts:/usr/lib/jvm/java-17-openjdk/lib/security/cacerts
+      - docker/ldap/config/cacerts:/usr/lib/jvm/java-21-openjdk/lib/security/cacerts
 ```
 
 ### **Using CustomTrustStore**
@@ -45,7 +45,7 @@ Create a docker file and add the following details based on the `truststoreConfi
    For docker container to access cacerts, copy the cacerts to `docker/ldap/config` as shown below.
 ```shell
 FROM docker.open-metadata.org/openmetadata/server:1.13.0
-COPY docker/ldap/config/cacerts /usr/lib/jvm/java-17-openjdk/lib/security/cacerts
+COPY docker/ldap/config/cacerts /usr/lib/jvm/java-21-openjdk/lib/security/cacerts
 ```
 
 ### **Using CustomTrustStore**

--- a/v1.13.x/deployment/security/ldap/docker.mdx
+++ b/v1.13.x/deployment/security/ldap/docker.mdx
@@ -44,14 +44,14 @@ Create a docker file and add the following details based on the `truststoreConfi
 ### **Using JVMDefault**
    For docker container to access cacerts, copy the cacerts to `docker/ldap/config` as shown below.
 ```shell
-FROM docker.open-metadata.org/openmetadata/server:0.13.2
+FROM docker.open-metadata.org/openmetadata/server:1.13.0
 COPY docker/ldap/config/cacerts /usr/lib/jvm/java-17-openjdk/lib/security/cacerts
 ```
 
 ### **Using CustomTrustStore**
    For docker container to access your truststore, copy the truststore to `docker/ldap/config` as shown below.
 ```shell
-FROM docker.open-metadata.org/openmetadata/server:0.13.2
+FROM docker.open-metadata.org/openmetadata/server:1.13.0
 COPY docker/ldap/config/{YOUR_TRUSTSTORE} /opt/openmetadata/ldap/truststore/{YOUR_TRUSTSTORE}
 ```
 

--- a/v1.13.x/deployment/upgrade.mdx
+++ b/v1.13.x/deployment/upgrade.mdx
@@ -10,7 +10,7 @@ import PostUpgradeSteps from '/snippets/deployment/upgrade/post-upgrade-steps.md
 
 # Upgrade OpenMetadata
 
-In this guide, you will find all the necessary information to safely upgrade your OpenMetadata instance to 1.12.6.
+In this guide, you will find all the necessary information to safely upgrade your OpenMetadata instance to 1.13.0.
 
 <UpgradePrerequisites />
 

--- a/v1.13.x/deployment/upgrade/bare-metal/steps.mdx
+++ b/v1.13.x/deployment/upgrade/bare-metal/steps.mdx
@@ -49,7 +49,7 @@ For example, to navigate into the directory created by issuing the tar command a
 command.
 
 ```commandline
-cd openmetadata-1.1.0
+cd openmetadata-1.13.0
 ```
 
 ## Step 4: Stop the OpenMetadata server

--- a/v1.13.x/deployment/upgrade/kubernetes.mdx
+++ b/v1.13.x/deployment/upgrade/kubernetes.mdx
@@ -50,12 +50,12 @@ Verify with the below command to see the latest release available locally.
 ```commandline
 helm search repo open-metadata --versions
 > NAME                                   	CHART VERSION	APP VERSION	DESCRIPTION
-open-metadata/openmetadata              1.3.1           1.3.1           A Helm chart for OpenMetadata on Kubernetes
-open-metadata/openmetadata              1.2.8           1.2.5           A Helm chart for OpenMetadata on Kubernetes
+open-metadata/openmetadata              1.13.0          1.13.0          A Helm chart for OpenMetadata on Kubernetes
+open-metadata/openmetadata              1.12.11         1.12.11         A Helm chart for OpenMetadata on Kubernetes
 
 ...
-open-metadata/openmetadata-dependencies 1.3.1           1.3.1           Helm Dependencies for OpenMetadata
-open-metadata/openmetadata-dependencies 1.2.8           1.2.5           Helm Dependencies for OpenMetadata
+open-metadata/openmetadata-dependencies 1.13.0          1.13.0          Helm Dependencies for OpenMetadata
+open-metadata/openmetadata-dependencies 1.12.11         1.12.11         Helm Dependencies for OpenMetadata
 ...
 ```
 

--- a/v1.13.x/quick-start/local-docker-deployment.mdx
+++ b/v1.13.x/quick-start/local-docker-deployment.mdx
@@ -120,15 +120,15 @@ The latest version is at the top of the page
 You can use the curl or wget command as well to fetch the docker compose files from your terminal -
 
 ```commandline
-curl -sL -o docker-compose.yml https://github.com/open-metadata/OpenMetadata/releases/download/1.12.6-release/docker-compose.yml
+curl -sL -o docker-compose.yml https://github.com/open-metadata/OpenMetadata/releases/download/1.13.0-release/docker-compose.yml
 
-curl -sL -o docker-compose-postgres.yml https://github.com/open-metadata/OpenMetadata/releases/download/1.12.6-release/docker-compose-postgres.yml
+curl -sL -o docker-compose-postgres.yml https://github.com/open-metadata/OpenMetadata/releases/download/1.13.0-release/docker-compose-postgres.yml
 ```
 
 ```commandline
-wget https://github.com/open-metadata/OpenMetadata/releases/download/1.12.6-release/docker-compose.yml
+wget https://github.com/open-metadata/OpenMetadata/releases/download/1.13.0-release/docker-compose.yml
 
-wget https://github.com/open-metadata/OpenMetadata/releases/download/1.12.6-release/docker-compose-postgres.yml
+wget https://github.com/open-metadata/OpenMetadata/releases/download/1.13.0-release/docker-compose-postgres.yml
 ```
 
 #### 3. Start the Docker Compose Services
@@ -167,10 +167,10 @@ You can validate that all containers are up by running with command `docker ps`.
 ```commandline
 ❯ docker ps
 CONTAINER ID   IMAGE                                                  COMMAND                  CREATED          STATUS                    PORTS                                                            NAMES
-470cc8149826   openmetadata/server:1.12.6                             "./openmetadata-star…"   45 seconds ago   Up 43 seconds             3306/tcp, 9200/tcp, 9300/tcp, 0.0.0.0:8585-8586->8585-8586/tcp   openmetadata_server
-63578aacbff5   openmetadata/ingestion:1.12.6                           "./ingestion_depende…"   45 seconds ago   Up 43 seconds             0.0.0.0:8080->8080/tcp                                           openmetadata_ingestion
-9f5ee8334f4b   docker.elastic.co/elasticsearch/elasticsearch:7.16.3   "/tini -- /usr/local…"   45 seconds ago   Up 44 seconds             0.0.0.0:9200->9200/tcp, 0.0.0.0:9300->9300/tcp                   openmetadata_elasticsearch
-08947ab3424b   openmetadata/db:1.12.6                                  "/entrypoint.sh mysq…"   45 seconds ago   Up 44 seconds (healthy)   3306/tcp, 33060-33061/tcp                                        openmetadata_mysql
+470cc8149826   openmetadata/server:1.13.0                            "./openmetadata-star…"   45 seconds ago   Up 43 seconds             3306/tcp, 9200/tcp, 9300/tcp, 0.0.0.0:8585-8586->8585-8586/tcp   openmetadata_server
+63578aacbff5   openmetadata/ingestion:1.13.0                         "./ingestion_depende…"   45 seconds ago   Up 43 seconds             0.0.0.0:8080->8080/tcp                                           openmetadata_ingestion
+9f5ee8334f4b   docker.elastic.co/elasticsearch/elasticsearch:9.3.0    "/bin/tini -- /usr/l…"   45 seconds ago   Up 44 seconds             0.0.0.0:9200->9200/tcp, 0.0.0.0:9300->9300/tcp                   openmetadata_elasticsearch
+08947ab3424b   openmetadata/db:1.13.0                                "/entrypoint.sh mysq…"   45 seconds ago   Up 44 seconds (healthy)   3306/tcp, 33060-33061/tcp                                        openmetadata_mysql
 ```
 
 In a few seconds, you should be able to access the OpenMetadata UI at [http://localhost:8585](http://localhost:8585)

--- a/v1.13.x/quick-start/local-kubernetes-deployment.mdx
+++ b/v1.13.x/quick-start/local-kubernetes-deployment.mdx
@@ -103,9 +103,9 @@ Please note that the pods names above as `openmetadata-dependencies-*` are part 
 </Tip>
 
 Helm Chart for OpenMetadata Dependencies uses the following helm charts:
-- [Bitnami MySQL](https://artifacthub.io/packages/helm/bitnami/mysql/9.7.2) (helm chart version 9.7.2)
-- [OpenSearch](https://artifacthub.io/packages/helm/opensearch-project-helm-charts/opensearch/2.12.2) (helm chart version 2.12.2)
-- [Airflow](https://artifacthub.io/packages/helm/airflow-helm/airflow/8.8.0) (helm chart version 8.8.0)
+- [Bitnami MySQL](https://artifacthub.io/packages/helm/bitnami/mysql/14.0.2) (helm chart version 14.0.2)
+- [OpenSearch](https://artifacthub.io/packages/helm/opensearch-project-helm-charts/opensearch/3.3.2) (helm chart version 3.3.2)
+- [Airflow](https://artifacthub.io/packages/helm/apache-airflow/airflow/1.18.0) (helm chart version 1.18.0)
 
 ### 5. Install OpenMetadata Helm Chart
 


### PR DESCRIPTION
## Summary
- Update 1.13 deployment requirements from Elasticsearch 8.x, OpenSearch 2.x, and Airflow 2.x examples to Elasticsearch 9.x, OpenSearch 3.x, and Airflow 3.2.1.
- Refresh active Docker, Kubernetes, external ingestion, MWAA, Composer, SDK, and connector snippets to OpenMetadata 1.13.0 and openmetadata-ingestion 1.13.0.0.
- Leave release notes and minimum-availability statements unchanged where older versions are historical context.

## Validation
- git diff --check
- rtk mint broken-links

## Source checks
- OpenMetadata 1.13 release compose/setup sources use Elasticsearch 9.3.0, OpenSearch 3.4.0, and Airflow 3.2.1.
- PyPI lists openmetadata-ingestion 1.13.0.0.