### PR TITLE
Docs: Add new MCP tools and restructure MCP reference pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1294,11 +1294,16 @@
                     ]
                   },
                   "v1.13.x/how-to-guides/mcp/reference",
-                  "v1.13.x/how-to-guides/mcp/claude",
-                  "v1.13.x/how-to-guides/mcp/claude-code",
-                  "v1.13.x/how-to-guides/mcp/goose",
-                  "v1.13.x/how-to-guides/mcp/cursor",
-                  "v1.13.x/how-to-guides/mcp/vscode",
+                  {
+                    "group": "Getting Started with MCP Clients",
+                    "pages": [
+                      "v1.13.x/how-to-guides/mcp/claude",
+                      "v1.13.x/how-to-guides/mcp/claude-code",
+                      "v1.13.x/how-to-guides/mcp/goose",
+                      "v1.13.x/how-to-guides/mcp/cursor",
+                      "v1.13.x/how-to-guides/mcp/vscode"
+                    ]
+                  },
                   "v1.13.x/how-to-guides/mcp/semantic-search"
                 ]
               }
@@ -3556,11 +3561,16 @@
                     ]
                   },
                   "v1.12.x/how-to-guides/mcp/reference",
-                  "v1.12.x/how-to-guides/mcp/claude",
-                  "v1.12.x/how-to-guides/mcp/claude-code",
-                  "v1.12.x/how-to-guides/mcp/goose",
-                  "v1.12.x/how-to-guides/mcp/cursor",
-                  "v1.12.x/how-to-guides/mcp/vscode",
+                  {
+                    "group": "Getting Started with MCP Clients",
+                    "pages": [
+                      "v1.12.x/how-to-guides/mcp/claude",
+                      "v1.12.x/how-to-guides/mcp/claude-code",
+                      "v1.12.x/how-to-guides/mcp/goose",
+                      "v1.12.x/how-to-guides/mcp/cursor",
+                      "v1.12.x/how-to-guides/mcp/vscode"
+                    ]
+                  },
                   "v1.12.x/how-to-guides/mcp/semantic-search"
                 ]
               }
@@ -5842,11 +5852,16 @@
                     ]
                   },
                   "v2.0.x-SNAPSHOT/how-to-guides/mcp/reference",
-                  "v2.0.x-SNAPSHOT/how-to-guides/mcp/claude",
-                  "v2.0.x-SNAPSHOT/how-to-guides/mcp/claude-code",
-                  "v2.0.x-SNAPSHOT/how-to-guides/mcp/goose",
-                  "v2.0.x-SNAPSHOT/how-to-guides/mcp/cursor",
-                  "v2.0.x-SNAPSHOT/how-to-guides/mcp/vscode",
+                  {
+                    "group": "Getting Started with MCP Clients",
+                    "pages": [
+                      "v2.0.x-SNAPSHOT/how-to-guides/mcp/claude",
+                      "v2.0.x-SNAPSHOT/how-to-guides/mcp/claude-code",
+                      "v2.0.x-SNAPSHOT/how-to-guides/mcp/goose",
+                      "v2.0.x-SNAPSHOT/how-to-guides/mcp/cursor",
+                      "v2.0.x-SNAPSHOT/how-to-guides/mcp/vscode"
+                    ]
+                  },
                   "v2.0.x-SNAPSHOT/how-to-guides/mcp/semantic-search"
                 ]
               }

--- a/v1.12.x/how-to-guides/mcp/claude-code.mdx
+++ b/v1.12.x/how-to-guides/mcp/claude-code.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Claude Code
 description: Connect your OpenMetadata MCP Server to Claude Code (CLI) for AI-powered metadata exploration from the terminal.
-sidebarTitle: Getting Started with Claude Code
+sidebarTitle: Claude Code
 ---
 
 # Getting Started with Claude Code

--- a/v1.12.x/how-to-guides/mcp/claude.mdx
+++ b/v1.12.x/how-to-guides/mcp/claude.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Claude Desktop
 description: Set up MCP Server to connect Claude Desktop with OAuth or PAT-based authentication for AI-powered access to your data.
-sidebarTitle: Getting Started with Claude Desktop
+sidebarTitle: Claude Desktop
 ---
 
 # Getting Started with Claude Desktop

--- a/v1.12.x/how-to-guides/mcp/cursor.mdx
+++ b/v1.12.x/how-to-guides/mcp/cursor.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Cursor
 description: Connect your OpenMetadata MCP Server to Cursor IDE with OAuth or PAT-based authentication for AI-powered metadata exploration.
-sidebarTitle: Getting Started with Cursor
+sidebarTitle: Cursor
 ---
 
 # Getting Started with Cursor

--- a/v1.12.x/how-to-guides/mcp/goose.mdx
+++ b/v1.12.x/how-to-guides/mcp/goose.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Goose Desktop
 description: Learn how to connect Goose Desktop with MCP Server, create tokens, and enable secure AI-powered access to your data platform.
-sidebarTitle: Getting Started with Goose Desktop
+sidebarTitle: Goose Desktop
 ---
 
 # Getting Started with Goose Desktop

--- a/v1.12.x/how-to-guides/mcp/reference.mdx
+++ b/v1.12.x/how-to-guides/mcp/reference.mdx
@@ -11,10 +11,10 @@ All OpenMetadata MCP tools, with parameters and examples.
 
 | Category | Tools |
 |---|---|
-| **Discover** | [search_metadata](#search_metadata), [semantic_search](#semantic_search), [search_company_context](#search_company_context) |
-| **Inspect** | [get_entity_details](#get_entity_details), [get_company_context](#get_company_context) |
+| **Discover** | [search_metadata](#search_metadata), [semantic_search](#semantic_search) |
+| **Inspect** | [get_entity_details](#get_entity_details) |
 | **Lineage & Impact** | [get_entity_lineage](#get_entity_lineage), [create_lineage](#create_lineage), [root_cause_analysis](#root_cause_analysis) |
-| **Knowledge** | [create_glossary](#create_glossary), [create_glossary_term](#create_glossary_term), [create_context_memory](#create_context_memory) |
+| **Knowledge** | [create_glossary](#create_glossary), [create_glossary_term](#create_glossary_term) |
 | **Govern & Classify** | [create_classification](#create_classification), [create_tag](#create_tag), [create_domain](#create_domain), [create_data_product](#create_data_product), [patch_entity](#patch_entity) |
 | **Data Quality** | [get_test_definitions](#get_test_definitions), [create_test_case](#create_test_case) |
 | **Metrics** | [create_metric](#create_metric) |
@@ -185,34 +185,6 @@ Search and find data assets across your catalog using keyword, semantic, or natu
 }
 ```
 
-### search_company_context
-
-**Description**: Semantic search over company context knowledge pills from the Context Center. Returns matching pills with their title, question, answer, summary, and source file. Use this to answer questions from company documents, runbooks, FAQs, and policies.
-
-**Parameters**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `query` | string | Yes | Natural-language question or topic to find relevant company knowledge for |
-| `size` | integer | No | Number of pills to return. Default is 10, maximum is 50 |
-
-**Example**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "search_company_context",
-    "arguments": {
-      "query": "data retention policy",
-      "size": 5
-    }
-  }
-}
-```
-
 ## Inspect
 
 Retrieve detailed information about specific entities and company knowledge pills.
@@ -277,32 +249,6 @@ Retrieve detailed information about specific entities and company knowledge pill
         "text": "## Table: customer_orders\n\n**FQN**: mysql_prod.ecommerce.public.customer_orders\n**Service**: mysql_prod (MySQL)\n**Database**: ecommerce | **Schema**: public\n**Description**: Stores all customer order transactions\n\n**Owners**: ecommerce-team, sarah.johnson@company.com\n**Tags**: PII, Financial, Customer-Data | **Tier**: Tier1\n\n**Columns** (5):\n- order_id (BIGINT) - Primary key\n- customer_id (BIGINT) - FK to customer table\n- order_date (TIMESTAMP)\n- total_amount (DECIMAL)\n- status (VARCHAR)"
       }
     ]
-  }
-}
-```
-
-### get_company_context
-
-**Description**: Fetch a single company context knowledge pill by its fully qualified name. Returns the full title, question, answer, summary, and source file. Use the `fullyQualifiedName` or `name` returned by `search_company_context`.
-
-**Parameters**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `fqn` | string | Yes | The `fullyQualifiedName` or `name` of the knowledge pill from a `search_company_context` result. Pass it verbatim |
-
-**Example**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "get_company_context",
-    "arguments": {
-      "fqn": "data-retention-policy.gdpr-rules"
-    }
   }
 }
 ```
@@ -563,47 +509,6 @@ Create and manage glossaries, terms, and reusable context memories.
       "name": "Organic CAC",
       "description": "Customer acquisition cost for customers acquired through organic channels (SEO, word of mouth) without paid advertising",
       "owners": ["marketing-team"]
-    }
-  }
-}
-```
-
-### create_context_memory
-
-**Description**: Save a reusable piece of knowledge to the Context Center — a preference, instruction, runbook step, or FAQ answer the assistant should retain across conversations. Use this when the user explicitly asks you to remember, note, or store something.
-
-**Parameters**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `name` | string | Yes | Stable, unique system name. Reusing an existing name updates that memory |
-| `question` | string | Yes | The canonical question or instruction this memory represents |
-| `answer` | string | Yes | The canonical answer or guidance to retain |
-| `title` | string | No | Short human-readable title shown in the Context Center |
-| `summary` | string | No | One-line summary of the memory |
-| `memoryType` | string | No | `Preference`, `UseCase`, `Note`, `Runbook`, or `Faq`. Defaults to `Note` |
-| `memoryScope` | string | No | `UserGlobal` (broad) or `EntityScoped` (tied to a specific entity) |
-| `owners` | array | No | OpenMetadata usernames or team names |
-| `tags` | array | No | Tag FQNs to apply |
-| `domains` | array | No | Domain FQNs this memory belongs to |
-
-**Example**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "create_context_memory",
-    "arguments": {
-      "name": "finance-warehouse-preference",
-      "title": "Finance Dashboard Warehouse",
-      "question": "Which warehouse should finance dashboards query?",
-      "answer": "Always query the FINANCE_PROD warehouse for finance dashboards.",
-      "memoryType": "Preference",
-      "memoryScope": "UserGlobal",
-      "domains": ["Finance"]
     }
   }
 }

--- a/v1.12.x/how-to-guides/mcp/reference.mdx
+++ b/v1.12.x/how-to-guides/mcp/reference.mdx
@@ -9,28 +9,19 @@ All OpenMetadata MCP tools, with parameters and examples.
 
 ## Available Tools
 
-| Tool | Category | Description |
-|------|----------|-------------|
-| [`search_metadata`](#search_metadata) | Discovery | Keyword-based search for data assets and business terms |
-| [`semantic_search`](#semantic_search) | Discovery | Meaning-based search using vector embeddings |
-| [`get_entity_details`](#get_entity_details) | Discovery | Retrieve full details for a specific entity by FQN |
-| [`patch_entity`](#patch_entity) | Governance | Update an existing entity using JSON Patch |
-| [`create_glossary`](#create_glossary) | Governance | Create a new glossary to organize business terms |
-| [`create_glossary_term`](#create_glossary_term) | Governance | Add a term to an existing glossary |
-| [`create_metric`](#create_metric) | Governance | Create a new metric entity |
-| [`create_classification`](#create_classification) | Governance | Create a new tag classification (top-level tag container) |
-| [`create_tag`](#create_tag) | Governance | Create a new tag within an existing classification |
-| [`create_domain`](#create_domain) | Governance | Create a new domain for grouping data assets |
-| [`create_data_product`](#create_data_product) | Governance | Create a new data product within one or more domains |
-| [`get_entity_lineage`](#get_entity_lineage) | Lineage | Explore upstream/downstream dependencies |
-| [`create_lineage`](#create_lineage) | Lineage | Create a lineage relationship between two entities |
-| [`get_test_definitions`](#get_test_definitions) | Data Quality | List available test definitions for tables or columns |
-| [`create_test_case`](#create_test_case) | Data Quality | Create a data quality test for a table or column |
-| [`root_cause_analysis`](#root_cause_analysis) | Data Quality | Perform root cause analysis via data quality lineage |
+| Category | Tools |
+|---|---|
+| **Discover** | [search_metadata](#search_metadata), [semantic_search](#semantic_search), [search_company_context](#search_company_context) |
+| **Inspect** | [get_entity_details](#get_entity_details), [get_company_context](#get_company_context) |
+| **Lineage & Impact** | [get_entity_lineage](#get_entity_lineage), [create_lineage](#create_lineage), [root_cause_analysis](#root_cause_analysis) |
+| **Knowledge** | [create_glossary](#create_glossary), [create_glossary_term](#create_glossary_term), [create_context_memory](#create_context_memory) |
+| **Govern & Classify** | [create_classification](#create_classification), [create_tag](#create_tag), [create_domain](#create_domain), [create_data_product](#create_data_product), [patch_entity](#patch_entity) |
+| **Data Quality** | [get_test_definitions](#get_test_definitions), [create_test_case](#create_test_case) |
+| **Metrics** | [create_metric](#create_metric) |
 
----
+## Discover
 
-## Discovery & Search Tools
+Search and find data assets across your catalog using keyword, semantic, or natural language queries.
 
 ### search_metadata
 
@@ -42,7 +33,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 - Search for glossary terms
 - Locate pipelines by name or description
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -56,15 +47,14 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `includeAggregations` | boolean | No | Include aggregation/facet data (default: false) |
 | `maxAggregationBuckets` | integer | No | Max buckets per aggregation (default: 10, max: 50) |
 
-#### Entity Types
-
+**Entity Types**
 - **Service Entities**: `databaseService`, `messagingService`, `apiService`, `dashboardService`, `pipelineService`, `storageService`, `mlmodelService`, `metadataService`, `searchService`
 - **Data Asset Entities**: `apiCollection`, `apiEndpoint`, `table`, `storedProcedure`, `database`, `databaseSchema`, `dashboard`, `dashboardDataModel`, `pipeline`, `chart`, `topic`, `searchIndex`, `mlmodel`, `container`
 - **User Entities**: `user`, `team`
 - **Domain Entities**: `domain`, `dataProduct`
 - **Governance Entities**: `metric`, `glossary`, `glossaryTerm`
 
-#### Examples
+**Examples**
 
 **Basic Search**:
 
@@ -136,8 +126,6 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### semantic_search
 
 **Description**: Find data assets by meaning using vector search ([setup guide](../../deployment/semantic-search#enable-semantic-search)). Use for exploratory queries where you don't know exact names. Returns conceptually related assets even when no keywords match.
@@ -147,7 +135,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 - Find assets related to a concept (e.g., "customer spending behavior")
 - Discover hidden relationships across services
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -157,7 +145,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `k` | integer | No | KNN neighbor count for tuning result quality (default: 100) |
 | `threshold` | number | No | Minimum similarity score 0.0–1.0 (default: 0.0) |
 
-#### Examples
+**Examples**
 
 **Conceptual Search**:
 
@@ -197,20 +185,50 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
+### search_company_context
+
+**Description**: Semantic search over company context knowledge pills from the Context Center. Returns matching pills with their title, question, answer, summary, and source file. Use this to answer questions from company documents, runbooks, FAQs, and policies.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Natural-language question or topic to find relevant company knowledge for |
+| `size` | integer | No | Number of pills to return. Default is 10, maximum is 50 |
+
+**Example**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "search_company_context",
+    "arguments": {
+      "query": "data retention policy",
+      "size": 5
+    }
+  }
+}
+```
+
+## Inspect
+
+Retrieve detailed information about specific entities and company knowledge pills.
 
 ### get_entity_details
 
 **Description**: Retrieve full details for a specific entity by fully qualified name (FQN). Pass the exact `fullyQualifiedName` value from search results — do not construct FQNs manually.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `entityType` | string | Yes | Type of entity (e.g., `table`, `dashboard`, `topic`, `pipeline`) |
 | `fqn` | string | Yes | Fully qualified name — use the exact value from `search_metadata` or `semantic_search` results |
 
-#### Examples
+**Examples**
 
 **Get Table Details**:
 
@@ -263,15 +281,17 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
+### get_company_context
 
-## Governance Tools
+**Description**: Fetch a single company context knowledge pill by its fully qualified name. Returns the full title, question, answer, summary, and source file. Use the `fullyQualifiedName` or `name` returned by `search_company_context`.
 
-### patch_entity
+**Parameters**
 
-**Description**: Update an existing entity's properties using [JSON Patch](https://jsonpatch.com/) (RFC 6902). Use `get_entity_details` first to retrieve the current state before constructing a patch.
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `fqn` | string | Yes | The `fullyQualifiedName` or `name` of the knowledge pill from a `search_company_context` result. Pass it verbatim |
 
-#### Example
+**Example**
 
 ```json
 {
@@ -279,23 +299,152 @@ All OpenMetadata MCP tools, with parameters and examples.
   "id": 1,
   "method": "tools/call",
   "params": {
-    "name": "patch_entity",
+    "name": "get_company_context",
     "arguments": {
-      "entityType": "table",
-      "fqn": "mysql_prod.ecommerce.public.customer_orders",
-      "patch": "[{\"op\":\"replace\",\"path\":\"/description\",\"value\":\"Updated description for customer orders table.\"}]"
+      "fqn": "data-retention-policy.gdpr-rules"
     }
   }
 }
 ```
 
----
+## Lineage & Impact
+
+Explore data dependencies, trace upstream sources, and analyze downstream impact.
+
+### get_entity_lineage
+
+**Description**: Retrieve upstream and downstream lineage for any entity to understand data dependencies and perform impact analysis. Pass the exact `fullyQualifiedName` from search results.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `entityType` | string | Yes | Type of entity |
+| `fqn` | string | Yes | Fully qualified name of the entity |
+| `upstreamDepth` | integer | No | Hops to traverse upstream (default: 3, max: 10) |
+| `downstreamDepth` | integer | No | Hops to traverse downstream (default: 3, max: 10) |
+| `includeColumnLineage` | boolean | No | Include column-level lineage mappings. Default is `false` (table-level only) |
+
+**Examples**
+
+**Get Full Lineage**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "get_entity_lineage",
+    "arguments": {
+      "entityType": "table",
+      "fqn": "mysql_prod.ecommerce.public.sales_transactions",
+      "upstreamDepth": 3,
+      "downstreamDepth": 3
+    }
+  }
+}
+```
+
+**Downstream-Focused Impact Analysis**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "get_entity_lineage",
+    "arguments": {
+      "entityType": "table",
+      "fqn": "mysql_prod.ecommerce.public.sales_transactions",
+      "upstreamDepth": 1,
+      "downstreamDepth": 5
+    }
+  }
+}
+```
+
+### create_lineage
+
+**Description**: Create a lineage relationship between two entities. Requires the `id` (UUID) and `type` of both the source and destination entities.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `fromEntity` | object | Yes | Source entity with `type` (string) and `id` (UUID string) |
+| `toEntity` | object | Yes | Destination entity with `type` (string) and `id` (UUID string) |
+
+**Example**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "create_lineage",
+    "arguments": {
+      "fromEntity": {
+        "type": "table",
+        "id": "3a1b2c3d-4e5f-6789-abcd-ef0123456789"
+      },
+      "toEntity": {
+        "type": "table",
+        "id": "9f8e7d6c-5b4a-3210-fedc-ba9876543210"
+      }
+    }
+  }
+}
+```
+
+> **Tip**: Retrieve entity UUIDs from `get_entity_details` results before calling `create_lineage`.
+
+### root_cause_analysis
+
+**Description**: Trace a data quality failure back to its origin by traversing data quality lineage across pipeline hops.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `fqn` | string | Yes | FQN of the entity where failure was detected |
+| `entityType` | string | Yes | Entity type to analyze (for example, `table`) |
+| `upstreamDepth` | integer | No | Hops to traverse upstream (default: 3, max: 10) |
+| `downstreamDepth` | integer | No | Hops to traverse downstream (default: 3, max: 10) |
+| `queryFilter` | string | No | Optional OpenSearch DSL filter JSON |
+| `includeDeleted` | boolean | No | Include deleted entities in traversal (default: false) |
+
+**Example**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 12,
+  "method": "tools/call",
+  "params": {
+    "name": "root_cause_analysis",
+    "arguments": {
+      "fqn": "mysql_prod.ecommerce.public.customer_orders",
+      "entityType": "table",
+      "upstreamDepth": 4,
+      "downstreamDepth": 1,
+      "includeDeleted": false
+    }
+  }
+}
+```
+
+## Knowledge
+
+Create and manage glossaries, terms, and reusable context memories.
 
 ### create_glossary
 
 **Description**: Create a new glossary to organize business terms. Set `mutuallyExclusive: true` to restrict entities to a single term from the glossary at a time.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -305,7 +454,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `owners` | array | No | List of owner usernames or emails |
 | `reviewers` | array | No | List of reviewer usernames or emails |
 
-#### Examples
+**Examples**
 
 **Create a Business Glossary**:
 
@@ -363,13 +512,11 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### create_glossary_term
 
 **Description**: Create a new term within an existing glossary. Supports hierarchical parent–child relationships between terms.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -380,7 +527,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `owners` | array | No | List of owner usernames or emails |
 | `reviewers` | array | No | List of reviewer usernames or emails |
 
-#### Examples
+**Examples**
 
 **Create a Root-Level Term**:
 
@@ -421,65 +568,56 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
+### create_context_memory
 
-### create_metric
+**Description**: Save a reusable piece of knowledge to the Context Center — a preference, instruction, runbook step, or FAQ answer the assistant should retain across conversations. Use this when the user explicitly asks you to remember, note, or store something.
 
-**Description**: Create a new metric entity in OpenMetadata to track and standardize business KPIs.
-
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `name` | string | Yes | Name of the metric |
-| `description` | string | No | Description of the metric in Markdown format |
-| `displayName` | string | No | Human-readable display name for the metric |
-| `metricExpressionLanguage` | string | Yes | Expression language used for the metric (for example, `SQL`) |
-| `metricExpressionCode` | string | Yes | Metric formula/expression in the selected language |
-| `metricType` | string | No | Metric type such as `COUNT`, `SUM`, `AVERAGE`, `RATIO`, or `OTHER` |
-| `granularity` | string | No | Time granularity such as `DAY`, `WEEK`, `MONTH`, `QUARTER`, or `YEAR` |
-| `unitOfMeasurement` | string | No | Unit of measurement such as `COUNT`, `DOLLARS`, `PERCENTAGE`, or `OTHER` |
-| `customUnitOfMeasurement` | string | No | Custom unit string, required when `unitOfMeasurement` is `OTHER` |
-| `owners` | array | No | List of owner usernames or emails |
-| `reviewers` | array | No | List of reviewer usernames or emails |
-| `relatedMetrics` | array | No | List of related metric FQNs |
-| `tags` | array | No | List of tags to apply |
-| `domains` | array | No | List of domains to associate |
+| `name` | string | Yes | Stable, unique system name. Reusing an existing name updates that memory |
+| `question` | string | Yes | The canonical question or instruction this memory represents |
+| `answer` | string | Yes | The canonical answer or guidance to retain |
+| `title` | string | No | Short human-readable title shown in the Context Center |
+| `summary` | string | No | One-line summary of the memory |
+| `memoryType` | string | No | `Preference`, `UseCase`, `Note`, `Runbook`, or `Faq`. Defaults to `Note` |
+| `memoryScope` | string | No | `UserGlobal` (broad) or `EntityScoped` (tied to a specific entity) |
+| `owners` | array | No | OpenMetadata usernames or team names |
+| `tags` | array | No | Tag FQNs to apply |
+| `domains` | array | No | Domain FQNs this memory belongs to |
 
-#### Example
+**Example**
 
 ```json
 {
   "jsonrpc": "2.0",
-  "id": 10,
+  "id": 1,
   "method": "tools/call",
   "params": {
-    "name": "create_metric",
+    "name": "create_context_memory",
     "arguments": {
-      "name": "monthly_recurring_revenue",
-      "displayName": "Monthly Recurring Revenue",
-      "description": "Monthly recurring revenue from active subscriptions.",
-      "metricExpressionLanguage": "SQL",
-      "metricExpressionCode": "SUM(subscription_amount)",
-      "metricType": "SUM",
-      "granularity": "MONTH",
-      "unitOfMeasurement": "DOLLARS",
-      "owners": ["finance-team"],
-      "reviewers": ["data-governance-team"],
-      "tags": ["Finance", "KPI"],
-      "domains": ["Revenue"]
+      "name": "finance-warehouse-preference",
+      "title": "Finance Dashboard Warehouse",
+      "question": "Which warehouse should finance dashboards query?",
+      "answer": "Always query the FINANCE_PROD warehouse for finance dashboards.",
+      "memoryType": "Preference",
+      "memoryScope": "UserGlobal",
+      "domains": ["Finance"]
     }
   }
 }
 ```
 
----
+## Govern & Classify
+
+Define and apply classifications, tags, domains, data products, and entity updates.
 
 ### create_classification
 
 **Description**: Create a new Classification in OpenMetadata. A Classification is a top-level container that groups related Tags (e.g., `PII`, `Tier`). The `name` becomes the root segment of every tag FQN under it. The `mutuallyExclusive` flag is immutable once the classification exists.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -491,7 +629,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
 | `domains` | array | No | FQNs of domains this classification belongs to. Each domain must already exist. |
 
-#### Example
+**Example**
 
 ```json
 {
@@ -511,13 +649,11 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### create_tag
 
 **Description**: Create a new Tag inside a Classification in OpenMetadata. The tag FQN is `Classification.TagName` (e.g., `PII.Sensitive`). At least one of `classification` or `parent` must be provided.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -531,7 +667,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
 | `domains` | array | No | FQNs of domains this tag belongs to. Each domain must already exist. |
 
-#### Examples
+**Examples**
 
 **Create a top-level tag**:
 
@@ -569,13 +705,11 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### create_domain
 
 **Description**: Create a new Domain in OpenMetadata. A Domain is a top-level governance grouping of data assets. To create a child domain, set `parent` to the FQN of an existing parent domain. `domainType` defaults to `Aggregate` if omitted.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -588,7 +722,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `owners` | array | No | OpenMetadata usernames or team names to set as owners. Each must already exist. |
 | `tags` | array | No | Tag FQNs to apply to this domain (e.g., `Tier.Tier1`). |
 
-#### Examples
+**Examples**
 
 **Create a top-level domain**:
 
@@ -629,13 +763,11 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### create_data_product
 
 **Description**: Create a new Data Product in OpenMetadata. A Data Product groups data assets that deliver business value and must belong to at least one Domain. All referenced domain FQNs must already exist.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -648,7 +780,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
 | `tags` | array | No | Tag FQNs to apply to this data product (e.g., `Tier.Tier1`, `PII.Sensitive`). |
 
-#### Example
+**Example**
 
 ```json
 {
@@ -670,26 +802,19 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
+### patch_entity
 
-## Lineage Tools
+**Description**: Update an existing entity's properties using [JSON Patch](https://jsonpatch.com/) (RFC 6902). Use `get_entity_details` first to retrieve the current state before constructing a patch.
 
-### get_entity_lineage
-
-**Description**: Retrieve upstream and downstream lineage for any entity to understand data dependencies and perform impact analysis. Pass the exact `fullyQualifiedName` from search results.
-
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `entityType` | string | Yes | Type of entity |
-| `fqn` | string | Yes | Fully qualified name of the entity |
-| `upstreamDepth` | integer | No | Hops to traverse upstream (default: 3, max: 10) |
-| `downstreamDepth` | integer | No | Hops to traverse downstream (default: 3, max: 10) |
+| `entityType` | string | Yes | Type of entity to patch (e.g., `table`, `glossaryTerm`) |
+| `fqn` | string | Yes | Fully qualified name of the entity to patch |
+| `patch` | string | Yes | JSON Patch operations array as a JSON string. Each operation has `op` (`add`/`remove`/`replace`), `path`, and `value` |
 
-#### Examples
-
-**Get Full Lineage**:
+**Example**
 
 ```json
 {
@@ -697,83 +822,25 @@ All OpenMetadata MCP tools, with parameters and examples.
   "id": 1,
   "method": "tools/call",
   "params": {
-    "name": "get_entity_lineage",
+    "name": "patch_entity",
     "arguments": {
       "entityType": "table",
-      "fqn": "mysql_prod.ecommerce.public.sales_transactions",
-      "upstreamDepth": 3,
-      "downstreamDepth": 3
+      "fqn": "mysql_prod.ecommerce.public.customer_orders",
+      "patch": "[{\"op\":\"replace\",\"path\":\"/description\",\"value\":\"Updated description for customer orders table.\"}]"
     }
   }
 }
 ```
 
-**Downstream-Focused Impact Analysis**:
+## Data Quality
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 2,
-  "method": "tools/call",
-  "params": {
-    "name": "get_entity_lineage",
-    "arguments": {
-      "entityType": "table",
-      "fqn": "mysql_prod.ecommerce.public.sales_transactions",
-      "upstreamDepth": 1,
-      "downstreamDepth": 5
-    }
-  }
-}
-```
-
----
-
-### create_lineage
-
-**Description**: Create a lineage relationship between two entities. Requires the `id` (UUID) and `type` of both the source and destination entities.
-
-#### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `fromEntity` | object | Yes | Source entity with `type` (string) and `id` (UUID string) |
-| `toEntity` | object | Yes | Destination entity with `type` (string) and `id` (UUID string) |
-
-#### Example
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "create_lineage",
-    "arguments": {
-      "fromEntity": {
-        "type": "table",
-        "id": "3a1b2c3d-4e5f-6789-abcd-ef0123456789"
-      },
-      "toEntity": {
-        "type": "table",
-        "id": "9f8e7d6c-5b4a-3210-fedc-ba9876543210"
-      }
-    }
-  }
-}
-```
-
-> **Tip**: Retrieve entity UUIDs from `get_entity_details` results before calling `create_lineage`.
-
----
-
-## Data Quality Tools
+Access test definitions and create test cases to validate your data assets.
 
 ### get_test_definitions
 
 **Description**: List test definitions available in OpenMetadata for tables or columns. Call this before `create_test_case` to identify valid test types and their required parameters.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -782,7 +849,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `after` | string | No | Pagination cursor — use `nextCursor` from the previous response |
 | `testPlatform` | string | No | Filter by platform: `OpenMetadata`, `GreatExpectations`, `DBT`, `Deequ`, `Soda`, `Other` (default: `OpenMetadata`) |
 
-#### Example
+**Example**
 
 ```json
 {
@@ -799,13 +866,11 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### create_test_case
 
 **Description**: Create a data quality test case for a table or column. For column tests, ensure the column's data type is listed in the test definition's `supportedDataTypes`.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -817,7 +882,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `entityType` | string | No | Target OpenMetadata entity type (default: `table`). For column-level tests, keep `entityType` as `table` and set `columnName`. |
 | `description` | string | No | Optional description of the test case |
 
-#### Example
+**Example**
 
 ```json
 {
@@ -839,38 +904,55 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
+## Metrics
 
-### root_cause_analysis
+Define and track measurable business and technical KPIs.
 
-**Description**: Trace a data quality failure back to its origin by traversing data quality lineage across pipeline hops.
+### create_metric
 
-#### Parameters
+**Description**: Create a new metric entity in OpenMetadata to track and standardize business KPIs.
+
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `fqn` | string | Yes | FQN of the entity where failure was detected |
-| `entityType` | string | Yes | Entity type to analyze (for example, `table`) |
-| `upstreamDepth` | integer | No | Hops to traverse upstream (default: 3, max: 10) |
-| `downstreamDepth` | integer | No | Hops to traverse downstream (default: 3, max: 10) |
-| `queryFilter` | string | No | Optional OpenSearch DSL filter JSON |
-| `includeDeleted` | boolean | No | Include deleted entities in traversal (default: false) |
+| `name` | string | Yes | Name of the metric |
+| `description` | string | No | Description of the metric in Markdown format |
+| `displayName` | string | No | Human-readable display name for the metric |
+| `metricExpressionLanguage` | string | Yes | Expression language used for the metric (for example, `SQL`) |
+| `metricExpressionCode` | string | Yes | Metric formula/expression in the selected language |
+| `metricType` | string | No | Metric type such as `COUNT`, `SUM`, `AVERAGE`, `RATIO`, or `OTHER` |
+| `granularity` | string | No | Time granularity such as `DAY`, `WEEK`, `MONTH`, `QUARTER`, or `YEAR` |
+| `unitOfMeasurement` | string | No | Unit of measurement such as `COUNT`, `DOLLARS`, `PERCENTAGE`, or `OTHER` |
+| `customUnitOfMeasurement` | string | No | Custom unit string, required when `unitOfMeasurement` is `OTHER` |
+| `owners` | array | No | List of owner usernames or emails |
+| `reviewers` | array | No | List of reviewer usernames or emails |
+| `relatedMetrics` | array | No | List of related metric FQNs |
+| `tags` | array | No | List of tags to apply |
+| `domains` | array | No | List of domains to associate |
 
-#### Example
+**Example**
 
 ```json
 {
   "jsonrpc": "2.0",
-  "id": 12,
+  "id": 10,
   "method": "tools/call",
   "params": {
-    "name": "root_cause_analysis",
+    "name": "create_metric",
     "arguments": {
-      "fqn": "mysql_prod.ecommerce.public.customer_orders",
-      "entityType": "table",
-      "upstreamDepth": 4,
-      "downstreamDepth": 1,
-      "includeDeleted": false
+      "name": "monthly_recurring_revenue",
+      "displayName": "Monthly Recurring Revenue",
+      "description": "Monthly recurring revenue from active subscriptions.",
+      "metricExpressionLanguage": "SQL",
+      "metricExpressionCode": "SUM(subscription_amount)",
+      "metricType": "SUM",
+      "granularity": "MONTH",
+      "unitOfMeasurement": "DOLLARS",
+      "owners": ["finance-team"],
+      "reviewers": ["data-governance-team"],
+      "tags": ["Finance", "KPI"],
+      "domains": ["Revenue"]
     }
   }
 }

--- a/v1.12.x/how-to-guides/mcp/reference.mdx
+++ b/v1.12.x/how-to-guides/mcp/reference.mdx
@@ -18,6 +18,10 @@ All OpenMetadata MCP tools, with parameters and examples.
 | [`create_glossary`](#create_glossary) | Governance | Create a new glossary to organize business terms |
 | [`create_glossary_term`](#create_glossary_term) | Governance | Add a term to an existing glossary |
 | [`create_metric`](#create_metric) | Governance | Create a new metric entity |
+| [`create_classification`](#create_classification) | Governance | Create a new tag classification (top-level tag container) |
+| [`create_tag`](#create_tag) | Governance | Create a new tag within an existing classification |
+| [`create_domain`](#create_domain) | Governance | Create a new domain for grouping data assets |
+| [`create_data_product`](#create_data_product) | Governance | Create a new data product within one or more domains |
 | [`get_entity_lineage`](#get_entity_lineage) | Lineage | Explore upstream/downstream dependencies |
 | [`create_lineage`](#create_lineage) | Lineage | Create a lineage relationship between two entities |
 | [`get_test_definitions`](#get_test_definitions) | Data Quality | List available test definitions for tables or columns |
@@ -464,6 +468,203 @@ All OpenMetadata MCP tools, with parameters and examples.
       "reviewers": ["data-governance-team"],
       "tags": ["Finance", "KPI"],
       "domains": ["Revenue"]
+    }
+  }
+}
+```
+
+---
+
+### create_classification
+
+**Description**: Create a new Classification in OpenMetadata. A Classification is a top-level container that groups related Tags (e.g., `PII`, `Tier`). The `name` becomes the root segment of every tag FQN under it. The `mutuallyExclusive` flag is immutable once the classification exists.
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Name of the classification. Becomes the root segment of tag FQNs (e.g., `PII` → `PII.Sensitive`). Must be unique. |
+| `description` | string | Yes | Description of the classification in Markdown format. |
+| `displayName` | string | No | Human-readable display name. |
+| `mutuallyExclusive` | boolean | No | If `true`, an entity can only carry one tag from this classification at a time. Immutable after creation. |
+| `owners` | array | No | OpenMetadata usernames or team names to set as owners. Each must already exist. |
+| `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
+| `domains` | array | No | FQNs of domains this classification belongs to. Each domain must already exist. |
+
+#### Example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "create_classification",
+    "arguments": {
+      "name": "PII",
+      "description": "Tags for classifying Personally Identifiable Information across data assets.",
+      "mutuallyExclusive": false,
+      "owners": ["data-governance-team"],
+      "reviewers": ["privacy-team"]
+    }
+  }
+}
+```
+
+---
+
+### create_tag
+
+**Description**: Create a new Tag inside a Classification in OpenMetadata. The tag FQN is `Classification.TagName` (e.g., `PII.Sensitive`). At least one of `classification` or `parent` must be provided.
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Name of the tag (the leaf segment, e.g., `Sensitive`). Must be unique within its parent. |
+| `description` | string | Yes | Description of the tag in Markdown format. |
+| `classification` | string | No | Name of the classification this tag belongs to (e.g., `PII`). Must already exist. Optional if `parent` is provided. |
+| `parent` | string | No | FQN of the parent tag for a nested tag (e.g., `PII.PersonalData`). Must already exist. Omit for a top-level tag. |
+| `displayName` | string | No | Human-readable display name. |
+| `mutuallyExclusive` | boolean | No | If `true`, child tags under this tag are mutually exclusive on an entity. |
+| `owners` | array | No | OpenMetadata usernames or team names to set as owners. Each must already exist. |
+| `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
+| `domains` | array | No | FQNs of domains this tag belongs to. Each domain must already exist. |
+
+#### Examples
+
+**Create a top-level tag**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "create_tag",
+    "arguments": {
+      "name": "Sensitive",
+      "description": "Data that contains sensitive personal information requiring strict access controls.",
+      "classification": "PII"
+    }
+  }
+}
+```
+
+**Create a nested tag**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "create_tag",
+    "arguments": {
+      "name": "Email",
+      "description": "Email addresses — a subset of sensitive personal data.",
+      "parent": "PII.Sensitive"
+    }
+  }
+}
+```
+
+---
+
+### create_domain
+
+**Description**: Create a new Domain in OpenMetadata. A Domain is a top-level governance grouping of data assets. To create a child domain, set `parent` to the FQN of an existing parent domain. `domainType` defaults to `Aggregate` if omitted.
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Name of the domain. Must be unique. |
+| `description` | string | Yes | Description of the domain in Markdown format. |
+| `domainType` | string | No | Type of domain: `Source-aligned`, `Consumer-aligned`, or `Aggregate` (default). |
+| `parent` | string | No | FQN of an existing parent domain when creating a child domain. Omit for a top-level domain. |
+| `displayName` | string | No | Human-readable display name. |
+| `experts` | array | No | OpenMetadata login names of domain experts (e.g., `john.doe`). Each must already exist. |
+| `owners` | array | No | OpenMetadata usernames or team names to set as owners. Each must already exist. |
+| `tags` | array | No | Tag FQNs to apply to this domain (e.g., `Tier.Tier1`). |
+
+#### Examples
+
+**Create a top-level domain**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "create_domain",
+    "arguments": {
+      "name": "Finance",
+      "description": "Domain for all finance and accounting data assets.",
+      "domainType": "Consumer-aligned",
+      "experts": ["jane.doe"],
+      "owners": ["finance-team"]
+    }
+  }
+}
+```
+
+**Create a child domain**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "create_domain",
+    "arguments": {
+      "name": "Revenue",
+      "description": "Sub-domain covering revenue tracking and forecasting.",
+      "domainType": "Aggregate",
+      "parent": "Finance"
+    }
+  }
+}
+```
+
+---
+
+### create_data_product
+
+**Description**: Create a new Data Product in OpenMetadata. A Data Product groups data assets that deliver business value and must belong to at least one Domain. All referenced domain FQNs must already exist.
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Name of the data product. Must be unique. |
+| `description` | string | Yes | Description of the data product in Markdown format. |
+| `domains` | array | Yes | FQNs of the domains this data product belongs to (e.g., `Finance`). At least one required; each must already exist. |
+| `displayName` | string | No | Human-readable display name. |
+| `experts` | array | No | OpenMetadata login names of data product experts (e.g., `john.doe`). Each must already exist. |
+| `owners` | array | No | OpenMetadata usernames or team names to set as owners. Each must already exist. |
+| `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
+| `tags` | array | No | Tag FQNs to apply to this data product (e.g., `Tier.Tier1`, `PII.Sensitive`). |
+
+#### Example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "create_data_product",
+    "arguments": {
+      "name": "customer_360",
+      "displayName": "Customer 360",
+      "description": "Unified view of customer data including orders, support history, and lifetime value.",
+      "domains": ["Finance", "Marketing"],
+      "experts": ["alice.smith"],
+      "owners": ["data-platform-team"],
+      "tags": ["Tier.Tier1"]
     }
   }
 }

--- a/v1.12.x/how-to-guides/mcp/vscode.mdx
+++ b/v1.12.x/how-to-guides/mcp/vscode.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with VS Code
 description: Connect your OpenMetadata MCP Server to Visual Studio Code for AI-powered metadata exploration.
-sidebarTitle: Getting Started with VS Code
+sidebarTitle: VS Code
 ---
 
 # Getting Started with VS Code

--- a/v1.13.x/how-to-guides/mcp/claude-code.mdx
+++ b/v1.13.x/how-to-guides/mcp/claude-code.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Claude Code
 description: Connect your OpenMetadata MCP Server to Claude Code (CLI) for AI-powered metadata exploration from the terminal.
-sidebarTitle: Getting Started with Claude Code
+sidebarTitle: Claude Code
 ---
 
 # Getting Started with Claude Code

--- a/v1.13.x/how-to-guides/mcp/claude.mdx
+++ b/v1.13.x/how-to-guides/mcp/claude.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Claude Desktop
 description: Set up MCP Server to connect Claude Desktop with OAuth or PAT-based authentication for AI-powered access to your data.
-sidebarTitle: Getting Started with Claude Desktop
+sidebarTitle: Claude Desktop
 ---
 
 # Getting Started with Claude Desktop

--- a/v1.13.x/how-to-guides/mcp/cursor.mdx
+++ b/v1.13.x/how-to-guides/mcp/cursor.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Cursor
 description: Connect your OpenMetadata MCP Server to Cursor IDE with OAuth or PAT-based authentication for AI-powered metadata exploration.
-sidebarTitle: Getting Started with Cursor
+sidebarTitle: Cursor
 ---
 
 # Getting Started with Cursor

--- a/v1.13.x/how-to-guides/mcp/goose.mdx
+++ b/v1.13.x/how-to-guides/mcp/goose.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Goose Desktop
 description: Learn how to connect Goose Desktop with MCP Server, create tokens, and enable secure AI-powered access to your data platform.
-sidebarTitle: Getting Started with Goose Desktop
+sidebarTitle: Goose Desktop
 ---
 
 # Getting Started with Goose Desktop

--- a/v1.13.x/how-to-guides/mcp/reference.mdx
+++ b/v1.13.x/how-to-guides/mcp/reference.mdx
@@ -11,10 +11,10 @@ All OpenMetadata MCP tools, with parameters and examples.
 
 | Category | Tools |
 |---|---|
-| **Discover** | [search_metadata](#search_metadata), [semantic_search](#semantic_search), [search_company_context](#search_company_context) |
-| **Inspect** | [get_entity_details](#get_entity_details), [get_company_context](#get_company_context) |
+| **Discover** | [search_metadata](#search_metadata), [semantic_search](#semantic_search) |
+| **Inspect** | [get_entity_details](#get_entity_details) |
 | **Lineage & Impact** | [get_entity_lineage](#get_entity_lineage), [create_lineage](#create_lineage), [root_cause_analysis](#root_cause_analysis) |
-| **Knowledge** | [create_glossary](#create_glossary), [create_glossary_term](#create_glossary_term), [create_context_memory](#create_context_memory) |
+| **Knowledge** | [create_glossary](#create_glossary), [create_glossary_term](#create_glossary_term) |
 | **Govern & Classify** | [create_classification](#create_classification), [create_tag](#create_tag), [create_domain](#create_domain), [create_data_product](#create_data_product), [patch_entity](#patch_entity) |
 | **Data Quality** | [get_test_definitions](#get_test_definitions), [create_test_case](#create_test_case) |
 | **Metrics** | [create_metric](#create_metric) |
@@ -185,34 +185,6 @@ Search and find data assets across your catalog using keyword, semantic, or natu
 }
 ```
 
-### search_company_context
-
-**Description**: Semantic search over company context knowledge pills from the Context Center. Returns matching pills with their title, question, answer, summary, and source file. Use this to answer questions from company documents, runbooks, FAQs, and policies.
-
-**Parameters**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `query` | string | Yes | Natural-language question or topic to find relevant company knowledge for |
-| `size` | integer | No | Number of pills to return. Default is 10, maximum is 50 |
-
-**Example**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "search_company_context",
-    "arguments": {
-      "query": "data retention policy",
-      "size": 5
-    }
-  }
-}
-```
-
 ## Inspect
 
 Retrieve detailed information about specific entities and company knowledge pills.
@@ -277,32 +249,6 @@ Retrieve detailed information about specific entities and company knowledge pill
         "text": "## Table: customer_orders\n\n**FQN**: mysql_prod.ecommerce.public.customer_orders\n**Service**: mysql_prod (MySQL)\n**Database**: ecommerce | **Schema**: public\n**Description**: Stores all customer order transactions\n\n**Owners**: ecommerce-team, sarah.johnson@company.com\n**Tags**: PII, Financial, Customer-Data | **Tier**: Tier1\n\n**Columns** (5):\n- order_id (BIGINT) - Primary key\n- customer_id (BIGINT) - FK to customer table\n- order_date (TIMESTAMP)\n- total_amount (DECIMAL)\n- status (VARCHAR)"
       }
     ]
-  }
-}
-```
-
-### get_company_context
-
-**Description**: Fetch a single company context knowledge pill by its fully qualified name. Returns the full title, question, answer, summary, and source file. Use the `fullyQualifiedName` or `name` returned by `search_company_context`.
-
-**Parameters**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `fqn` | string | Yes | The `fullyQualifiedName` or `name` of the knowledge pill from a `search_company_context` result. Pass it verbatim |
-
-**Example**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "get_company_context",
-    "arguments": {
-      "fqn": "data-retention-policy.gdpr-rules"
-    }
   }
 }
 ```
@@ -563,47 +509,6 @@ Create and manage glossaries, terms, and reusable context memories.
       "name": "Organic CAC",
       "description": "Customer acquisition cost for customers acquired through organic channels (SEO, word of mouth) without paid advertising",
       "owners": ["marketing-team"]
-    }
-  }
-}
-```
-
-### create_context_memory
-
-**Description**: Save a reusable piece of knowledge to the Context Center — a preference, instruction, runbook step, or FAQ answer the assistant should retain across conversations. Use this when the user explicitly asks you to remember, note, or store something.
-
-**Parameters**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `name` | string | Yes | Stable, unique system name. Reusing an existing name updates that memory |
-| `question` | string | Yes | The canonical question or instruction this memory represents |
-| `answer` | string | Yes | The canonical answer or guidance to retain |
-| `title` | string | No | Short human-readable title shown in the Context Center |
-| `summary` | string | No | One-line summary of the memory |
-| `memoryType` | string | No | `Preference`, `UseCase`, `Note`, `Runbook`, or `Faq`. Defaults to `Note` |
-| `memoryScope` | string | No | `UserGlobal` (broad) or `EntityScoped` (tied to a specific entity) |
-| `owners` | array | No | OpenMetadata usernames or team names |
-| `tags` | array | No | Tag FQNs to apply |
-| `domains` | array | No | Domain FQNs this memory belongs to |
-
-**Example**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "create_context_memory",
-    "arguments": {
-      "name": "finance-warehouse-preference",
-      "title": "Finance Dashboard Warehouse",
-      "question": "Which warehouse should finance dashboards query?",
-      "answer": "Always query the FINANCE_PROD warehouse for finance dashboards.",
-      "memoryType": "Preference",
-      "memoryScope": "UserGlobal",
-      "domains": ["Finance"]
     }
   }
 }

--- a/v1.13.x/how-to-guides/mcp/reference.mdx
+++ b/v1.13.x/how-to-guides/mcp/reference.mdx
@@ -9,28 +9,19 @@ All OpenMetadata MCP tools, with parameters and examples.
 
 ## Available Tools
 
-| Tool | Category | Description |
-|------|----------|-------------|
-| [`search_metadata`](#search_metadata) | Discovery | Keyword-based search for data assets and business terms |
-| [`semantic_search`](#semantic_search) | Discovery | Meaning-based search using vector embeddings |
-| [`get_entity_details`](#get_entity_details) | Discovery | Retrieve full details for a specific entity by FQN |
-| [`patch_entity`](#patch_entity) | Governance | Update an existing entity using JSON Patch |
-| [`create_glossary`](#create_glossary) | Governance | Create a new glossary to organize business terms |
-| [`create_glossary_term`](#create_glossary_term) | Governance | Add a term to an existing glossary |
-| [`create_metric`](#create_metric) | Governance | Create a new metric entity |
-| [`create_classification`](#create_classification) | Governance | Create a new tag classification (top-level tag container) |
-| [`create_tag`](#create_tag) | Governance | Create a new tag within an existing classification |
-| [`create_domain`](#create_domain) | Governance | Create a new domain for grouping data assets |
-| [`create_data_product`](#create_data_product) | Governance | Create a new data product within one or more domains |
-| [`get_entity_lineage`](#get_entity_lineage) | Lineage | Explore upstream/downstream dependencies |
-| [`create_lineage`](#create_lineage) | Lineage | Create a lineage relationship between two entities |
-| [`get_test_definitions`](#get_test_definitions) | Data Quality | List available test definitions for tables or columns |
-| [`create_test_case`](#create_test_case) | Data Quality | Create a data quality test for a table or column |
-| [`root_cause_analysis`](#root_cause_analysis) | Data Quality | Perform root cause analysis via data quality lineage |
+| Category | Tools |
+|---|---|
+| **Discover** | [search_metadata](#search_metadata), [semantic_search](#semantic_search), [search_company_context](#search_company_context) |
+| **Inspect** | [get_entity_details](#get_entity_details), [get_company_context](#get_company_context) |
+| **Lineage & Impact** | [get_entity_lineage](#get_entity_lineage), [create_lineage](#create_lineage), [root_cause_analysis](#root_cause_analysis) |
+| **Knowledge** | [create_glossary](#create_glossary), [create_glossary_term](#create_glossary_term), [create_context_memory](#create_context_memory) |
+| **Govern & Classify** | [create_classification](#create_classification), [create_tag](#create_tag), [create_domain](#create_domain), [create_data_product](#create_data_product), [patch_entity](#patch_entity) |
+| **Data Quality** | [get_test_definitions](#get_test_definitions), [create_test_case](#create_test_case) |
+| **Metrics** | [create_metric](#create_metric) |
 
----
+## Discover
 
-## Discovery & Search Tools
+Search and find data assets across your catalog using keyword, semantic, or natural language queries.
 
 ### search_metadata
 
@@ -42,7 +33,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 - Search for glossary terms
 - Locate pipelines by name or description
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -56,15 +47,14 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `includeAggregations` | boolean | No | Include aggregation/facet data (default: false) |
 | `maxAggregationBuckets` | integer | No | Max buckets per aggregation (default: 10, max: 50) |
 
-#### Entity Types
-
+**Entity Types**
 - **Service Entities**: `databaseService`, `messagingService`, `apiService`, `dashboardService`, `pipelineService`, `storageService`, `mlmodelService`, `metadataService`, `searchService`
 - **Data Asset Entities**: `apiCollection`, `apiEndpoint`, `table`, `storedProcedure`, `database`, `databaseSchema`, `dashboard`, `dashboardDataModel`, `pipeline`, `chart`, `topic`, `searchIndex`, `mlmodel`, `container`
 - **User Entities**: `user`, `team`
 - **Domain Entities**: `domain`, `dataProduct`
 - **Governance Entities**: `metric`, `glossary`, `glossaryTerm`
 
-#### Examples
+**Examples**
 
 **Basic Search**:
 
@@ -136,8 +126,6 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### semantic_search
 
 **Description**: Find data assets by meaning using vector search ([setup guide](../../deployment/semantic-search#enable-semantic-search)). Use for exploratory queries where you don't know exact names. Returns conceptually related assets even when no keywords match.
@@ -147,7 +135,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 - Find assets related to a concept (e.g., "customer spending behavior")
 - Discover hidden relationships across services
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -157,7 +145,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `k` | integer | No | KNN neighbor count for tuning result quality (default: 100) |
 | `threshold` | number | No | Minimum similarity score 0.0–1.0 (default: 0.0) |
 
-#### Examples
+**Examples**
 
 **Conceptual Search**:
 
@@ -197,20 +185,50 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
+### search_company_context
+
+**Description**: Semantic search over company context knowledge pills from the Context Center. Returns matching pills with their title, question, answer, summary, and source file. Use this to answer questions from company documents, runbooks, FAQs, and policies.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Natural-language question or topic to find relevant company knowledge for |
+| `size` | integer | No | Number of pills to return. Default is 10, maximum is 50 |
+
+**Example**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "search_company_context",
+    "arguments": {
+      "query": "data retention policy",
+      "size": 5
+    }
+  }
+}
+```
+
+## Inspect
+
+Retrieve detailed information about specific entities and company knowledge pills.
 
 ### get_entity_details
 
 **Description**: Retrieve full details for a specific entity by fully qualified name (FQN). Pass the exact `fullyQualifiedName` value from search results — do not construct FQNs manually.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `entityType` | string | Yes | Type of entity (e.g., `table`, `dashboard`, `topic`, `pipeline`) |
 | `fqn` | string | Yes | Fully qualified name — use the exact value from `search_metadata` or `semantic_search` results |
 
-#### Examples
+**Examples**
 
 **Get Table Details**:
 
@@ -263,15 +281,17 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
+### get_company_context
 
-## Governance Tools
+**Description**: Fetch a single company context knowledge pill by its fully qualified name. Returns the full title, question, answer, summary, and source file. Use the `fullyQualifiedName` or `name` returned by `search_company_context`.
 
-### patch_entity
+**Parameters**
 
-**Description**: Update an existing entity's properties using [JSON Patch](https://jsonpatch.com/) (RFC 6902). Use `get_entity_details` first to retrieve the current state before constructing a patch.
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `fqn` | string | Yes | The `fullyQualifiedName` or `name` of the knowledge pill from a `search_company_context` result. Pass it verbatim |
 
-#### Example
+**Example**
 
 ```json
 {
@@ -279,23 +299,152 @@ All OpenMetadata MCP tools, with parameters and examples.
   "id": 1,
   "method": "tools/call",
   "params": {
-    "name": "patch_entity",
+    "name": "get_company_context",
     "arguments": {
-      "entityType": "table",
-      "fqn": "mysql_prod.ecommerce.public.customer_orders",
-      "patch": "[{\"op\":\"replace\",\"path\":\"/description\",\"value\":\"Updated description for customer orders table.\"}]"
+      "fqn": "data-retention-policy.gdpr-rules"
     }
   }
 }
 ```
 
----
+## Lineage & Impact
+
+Explore data dependencies, trace upstream sources, and analyze downstream impact.
+
+### get_entity_lineage
+
+**Description**: Retrieve upstream and downstream lineage for any entity to understand data dependencies and perform impact analysis. Pass the exact `fullyQualifiedName` from search results.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `entityType` | string | Yes | Type of entity |
+| `fqn` | string | Yes | Fully qualified name of the entity |
+| `upstreamDepth` | integer | No | Hops to traverse upstream (default: 3, max: 10) |
+| `downstreamDepth` | integer | No | Hops to traverse downstream (default: 3, max: 10) |
+| `includeColumnLineage` | boolean | No | Include column-level lineage mappings. Default is `false` (table-level only) |
+
+**Examples**
+
+**Get Full Lineage**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "get_entity_lineage",
+    "arguments": {
+      "entityType": "table",
+      "fqn": "mysql_prod.ecommerce.public.sales_transactions",
+      "upstreamDepth": 3,
+      "downstreamDepth": 3
+    }
+  }
+}
+```
+
+**Downstream-Focused Impact Analysis**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "get_entity_lineage",
+    "arguments": {
+      "entityType": "table",
+      "fqn": "mysql_prod.ecommerce.public.sales_transactions",
+      "upstreamDepth": 1,
+      "downstreamDepth": 5
+    }
+  }
+}
+```
+
+### create_lineage
+
+**Description**: Create a lineage relationship between two entities. Requires the `id` (UUID) and `type` of both the source and destination entities.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `fromEntity` | object | Yes | Source entity with `type` (string) and `id` (UUID string) |
+| `toEntity` | object | Yes | Destination entity with `type` (string) and `id` (UUID string) |
+
+**Example**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "create_lineage",
+    "arguments": {
+      "fromEntity": {
+        "type": "table",
+        "id": "3a1b2c3d-4e5f-6789-abcd-ef0123456789"
+      },
+      "toEntity": {
+        "type": "table",
+        "id": "9f8e7d6c-5b4a-3210-fedc-ba9876543210"
+      }
+    }
+  }
+}
+```
+
+> **Tip**: Retrieve entity UUIDs from `get_entity_details` results before calling `create_lineage`.
+
+### root_cause_analysis
+
+**Description**: Trace a data quality failure back to its origin by traversing data quality lineage across pipeline hops.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `fqn` | string | Yes | FQN of the entity where failure was detected |
+| `entityType` | string | Yes | Entity type to analyze (for example, `table`) |
+| `upstreamDepth` | integer | No | Hops to traverse upstream (default: 3, max: 10) |
+| `downstreamDepth` | integer | No | Hops to traverse downstream (default: 3, max: 10) |
+| `queryFilter` | string | No | Optional OpenSearch DSL filter JSON |
+| `includeDeleted` | boolean | No | Include deleted entities in traversal (default: false) |
+
+**Example**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 12,
+  "method": "tools/call",
+  "params": {
+    "name": "root_cause_analysis",
+    "arguments": {
+      "fqn": "mysql_prod.ecommerce.public.customer_orders",
+      "entityType": "table",
+      "upstreamDepth": 4,
+      "downstreamDepth": 1,
+      "includeDeleted": false
+    }
+  }
+}
+```
+
+## Knowledge
+
+Create and manage glossaries, terms, and reusable context memories.
 
 ### create_glossary
 
 **Description**: Create a new glossary to organize business terms. Set `mutuallyExclusive: true` to restrict entities to a single term from the glossary at a time.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -305,7 +454,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `owners` | array | No | List of owner usernames or emails |
 | `reviewers` | array | No | List of reviewer usernames or emails |
 
-#### Examples
+**Examples**
 
 **Create a Business Glossary**:
 
@@ -363,13 +512,11 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### create_glossary_term
 
 **Description**: Create a new term within an existing glossary. Supports hierarchical parent–child relationships between terms.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -380,7 +527,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `owners` | array | No | List of owner usernames or emails |
 | `reviewers` | array | No | List of reviewer usernames or emails |
 
-#### Examples
+**Examples**
 
 **Create a Root-Level Term**:
 
@@ -421,65 +568,56 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
+### create_context_memory
 
-### create_metric
+**Description**: Save a reusable piece of knowledge to the Context Center — a preference, instruction, runbook step, or FAQ answer the assistant should retain across conversations. Use this when the user explicitly asks you to remember, note, or store something.
 
-**Description**: Create a new metric entity in OpenMetadata to track and standardize business KPIs.
-
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `name` | string | Yes | Name of the metric |
-| `description` | string | No | Description of the metric in Markdown format |
-| `displayName` | string | No | Human-readable display name for the metric |
-| `metricExpressionLanguage` | string | Yes | Expression language used for the metric (for example, `SQL`) |
-| `metricExpressionCode` | string | Yes | Metric formula/expression in the selected language |
-| `metricType` | string | No | Metric type such as `COUNT`, `SUM`, `AVERAGE`, `RATIO`, or `OTHER` |
-| `granularity` | string | No | Time granularity such as `DAY`, `WEEK`, `MONTH`, `QUARTER`, or `YEAR` |
-| `unitOfMeasurement` | string | No | Unit of measurement such as `COUNT`, `DOLLARS`, `PERCENTAGE`, or `OTHER` |
-| `customUnitOfMeasurement` | string | No | Custom unit string, required when `unitOfMeasurement` is `OTHER` |
-| `owners` | array | No | List of owner usernames or emails |
-| `reviewers` | array | No | List of reviewer usernames or emails |
-| `relatedMetrics` | array | No | List of related metric FQNs |
-| `tags` | array | No | List of tags to apply |
-| `domains` | array | No | List of domains to associate |
+| `name` | string | Yes | Stable, unique system name. Reusing an existing name updates that memory |
+| `question` | string | Yes | The canonical question or instruction this memory represents |
+| `answer` | string | Yes | The canonical answer or guidance to retain |
+| `title` | string | No | Short human-readable title shown in the Context Center |
+| `summary` | string | No | One-line summary of the memory |
+| `memoryType` | string | No | `Preference`, `UseCase`, `Note`, `Runbook`, or `Faq`. Defaults to `Note` |
+| `memoryScope` | string | No | `UserGlobal` (broad) or `EntityScoped` (tied to a specific entity) |
+| `owners` | array | No | OpenMetadata usernames or team names |
+| `tags` | array | No | Tag FQNs to apply |
+| `domains` | array | No | Domain FQNs this memory belongs to |
 
-#### Example
+**Example**
 
 ```json
 {
   "jsonrpc": "2.0",
-  "id": 10,
+  "id": 1,
   "method": "tools/call",
   "params": {
-    "name": "create_metric",
+    "name": "create_context_memory",
     "arguments": {
-      "name": "monthly_recurring_revenue",
-      "displayName": "Monthly Recurring Revenue",
-      "description": "Monthly recurring revenue from active subscriptions.",
-      "metricExpressionLanguage": "SQL",
-      "metricExpressionCode": "SUM(subscription_amount)",
-      "metricType": "SUM",
-      "granularity": "MONTH",
-      "unitOfMeasurement": "DOLLARS",
-      "owners": ["finance-team"],
-      "reviewers": ["data-governance-team"],
-      "tags": ["Finance", "KPI"],
-      "domains": ["Revenue"]
+      "name": "finance-warehouse-preference",
+      "title": "Finance Dashboard Warehouse",
+      "question": "Which warehouse should finance dashboards query?",
+      "answer": "Always query the FINANCE_PROD warehouse for finance dashboards.",
+      "memoryType": "Preference",
+      "memoryScope": "UserGlobal",
+      "domains": ["Finance"]
     }
   }
 }
 ```
 
----
+## Govern & Classify
+
+Define and apply classifications, tags, domains, data products, and entity updates.
 
 ### create_classification
 
 **Description**: Create a new Classification in OpenMetadata. A Classification is a top-level container that groups related Tags (e.g., `PII`, `Tier`). The `name` becomes the root segment of every tag FQN under it. The `mutuallyExclusive` flag is immutable once the classification exists.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -491,7 +629,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
 | `domains` | array | No | FQNs of domains this classification belongs to. Each domain must already exist. |
 
-#### Example
+**Example**
 
 ```json
 {
@@ -511,13 +649,11 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### create_tag
 
 **Description**: Create a new Tag inside a Classification in OpenMetadata. The tag FQN is `Classification.TagName` (e.g., `PII.Sensitive`). At least one of `classification` or `parent` must be provided.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -531,7 +667,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
 | `domains` | array | No | FQNs of domains this tag belongs to. Each domain must already exist. |
 
-#### Examples
+**Examples**
 
 **Create a top-level tag**:
 
@@ -569,13 +705,11 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### create_domain
 
 **Description**: Create a new Domain in OpenMetadata. A Domain is a top-level governance grouping of data assets. To create a child domain, set `parent` to the FQN of an existing parent domain. `domainType` defaults to `Aggregate` if omitted.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -588,7 +722,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `owners` | array | No | OpenMetadata usernames or team names to set as owners. Each must already exist. |
 | `tags` | array | No | Tag FQNs to apply to this domain (e.g., `Tier.Tier1`). |
 
-#### Examples
+**Examples**
 
 **Create a top-level domain**:
 
@@ -629,13 +763,11 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### create_data_product
 
 **Description**: Create a new Data Product in OpenMetadata. A Data Product groups data assets that deliver business value and must belong to at least one Domain. All referenced domain FQNs must already exist.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -648,7 +780,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
 | `tags` | array | No | Tag FQNs to apply to this data product (e.g., `Tier.Tier1`, `PII.Sensitive`). |
 
-#### Example
+**Example**
 
 ```json
 {
@@ -670,26 +802,19 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
+### patch_entity
 
-## Lineage Tools
+**Description**: Update an existing entity's properties using [JSON Patch](https://jsonpatch.com/) (RFC 6902). Use `get_entity_details` first to retrieve the current state before constructing a patch.
 
-### get_entity_lineage
-
-**Description**: Retrieve upstream and downstream lineage for any entity to understand data dependencies and perform impact analysis. Pass the exact `fullyQualifiedName` from search results.
-
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `entityType` | string | Yes | Type of entity |
-| `fqn` | string | Yes | Fully qualified name of the entity |
-| `upstreamDepth` | integer | No | Hops to traverse upstream (default: 3, max: 10) |
-| `downstreamDepth` | integer | No | Hops to traverse downstream (default: 3, max: 10) |
+| `entityType` | string | Yes | Type of entity to patch (e.g., `table`, `glossaryTerm`) |
+| `fqn` | string | Yes | Fully qualified name of the entity to patch |
+| `patch` | string | Yes | JSON Patch operations array as a JSON string. Each operation has `op` (`add`/`remove`/`replace`), `path`, and `value` |
 
-#### Examples
-
-**Get Full Lineage**:
+**Example**
 
 ```json
 {
@@ -697,83 +822,25 @@ All OpenMetadata MCP tools, with parameters and examples.
   "id": 1,
   "method": "tools/call",
   "params": {
-    "name": "get_entity_lineage",
+    "name": "patch_entity",
     "arguments": {
       "entityType": "table",
-      "fqn": "mysql_prod.ecommerce.public.sales_transactions",
-      "upstreamDepth": 3,
-      "downstreamDepth": 3
+      "fqn": "mysql_prod.ecommerce.public.customer_orders",
+      "patch": "[{\"op\":\"replace\",\"path\":\"/description\",\"value\":\"Updated description for customer orders table.\"}]"
     }
   }
 }
 ```
 
-**Downstream-Focused Impact Analysis**:
+## Data Quality
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 2,
-  "method": "tools/call",
-  "params": {
-    "name": "get_entity_lineage",
-    "arguments": {
-      "entityType": "table",
-      "fqn": "mysql_prod.ecommerce.public.sales_transactions",
-      "upstreamDepth": 1,
-      "downstreamDepth": 5
-    }
-  }
-}
-```
-
----
-
-### create_lineage
-
-**Description**: Create a lineage relationship between two entities. Requires the `id` (UUID) and `type` of both the source and destination entities.
-
-#### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `fromEntity` | object | Yes | Source entity with `type` (string) and `id` (UUID string) |
-| `toEntity` | object | Yes | Destination entity with `type` (string) and `id` (UUID string) |
-
-#### Example
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "create_lineage",
-    "arguments": {
-      "fromEntity": {
-        "type": "table",
-        "id": "3a1b2c3d-4e5f-6789-abcd-ef0123456789"
-      },
-      "toEntity": {
-        "type": "table",
-        "id": "9f8e7d6c-5b4a-3210-fedc-ba9876543210"
-      }
-    }
-  }
-}
-```
-
-> **Tip**: Retrieve entity UUIDs from `get_entity_details` results before calling `create_lineage`.
-
----
-
-## Data Quality Tools
+Access test definitions and create test cases to validate your data assets.
 
 ### get_test_definitions
 
 **Description**: List test definitions available in OpenMetadata for tables or columns. Call this before `create_test_case` to identify valid test types and their required parameters.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -782,7 +849,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `after` | string | No | Pagination cursor — use `nextCursor` from the previous response |
 | `testPlatform` | string | No | Filter by platform: `OpenMetadata`, `GreatExpectations`, `DBT`, `Deequ`, `Soda`, `Other` (default: `OpenMetadata`) |
 
-#### Example
+**Example**
 
 ```json
 {
@@ -799,13 +866,11 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### create_test_case
 
 **Description**: Create a data quality test case for a table or column. For column tests, ensure the column's data type is listed in the test definition's `supportedDataTypes`.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -817,7 +882,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `entityType` | string | No | Target OpenMetadata entity type (default: `table`). For column-level tests, keep `entityType` as `table` and set `columnName`. |
 | `description` | string | No | Optional description of the test case |
 
-#### Example
+**Example**
 
 ```json
 {
@@ -839,38 +904,55 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
+## Metrics
 
-### root_cause_analysis
+Define and track measurable business and technical KPIs.
 
-**Description**: Trace a data quality failure back to its origin by traversing data quality lineage across pipeline hops.
+### create_metric
 
-#### Parameters
+**Description**: Create a new metric entity in OpenMetadata to track and standardize business KPIs.
+
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `fqn` | string | Yes | FQN of the entity where failure was detected |
-| `entityType` | string | Yes | Entity type to analyze (for example, `table`) |
-| `upstreamDepth` | integer | No | Hops to traverse upstream (default: 3, max: 10) |
-| `downstreamDepth` | integer | No | Hops to traverse downstream (default: 3, max: 10) |
-| `queryFilter` | string | No | Optional OpenSearch DSL filter JSON |
-| `includeDeleted` | boolean | No | Include deleted entities in traversal (default: false) |
+| `name` | string | Yes | Name of the metric |
+| `description` | string | No | Description of the metric in Markdown format |
+| `displayName` | string | No | Human-readable display name for the metric |
+| `metricExpressionLanguage` | string | Yes | Expression language used for the metric (for example, `SQL`) |
+| `metricExpressionCode` | string | Yes | Metric formula/expression in the selected language |
+| `metricType` | string | No | Metric type such as `COUNT`, `SUM`, `AVERAGE`, `RATIO`, or `OTHER` |
+| `granularity` | string | No | Time granularity such as `DAY`, `WEEK`, `MONTH`, `QUARTER`, or `YEAR` |
+| `unitOfMeasurement` | string | No | Unit of measurement such as `COUNT`, `DOLLARS`, `PERCENTAGE`, or `OTHER` |
+| `customUnitOfMeasurement` | string | No | Custom unit string, required when `unitOfMeasurement` is `OTHER` |
+| `owners` | array | No | List of owner usernames or emails |
+| `reviewers` | array | No | List of reviewer usernames or emails |
+| `relatedMetrics` | array | No | List of related metric FQNs |
+| `tags` | array | No | List of tags to apply |
+| `domains` | array | No | List of domains to associate |
 
-#### Example
+**Example**
 
 ```json
 {
   "jsonrpc": "2.0",
-  "id": 12,
+  "id": 10,
   "method": "tools/call",
   "params": {
-    "name": "root_cause_analysis",
+    "name": "create_metric",
     "arguments": {
-      "fqn": "mysql_prod.ecommerce.public.customer_orders",
-      "entityType": "table",
-      "upstreamDepth": 4,
-      "downstreamDepth": 1,
-      "includeDeleted": false
+      "name": "monthly_recurring_revenue",
+      "displayName": "Monthly Recurring Revenue",
+      "description": "Monthly recurring revenue from active subscriptions.",
+      "metricExpressionLanguage": "SQL",
+      "metricExpressionCode": "SUM(subscription_amount)",
+      "metricType": "SUM",
+      "granularity": "MONTH",
+      "unitOfMeasurement": "DOLLARS",
+      "owners": ["finance-team"],
+      "reviewers": ["data-governance-team"],
+      "tags": ["Finance", "KPI"],
+      "domains": ["Revenue"]
     }
   }
 }

--- a/v1.13.x/how-to-guides/mcp/reference.mdx
+++ b/v1.13.x/how-to-guides/mcp/reference.mdx
@@ -18,6 +18,10 @@ All OpenMetadata MCP tools, with parameters and examples.
 | [`create_glossary`](#create_glossary) | Governance | Create a new glossary to organize business terms |
 | [`create_glossary_term`](#create_glossary_term) | Governance | Add a term to an existing glossary |
 | [`create_metric`](#create_metric) | Governance | Create a new metric entity |
+| [`create_classification`](#create_classification) | Governance | Create a new tag classification (top-level tag container) |
+| [`create_tag`](#create_tag) | Governance | Create a new tag within an existing classification |
+| [`create_domain`](#create_domain) | Governance | Create a new domain for grouping data assets |
+| [`create_data_product`](#create_data_product) | Governance | Create a new data product within one or more domains |
 | [`get_entity_lineage`](#get_entity_lineage) | Lineage | Explore upstream/downstream dependencies |
 | [`create_lineage`](#create_lineage) | Lineage | Create a lineage relationship between two entities |
 | [`get_test_definitions`](#get_test_definitions) | Data Quality | List available test definitions for tables or columns |
@@ -464,6 +468,203 @@ All OpenMetadata MCP tools, with parameters and examples.
       "reviewers": ["data-governance-team"],
       "tags": ["Finance", "KPI"],
       "domains": ["Revenue"]
+    }
+  }
+}
+```
+
+---
+
+### create_classification
+
+**Description**: Create a new Classification in OpenMetadata. A Classification is a top-level container that groups related Tags (e.g., `PII`, `Tier`). The `name` becomes the root segment of every tag FQN under it. The `mutuallyExclusive` flag is immutable once the classification exists.
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Name of the classification. Becomes the root segment of tag FQNs (e.g., `PII` → `PII.Sensitive`). Must be unique. |
+| `description` | string | Yes | Description of the classification in Markdown format. |
+| `displayName` | string | No | Human-readable display name. |
+| `mutuallyExclusive` | boolean | No | If `true`, an entity can only carry one tag from this classification at a time. Immutable after creation. |
+| `owners` | array | No | OpenMetadata usernames or team names to set as owners. Each must already exist. |
+| `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
+| `domains` | array | No | FQNs of domains this classification belongs to. Each domain must already exist. |
+
+#### Example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "create_classification",
+    "arguments": {
+      "name": "PII",
+      "description": "Tags for classifying Personally Identifiable Information across data assets.",
+      "mutuallyExclusive": false,
+      "owners": ["data-governance-team"],
+      "reviewers": ["privacy-team"]
+    }
+  }
+}
+```
+
+---
+
+### create_tag
+
+**Description**: Create a new Tag inside a Classification in OpenMetadata. The tag FQN is `Classification.TagName` (e.g., `PII.Sensitive`). At least one of `classification` or `parent` must be provided.
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Name of the tag (the leaf segment, e.g., `Sensitive`). Must be unique within its parent. |
+| `description` | string | Yes | Description of the tag in Markdown format. |
+| `classification` | string | No | Name of the classification this tag belongs to (e.g., `PII`). Must already exist. Optional if `parent` is provided. |
+| `parent` | string | No | FQN of the parent tag for a nested tag (e.g., `PII.PersonalData`). Must already exist. Omit for a top-level tag. |
+| `displayName` | string | No | Human-readable display name. |
+| `mutuallyExclusive` | boolean | No | If `true`, child tags under this tag are mutually exclusive on an entity. |
+| `owners` | array | No | OpenMetadata usernames or team names to set as owners. Each must already exist. |
+| `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
+| `domains` | array | No | FQNs of domains this tag belongs to. Each domain must already exist. |
+
+#### Examples
+
+**Create a top-level tag**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "create_tag",
+    "arguments": {
+      "name": "Sensitive",
+      "description": "Data that contains sensitive personal information requiring strict access controls.",
+      "classification": "PII"
+    }
+  }
+}
+```
+
+**Create a nested tag**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "create_tag",
+    "arguments": {
+      "name": "Email",
+      "description": "Email addresses — a subset of sensitive personal data.",
+      "parent": "PII.Sensitive"
+    }
+  }
+}
+```
+
+---
+
+### create_domain
+
+**Description**: Create a new Domain in OpenMetadata. A Domain is a top-level governance grouping of data assets. To create a child domain, set `parent` to the FQN of an existing parent domain. `domainType` defaults to `Aggregate` if omitted.
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Name of the domain. Must be unique. |
+| `description` | string | Yes | Description of the domain in Markdown format. |
+| `domainType` | string | No | Type of domain: `Source-aligned`, `Consumer-aligned`, or `Aggregate` (default). |
+| `parent` | string | No | FQN of an existing parent domain when creating a child domain. Omit for a top-level domain. |
+| `displayName` | string | No | Human-readable display name. |
+| `experts` | array | No | OpenMetadata login names of domain experts (e.g., `john.doe`). Each must already exist. |
+| `owners` | array | No | OpenMetadata usernames or team names to set as owners. Each must already exist. |
+| `tags` | array | No | Tag FQNs to apply to this domain (e.g., `Tier.Tier1`). |
+
+#### Examples
+
+**Create a top-level domain**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "create_domain",
+    "arguments": {
+      "name": "Finance",
+      "description": "Domain for all finance and accounting data assets.",
+      "domainType": "Consumer-aligned",
+      "experts": ["jane.doe"],
+      "owners": ["finance-team"]
+    }
+  }
+}
+```
+
+**Create a child domain**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "create_domain",
+    "arguments": {
+      "name": "Revenue",
+      "description": "Sub-domain covering revenue tracking and forecasting.",
+      "domainType": "Aggregate",
+      "parent": "Finance"
+    }
+  }
+}
+```
+
+---
+
+### create_data_product
+
+**Description**: Create a new Data Product in OpenMetadata. A Data Product groups data assets that deliver business value and must belong to at least one Domain. All referenced domain FQNs must already exist.
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Name of the data product. Must be unique. |
+| `description` | string | Yes | Description of the data product in Markdown format. |
+| `domains` | array | Yes | FQNs of the domains this data product belongs to (e.g., `Finance`). At least one required; each must already exist. |
+| `displayName` | string | No | Human-readable display name. |
+| `experts` | array | No | OpenMetadata login names of data product experts (e.g., `john.doe`). Each must already exist. |
+| `owners` | array | No | OpenMetadata usernames or team names to set as owners. Each must already exist. |
+| `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
+| `tags` | array | No | Tag FQNs to apply to this data product (e.g., `Tier.Tier1`, `PII.Sensitive`). |
+
+#### Example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "create_data_product",
+    "arguments": {
+      "name": "customer_360",
+      "displayName": "Customer 360",
+      "description": "Unified view of customer data including orders, support history, and lifetime value.",
+      "domains": ["Finance", "Marketing"],
+      "experts": ["alice.smith"],
+      "owners": ["data-platform-team"],
+      "tags": ["Tier.Tier1"]
     }
   }
 }

--- a/v1.13.x/how-to-guides/mcp/vscode.mdx
+++ b/v1.13.x/how-to-guides/mcp/vscode.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with VS Code
 description: Connect your OpenMetadata MCP Server to Visual Studio Code for AI-powered metadata exploration.
-sidebarTitle: Getting Started with VS Code
+sidebarTitle: VS Code
 ---
 
 # Getting Started with VS Code

--- a/v2.0.x-SNAPSHOT/how-to-guides/mcp/claude-code.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/mcp/claude-code.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Claude Code
 description: Connect your OpenMetadata MCP Server to Claude Code (CLI) for AI-powered metadata exploration from the terminal.
-sidebarTitle: Getting Started with Claude Code
+sidebarTitle: Claude Code
 ---
 
 # Getting Started with Claude Code

--- a/v2.0.x-SNAPSHOT/how-to-guides/mcp/claude.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/mcp/claude.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Claude Desktop
 description: Set up MCP Server to connect Claude Desktop with OAuth or PAT-based authentication for AI-powered access to your data.
-sidebarTitle: Getting Started with Claude Desktop
+sidebarTitle: Claude Desktop
 ---
 
 # Getting Started with Claude Desktop

--- a/v2.0.x-SNAPSHOT/how-to-guides/mcp/cursor.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/mcp/cursor.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Cursor
 description: Connect your OpenMetadata MCP Server to Cursor IDE with OAuth or PAT-based authentication for AI-powered metadata exploration.
-sidebarTitle: Getting Started with Cursor
+sidebarTitle: Cursor
 ---
 
 # Getting Started with Cursor

--- a/v2.0.x-SNAPSHOT/how-to-guides/mcp/goose.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/mcp/goose.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Goose Desktop
 description: Learn how to connect Goose Desktop with MCP Server, create tokens, and enable secure AI-powered access to your data platform.
-sidebarTitle: Getting Started with Goose Desktop
+sidebarTitle: Goose Desktop
 ---
 
 # Getting Started with Goose Desktop

--- a/v2.0.x-SNAPSHOT/how-to-guides/mcp/reference.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/mcp/reference.mdx
@@ -9,28 +9,19 @@ All OpenMetadata MCP tools, with parameters and examples.
 
 ## Available Tools
 
-| Tool | Category | Description |
-|------|----------|-------------|
-| [`search_metadata`](#search_metadata) | Discovery | Keyword-based search for data assets and business terms |
-| [`semantic_search`](#semantic_search) | Discovery | Meaning-based search using vector embeddings |
-| [`get_entity_details`](#get_entity_details) | Discovery | Retrieve full details for a specific entity by FQN |
-| [`patch_entity`](#patch_entity) | Governance | Update an existing entity using JSON Patch |
-| [`create_glossary`](#create_glossary) | Governance | Create a new glossary to organize business terms |
-| [`create_glossary_term`](#create_glossary_term) | Governance | Add a term to an existing glossary |
-| [`create_metric`](#create_metric) | Governance | Create a new metric entity |
-| [`create_classification`](#create_classification) | Governance | Create a new tag classification (top-level tag container) |
-| [`create_tag`](#create_tag) | Governance | Create a new tag within an existing classification |
-| [`create_domain`](#create_domain) | Governance | Create a new domain for grouping data assets |
-| [`create_data_product`](#create_data_product) | Governance | Create a new data product within one or more domains |
-| [`get_entity_lineage`](#get_entity_lineage) | Lineage | Explore upstream/downstream dependencies |
-| [`create_lineage`](#create_lineage) | Lineage | Create a lineage relationship between two entities |
-| [`get_test_definitions`](#get_test_definitions) | Data Quality | List available test definitions for tables or columns |
-| [`create_test_case`](#create_test_case) | Data Quality | Create a data quality test for a table or column |
-| [`root_cause_analysis`](#root_cause_analysis) | Data Quality | Perform root cause analysis via data quality lineage |
+| Category | Tools |
+|---|---|
+| **Discover** | [search_metadata](#search_metadata), [semantic_search](#semantic_search), [search_company_context](#search_company_context) |
+| **Inspect** | [get_entity_details](#get_entity_details), [get_company_context](#get_company_context) |
+| **Lineage & Impact** | [get_entity_lineage](#get_entity_lineage), [create_lineage](#create_lineage), [root_cause_analysis](#root_cause_analysis) |
+| **Knowledge** | [create_glossary](#create_glossary), [create_glossary_term](#create_glossary_term), [create_context_memory](#create_context_memory) |
+| **Govern & Classify** | [create_classification](#create_classification), [create_tag](#create_tag), [create_domain](#create_domain), [create_data_product](#create_data_product), [patch_entity](#patch_entity) |
+| **Data Quality** | [get_test_definitions](#get_test_definitions), [create_test_case](#create_test_case) |
+| **Metrics** | [create_metric](#create_metric) |
 
----
+## Discover
 
-## Discovery & Search Tools
+Search and find data assets across your catalog using keyword, semantic, or natural language queries.
 
 ### search_metadata
 
@@ -42,7 +33,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 - Search for glossary terms
 - Locate pipelines by name or description
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -56,15 +47,14 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `includeAggregations` | boolean | No | Include aggregation/facet data (default: false) |
 | `maxAggregationBuckets` | integer | No | Max buckets per aggregation (default: 10, max: 50) |
 
-#### Entity Types
-
+**Entity Types**
 - **Service Entities**: `databaseService`, `messagingService`, `apiService`, `dashboardService`, `pipelineService`, `storageService`, `mlmodelService`, `metadataService`, `searchService`
 - **Data Asset Entities**: `apiCollection`, `apiEndpoint`, `table`, `storedProcedure`, `database`, `databaseSchema`, `dashboard`, `dashboardDataModel`, `pipeline`, `chart`, `topic`, `searchIndex`, `mlmodel`, `container`
 - **User Entities**: `user`, `team`
 - **Domain Entities**: `domain`, `dataProduct`
 - **Governance Entities**: `metric`, `glossary`, `glossaryTerm`
 
-#### Examples
+**Examples**
 
 **Basic Search**:
 
@@ -136,8 +126,6 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### semantic_search
 
 **Description**: Find data assets by meaning using vector search ([setup guide](../../deployment/semantic-search#enable-semantic-search)). Use for exploratory queries where you don't know exact names. Returns conceptually related assets even when no keywords match.
@@ -147,7 +135,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 - Find assets related to a concept (e.g., "customer spending behavior")
 - Discover hidden relationships across services
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -157,7 +145,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `k` | integer | No | KNN neighbor count for tuning result quality (default: 100) |
 | `threshold` | number | No | Minimum similarity score 0.0–1.0 (default: 0.0) |
 
-#### Examples
+**Examples**
 
 **Conceptual Search**:
 
@@ -197,20 +185,50 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
+### search_company_context
+
+**Description**: Semantic search over company context knowledge pills from the Context Center. Returns matching pills with their title, question, answer, summary, and source file. Use this to answer questions from company documents, runbooks, FAQs, and policies.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Natural-language question or topic to find relevant company knowledge for |
+| `size` | integer | No | Number of pills to return. Default is 10, maximum is 50 |
+
+**Example**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "search_company_context",
+    "arguments": {
+      "query": "data retention policy",
+      "size": 5
+    }
+  }
+}
+```
+
+## Inspect
+
+Retrieve detailed information about specific entities and company knowledge pills.
 
 ### get_entity_details
 
 **Description**: Retrieve full details for a specific entity by fully qualified name (FQN). Pass the exact `fullyQualifiedName` value from search results — do not construct FQNs manually.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `entityType` | string | Yes | Type of entity (e.g., `table`, `dashboard`, `topic`, `pipeline`) |
 | `fqn` | string | Yes | Fully qualified name — use the exact value from `search_metadata` or `semantic_search` results |
 
-#### Examples
+**Examples**
 
 **Get Table Details**:
 
@@ -263,15 +281,17 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
+### get_company_context
 
-## Governance Tools
+**Description**: Fetch a single company context knowledge pill by its fully qualified name. Returns the full title, question, answer, summary, and source file. Use the `fullyQualifiedName` or `name` returned by `search_company_context`.
 
-### patch_entity
+**Parameters**
 
-**Description**: Update an existing entity's properties using [JSON Patch](https://jsonpatch.com/) (RFC 6902). Use `get_entity_details` first to retrieve the current state before constructing a patch.
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `fqn` | string | Yes | The `fullyQualifiedName` or `name` of the knowledge pill from a `search_company_context` result. Pass it verbatim |
 
-#### Example
+**Example**
 
 ```json
 {
@@ -279,23 +299,152 @@ All OpenMetadata MCP tools, with parameters and examples.
   "id": 1,
   "method": "tools/call",
   "params": {
-    "name": "patch_entity",
+    "name": "get_company_context",
     "arguments": {
-      "entityType": "table",
-      "fqn": "mysql_prod.ecommerce.public.customer_orders",
-      "patch": "[{\"op\":\"replace\",\"path\":\"/description\",\"value\":\"Updated description for customer orders table.\"}]"
+      "fqn": "data-retention-policy.gdpr-rules"
     }
   }
 }
 ```
 
----
+## Lineage & Impact
+
+Explore data dependencies, trace upstream sources, and analyze downstream impact.
+
+### get_entity_lineage
+
+**Description**: Retrieve upstream and downstream lineage for any entity to understand data dependencies and perform impact analysis. Pass the exact `fullyQualifiedName` from search results.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `entityType` | string | Yes | Type of entity |
+| `fqn` | string | Yes | Fully qualified name of the entity |
+| `upstreamDepth` | integer | No | Hops to traverse upstream (default: 3, max: 10) |
+| `downstreamDepth` | integer | No | Hops to traverse downstream (default: 3, max: 10) |
+| `includeColumnLineage` | boolean | No | Include column-level lineage mappings. Default is `false` (table-level only) |
+
+**Examples**
+
+**Get Full Lineage**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "get_entity_lineage",
+    "arguments": {
+      "entityType": "table",
+      "fqn": "mysql_prod.ecommerce.public.sales_transactions",
+      "upstreamDepth": 3,
+      "downstreamDepth": 3
+    }
+  }
+}
+```
+
+**Downstream-Focused Impact Analysis**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "get_entity_lineage",
+    "arguments": {
+      "entityType": "table",
+      "fqn": "mysql_prod.ecommerce.public.sales_transactions",
+      "upstreamDepth": 1,
+      "downstreamDepth": 5
+    }
+  }
+}
+```
+
+### create_lineage
+
+**Description**: Create a lineage relationship between two entities. Requires the `id` (UUID) and `type` of both the source and destination entities.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `fromEntity` | object | Yes | Source entity with `type` (string) and `id` (UUID string) |
+| `toEntity` | object | Yes | Destination entity with `type` (string) and `id` (UUID string) |
+
+**Example**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "create_lineage",
+    "arguments": {
+      "fromEntity": {
+        "type": "table",
+        "id": "3a1b2c3d-4e5f-6789-abcd-ef0123456789"
+      },
+      "toEntity": {
+        "type": "table",
+        "id": "9f8e7d6c-5b4a-3210-fedc-ba9876543210"
+      }
+    }
+  }
+}
+```
+
+> **Tip**: Retrieve entity UUIDs from `get_entity_details` results before calling `create_lineage`.
+
+### root_cause_analysis
+
+**Description**: Trace a data quality failure back to its origin by traversing data quality lineage across pipeline hops.
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `fqn` | string | Yes | FQN of the entity where failure was detected |
+| `entityType` | string | Yes | Entity type to analyze (for example, `table`) |
+| `upstreamDepth` | integer | No | Hops to traverse upstream (default: 3, max: 10) |
+| `downstreamDepth` | integer | No | Hops to traverse downstream (default: 3, max: 10) |
+| `queryFilter` | string | No | Optional OpenSearch DSL filter JSON |
+| `includeDeleted` | boolean | No | Include deleted entities in traversal (default: false) |
+
+**Example**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 12,
+  "method": "tools/call",
+  "params": {
+    "name": "root_cause_analysis",
+    "arguments": {
+      "fqn": "mysql_prod.ecommerce.public.customer_orders",
+      "entityType": "table",
+      "upstreamDepth": 4,
+      "downstreamDepth": 1,
+      "includeDeleted": false
+    }
+  }
+}
+```
+
+## Knowledge
+
+Create and manage glossaries, terms, and reusable context memories.
 
 ### create_glossary
 
 **Description**: Create a new glossary to organize business terms. Set `mutuallyExclusive: true` to restrict entities to a single term from the glossary at a time.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -305,7 +454,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `owners` | array | No | List of owner usernames or emails |
 | `reviewers` | array | No | List of reviewer usernames or emails |
 
-#### Examples
+**Examples**
 
 **Create a Business Glossary**:
 
@@ -363,13 +512,11 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### create_glossary_term
 
 **Description**: Create a new term within an existing glossary. Supports hierarchical parent–child relationships between terms.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -380,7 +527,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `owners` | array | No | List of owner usernames or emails |
 | `reviewers` | array | No | List of reviewer usernames or emails |
 
-#### Examples
+**Examples**
 
 **Create a Root-Level Term**:
 
@@ -421,65 +568,56 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
+### create_context_memory
 
-### create_metric
+**Description**: Save a reusable piece of knowledge to the Context Center — a preference, instruction, runbook step, or FAQ answer the assistant should retain across conversations. Use this when the user explicitly asks you to remember, note, or store something.
 
-**Description**: Create a new metric entity in OpenMetadata to track and standardize business KPIs.
-
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `name` | string | Yes | Name of the metric |
-| `description` | string | No | Description of the metric in Markdown format |
-| `displayName` | string | No | Human-readable display name for the metric |
-| `metricExpressionLanguage` | string | Yes | Expression language used for the metric (for example, `SQL`) |
-| `metricExpressionCode` | string | Yes | Metric formula/expression in the selected language |
-| `metricType` | string | No | Metric type such as `COUNT`, `SUM`, `AVERAGE`, `RATIO`, or `OTHER` |
-| `granularity` | string | No | Time granularity such as `DAY`, `WEEK`, `MONTH`, `QUARTER`, or `YEAR` |
-| `unitOfMeasurement` | string | No | Unit of measurement such as `COUNT`, `DOLLARS`, `PERCENTAGE`, or `OTHER` |
-| `customUnitOfMeasurement` | string | No | Custom unit string, required when `unitOfMeasurement` is `OTHER` |
-| `owners` | array | No | List of owner usernames or emails |
-| `reviewers` | array | No | List of reviewer usernames or emails |
-| `relatedMetrics` | array | No | List of related metric FQNs |
-| `tags` | array | No | List of tags to apply |
-| `domains` | array | No | List of domains to associate |
+| `name` | string | Yes | Stable, unique system name. Reusing an existing name updates that memory |
+| `question` | string | Yes | The canonical question or instruction this memory represents |
+| `answer` | string | Yes | The canonical answer or guidance to retain |
+| `title` | string | No | Short human-readable title shown in the Context Center |
+| `summary` | string | No | One-line summary of the memory |
+| `memoryType` | string | No | `Preference`, `UseCase`, `Note`, `Runbook`, or `Faq`. Defaults to `Note` |
+| `memoryScope` | string | No | `UserGlobal` (broad) or `EntityScoped` (tied to a specific entity) |
+| `owners` | array | No | OpenMetadata usernames or team names |
+| `tags` | array | No | Tag FQNs to apply |
+| `domains` | array | No | Domain FQNs this memory belongs to |
 
-#### Example
+**Example**
 
 ```json
 {
   "jsonrpc": "2.0",
-  "id": 10,
+  "id": 1,
   "method": "tools/call",
   "params": {
-    "name": "create_metric",
+    "name": "create_context_memory",
     "arguments": {
-      "name": "monthly_recurring_revenue",
-      "displayName": "Monthly Recurring Revenue",
-      "description": "Monthly recurring revenue from active subscriptions.",
-      "metricExpressionLanguage": "SQL",
-      "metricExpressionCode": "SUM(subscription_amount)",
-      "metricType": "SUM",
-      "granularity": "MONTH",
-      "unitOfMeasurement": "DOLLARS",
-      "owners": ["finance-team"],
-      "reviewers": ["data-governance-team"],
-      "tags": ["Finance", "KPI"],
-      "domains": ["Revenue"]
+      "name": "finance-warehouse-preference",
+      "title": "Finance Dashboard Warehouse",
+      "question": "Which warehouse should finance dashboards query?",
+      "answer": "Always query the FINANCE_PROD warehouse for finance dashboards.",
+      "memoryType": "Preference",
+      "memoryScope": "UserGlobal",
+      "domains": ["Finance"]
     }
   }
 }
 ```
 
----
+## Govern & Classify
+
+Define and apply classifications, tags, domains, data products, and entity updates.
 
 ### create_classification
 
 **Description**: Create a new Classification in OpenMetadata. A Classification is a top-level container that groups related Tags (e.g., `PII`, `Tier`). The `name` becomes the root segment of every tag FQN under it. The `mutuallyExclusive` flag is immutable once the classification exists.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -491,7 +629,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
 | `domains` | array | No | FQNs of domains this classification belongs to. Each domain must already exist. |
 
-#### Example
+**Example**
 
 ```json
 {
@@ -511,13 +649,11 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### create_tag
 
 **Description**: Create a new Tag inside a Classification in OpenMetadata. The tag FQN is `Classification.TagName` (e.g., `PII.Sensitive`). At least one of `classification` or `parent` must be provided.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -531,7 +667,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
 | `domains` | array | No | FQNs of domains this tag belongs to. Each domain must already exist. |
 
-#### Examples
+**Examples**
 
 **Create a top-level tag**:
 
@@ -569,13 +705,11 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### create_domain
 
 **Description**: Create a new Domain in OpenMetadata. A Domain is a top-level governance grouping of data assets. To create a child domain, set `parent` to the FQN of an existing parent domain. `domainType` defaults to `Aggregate` if omitted.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -588,7 +722,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `owners` | array | No | OpenMetadata usernames or team names to set as owners. Each must already exist. |
 | `tags` | array | No | Tag FQNs to apply to this domain (e.g., `Tier.Tier1`). |
 
-#### Examples
+**Examples**
 
 **Create a top-level domain**:
 
@@ -629,13 +763,11 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### create_data_product
 
 **Description**: Create a new Data Product in OpenMetadata. A Data Product groups data assets that deliver business value and must belong to at least one Domain. All referenced domain FQNs must already exist.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -648,7 +780,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
 | `tags` | array | No | Tag FQNs to apply to this data product (e.g., `Tier.Tier1`, `PII.Sensitive`). |
 
-#### Example
+**Example**
 
 ```json
 {
@@ -670,26 +802,19 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
+### patch_entity
 
-## Lineage Tools
+**Description**: Update an existing entity's properties using [JSON Patch](https://jsonpatch.com/) (RFC 6902). Use `get_entity_details` first to retrieve the current state before constructing a patch.
 
-### get_entity_lineage
-
-**Description**: Retrieve upstream and downstream lineage for any entity to understand data dependencies and perform impact analysis. Pass the exact `fullyQualifiedName` from search results.
-
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `entityType` | string | Yes | Type of entity |
-| `fqn` | string | Yes | Fully qualified name of the entity |
-| `upstreamDepth` | integer | No | Hops to traverse upstream (default: 3, max: 10) |
-| `downstreamDepth` | integer | No | Hops to traverse downstream (default: 3, max: 10) |
+| `entityType` | string | Yes | Type of entity to patch (e.g., `table`, `glossaryTerm`) |
+| `fqn` | string | Yes | Fully qualified name of the entity to patch |
+| `patch` | string | Yes | JSON Patch operations array as a JSON string. Each operation has `op` (`add`/`remove`/`replace`), `path`, and `value` |
 
-#### Examples
-
-**Get Full Lineage**:
+**Example**
 
 ```json
 {
@@ -697,83 +822,25 @@ All OpenMetadata MCP tools, with parameters and examples.
   "id": 1,
   "method": "tools/call",
   "params": {
-    "name": "get_entity_lineage",
+    "name": "patch_entity",
     "arguments": {
       "entityType": "table",
-      "fqn": "mysql_prod.ecommerce.public.sales_transactions",
-      "upstreamDepth": 3,
-      "downstreamDepth": 3
+      "fqn": "mysql_prod.ecommerce.public.customer_orders",
+      "patch": "[{\"op\":\"replace\",\"path\":\"/description\",\"value\":\"Updated description for customer orders table.\"}]"
     }
   }
 }
 ```
 
-**Downstream-Focused Impact Analysis**:
+## Data Quality
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 2,
-  "method": "tools/call",
-  "params": {
-    "name": "get_entity_lineage",
-    "arguments": {
-      "entityType": "table",
-      "fqn": "mysql_prod.ecommerce.public.sales_transactions",
-      "upstreamDepth": 1,
-      "downstreamDepth": 5
-    }
-  }
-}
-```
-
----
-
-### create_lineage
-
-**Description**: Create a lineage relationship between two entities. Requires the `id` (UUID) and `type` of both the source and destination entities.
-
-#### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `fromEntity` | object | Yes | Source entity with `type` (string) and `id` (UUID string) |
-| `toEntity` | object | Yes | Destination entity with `type` (string) and `id` (UUID string) |
-
-#### Example
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "create_lineage",
-    "arguments": {
-      "fromEntity": {
-        "type": "table",
-        "id": "3a1b2c3d-4e5f-6789-abcd-ef0123456789"
-      },
-      "toEntity": {
-        "type": "table",
-        "id": "9f8e7d6c-5b4a-3210-fedc-ba9876543210"
-      }
-    }
-  }
-}
-```
-
-> **Tip**: Retrieve entity UUIDs from `get_entity_details` results before calling `create_lineage`.
-
----
-
-## Data Quality Tools
+Access test definitions and create test cases to validate your data assets.
 
 ### get_test_definitions
 
 **Description**: List test definitions available in OpenMetadata for tables or columns. Call this before `create_test_case` to identify valid test types and their required parameters.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -782,7 +849,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `after` | string | No | Pagination cursor — use `nextCursor` from the previous response |
 | `testPlatform` | string | No | Filter by platform: `OpenMetadata`, `GreatExpectations`, `DBT`, `Deequ`, `Soda`, `Other` (default: `OpenMetadata`) |
 
-#### Example
+**Example**
 
 ```json
 {
@@ -799,13 +866,11 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
-
 ### create_test_case
 
 **Description**: Create a data quality test case for a table or column. For column tests, ensure the column's data type is listed in the test definition's `supportedDataTypes`.
 
-#### Parameters
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -817,7 +882,7 @@ All OpenMetadata MCP tools, with parameters and examples.
 | `entityType` | string | No | Target OpenMetadata entity type (default: `table`). For column-level tests, keep `entityType` as `table` and set `columnName`. |
 | `description` | string | No | Optional description of the test case |
 
-#### Example
+**Example**
 
 ```json
 {
@@ -839,38 +904,55 @@ All OpenMetadata MCP tools, with parameters and examples.
 }
 ```
 
----
+## Metrics
 
-### root_cause_analysis
+Define and track measurable business and technical KPIs.
 
-**Description**: Trace a data quality failure back to its origin by traversing data quality lineage across pipeline hops.
+### create_metric
 
-#### Parameters
+**Description**: Create a new metric entity in OpenMetadata to track and standardize business KPIs.
+
+**Parameters**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `fqn` | string | Yes | FQN of the entity where failure was detected |
-| `entityType` | string | Yes | Entity type to analyze (for example, `table`) |
-| `upstreamDepth` | integer | No | Hops to traverse upstream (default: 3, max: 10) |
-| `downstreamDepth` | integer | No | Hops to traverse downstream (default: 3, max: 10) |
-| `queryFilter` | string | No | Optional OpenSearch DSL filter JSON |
-| `includeDeleted` | boolean | No | Include deleted entities in traversal (default: false) |
+| `name` | string | Yes | Name of the metric |
+| `description` | string | No | Description of the metric in Markdown format |
+| `displayName` | string | No | Human-readable display name for the metric |
+| `metricExpressionLanguage` | string | Yes | Expression language used for the metric (for example, `SQL`) |
+| `metricExpressionCode` | string | Yes | Metric formula/expression in the selected language |
+| `metricType` | string | No | Metric type such as `COUNT`, `SUM`, `AVERAGE`, `RATIO`, or `OTHER` |
+| `granularity` | string | No | Time granularity such as `DAY`, `WEEK`, `MONTH`, `QUARTER`, or `YEAR` |
+| `unitOfMeasurement` | string | No | Unit of measurement such as `COUNT`, `DOLLARS`, `PERCENTAGE`, or `OTHER` |
+| `customUnitOfMeasurement` | string | No | Custom unit string, required when `unitOfMeasurement` is `OTHER` |
+| `owners` | array | No | List of owner usernames or emails |
+| `reviewers` | array | No | List of reviewer usernames or emails |
+| `relatedMetrics` | array | No | List of related metric FQNs |
+| `tags` | array | No | List of tags to apply |
+| `domains` | array | No | List of domains to associate |
 
-#### Example
+**Example**
 
 ```json
 {
   "jsonrpc": "2.0",
-  "id": 12,
+  "id": 10,
   "method": "tools/call",
   "params": {
-    "name": "root_cause_analysis",
+    "name": "create_metric",
     "arguments": {
-      "fqn": "mysql_prod.ecommerce.public.customer_orders",
-      "entityType": "table",
-      "upstreamDepth": 4,
-      "downstreamDepth": 1,
-      "includeDeleted": false
+      "name": "monthly_recurring_revenue",
+      "displayName": "Monthly Recurring Revenue",
+      "description": "Monthly recurring revenue from active subscriptions.",
+      "metricExpressionLanguage": "SQL",
+      "metricExpressionCode": "SUM(subscription_amount)",
+      "metricType": "SUM",
+      "granularity": "MONTH",
+      "unitOfMeasurement": "DOLLARS",
+      "owners": ["finance-team"],
+      "reviewers": ["data-governance-team"],
+      "tags": ["Finance", "KPI"],
+      "domains": ["Revenue"]
     }
   }
 }

--- a/v2.0.x-SNAPSHOT/how-to-guides/mcp/reference.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/mcp/reference.mdx
@@ -18,6 +18,10 @@ All OpenMetadata MCP tools, with parameters and examples.
 | [`create_glossary`](#create_glossary) | Governance | Create a new glossary to organize business terms |
 | [`create_glossary_term`](#create_glossary_term) | Governance | Add a term to an existing glossary |
 | [`create_metric`](#create_metric) | Governance | Create a new metric entity |
+| [`create_classification`](#create_classification) | Governance | Create a new tag classification (top-level tag container) |
+| [`create_tag`](#create_tag) | Governance | Create a new tag within an existing classification |
+| [`create_domain`](#create_domain) | Governance | Create a new domain for grouping data assets |
+| [`create_data_product`](#create_data_product) | Governance | Create a new data product within one or more domains |
 | [`get_entity_lineage`](#get_entity_lineage) | Lineage | Explore upstream/downstream dependencies |
 | [`create_lineage`](#create_lineage) | Lineage | Create a lineage relationship between two entities |
 | [`get_test_definitions`](#get_test_definitions) | Data Quality | List available test definitions for tables or columns |
@@ -464,6 +468,203 @@ All OpenMetadata MCP tools, with parameters and examples.
       "reviewers": ["data-governance-team"],
       "tags": ["Finance", "KPI"],
       "domains": ["Revenue"]
+    }
+  }
+}
+```
+
+---
+
+### create_classification
+
+**Description**: Create a new Classification in OpenMetadata. A Classification is a top-level container that groups related Tags (e.g., `PII`, `Tier`). The `name` becomes the root segment of every tag FQN under it. The `mutuallyExclusive` flag is immutable once the classification exists.
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Name of the classification. Becomes the root segment of tag FQNs (e.g., `PII` → `PII.Sensitive`). Must be unique. |
+| `description` | string | Yes | Description of the classification in Markdown format. |
+| `displayName` | string | No | Human-readable display name. |
+| `mutuallyExclusive` | boolean | No | If `true`, an entity can only carry one tag from this classification at a time. Immutable after creation. |
+| `owners` | array | No | OpenMetadata usernames or team names to set as owners. Each must already exist. |
+| `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
+| `domains` | array | No | FQNs of domains this classification belongs to. Each domain must already exist. |
+
+#### Example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "create_classification",
+    "arguments": {
+      "name": "PII",
+      "description": "Tags for classifying Personally Identifiable Information across data assets.",
+      "mutuallyExclusive": false,
+      "owners": ["data-governance-team"],
+      "reviewers": ["privacy-team"]
+    }
+  }
+}
+```
+
+---
+
+### create_tag
+
+**Description**: Create a new Tag inside a Classification in OpenMetadata. The tag FQN is `Classification.TagName` (e.g., `PII.Sensitive`). At least one of `classification` or `parent` must be provided.
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Name of the tag (the leaf segment, e.g., `Sensitive`). Must be unique within its parent. |
+| `description` | string | Yes | Description of the tag in Markdown format. |
+| `classification` | string | No | Name of the classification this tag belongs to (e.g., `PII`). Must already exist. Optional if `parent` is provided. |
+| `parent` | string | No | FQN of the parent tag for a nested tag (e.g., `PII.PersonalData`). Must already exist. Omit for a top-level tag. |
+| `displayName` | string | No | Human-readable display name. |
+| `mutuallyExclusive` | boolean | No | If `true`, child tags under this tag are mutually exclusive on an entity. |
+| `owners` | array | No | OpenMetadata usernames or team names to set as owners. Each must already exist. |
+| `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
+| `domains` | array | No | FQNs of domains this tag belongs to. Each domain must already exist. |
+
+#### Examples
+
+**Create a top-level tag**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "create_tag",
+    "arguments": {
+      "name": "Sensitive",
+      "description": "Data that contains sensitive personal information requiring strict access controls.",
+      "classification": "PII"
+    }
+  }
+}
+```
+
+**Create a nested tag**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "create_tag",
+    "arguments": {
+      "name": "Email",
+      "description": "Email addresses — a subset of sensitive personal data.",
+      "parent": "PII.Sensitive"
+    }
+  }
+}
+```
+
+---
+
+### create_domain
+
+**Description**: Create a new Domain in OpenMetadata. A Domain is a top-level governance grouping of data assets. To create a child domain, set `parent` to the FQN of an existing parent domain. `domainType` defaults to `Aggregate` if omitted.
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Name of the domain. Must be unique. |
+| `description` | string | Yes | Description of the domain in Markdown format. |
+| `domainType` | string | No | Type of domain: `Source-aligned`, `Consumer-aligned`, or `Aggregate` (default). |
+| `parent` | string | No | FQN of an existing parent domain when creating a child domain. Omit for a top-level domain. |
+| `displayName` | string | No | Human-readable display name. |
+| `experts` | array | No | OpenMetadata login names of domain experts (e.g., `john.doe`). Each must already exist. |
+| `owners` | array | No | OpenMetadata usernames or team names to set as owners. Each must already exist. |
+| `tags` | array | No | Tag FQNs to apply to this domain (e.g., `Tier.Tier1`). |
+
+#### Examples
+
+**Create a top-level domain**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "create_domain",
+    "arguments": {
+      "name": "Finance",
+      "description": "Domain for all finance and accounting data assets.",
+      "domainType": "Consumer-aligned",
+      "experts": ["jane.doe"],
+      "owners": ["finance-team"]
+    }
+  }
+}
+```
+
+**Create a child domain**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "create_domain",
+    "arguments": {
+      "name": "Revenue",
+      "description": "Sub-domain covering revenue tracking and forecasting.",
+      "domainType": "Aggregate",
+      "parent": "Finance"
+    }
+  }
+}
+```
+
+---
+
+### create_data_product
+
+**Description**: Create a new Data Product in OpenMetadata. A Data Product groups data assets that deliver business value and must belong to at least one Domain. All referenced domain FQNs must already exist.
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Name of the data product. Must be unique. |
+| `description` | string | Yes | Description of the data product in Markdown format. |
+| `domains` | array | Yes | FQNs of the domains this data product belongs to (e.g., `Finance`). At least one required; each must already exist. |
+| `displayName` | string | No | Human-readable display name. |
+| `experts` | array | No | OpenMetadata login names of data product experts (e.g., `john.doe`). Each must already exist. |
+| `owners` | array | No | OpenMetadata usernames or team names to set as owners. Each must already exist. |
+| `reviewers` | array | No | OpenMetadata usernames or team names to set as reviewers. Each must already exist. |
+| `tags` | array | No | Tag FQNs to apply to this data product (e.g., `Tier.Tier1`, `PII.Sensitive`). |
+
+#### Example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "create_data_product",
+    "arguments": {
+      "name": "customer_360",
+      "displayName": "Customer 360",
+      "description": "Unified view of customer data including orders, support history, and lifetime value.",
+      "domains": ["Finance", "Marketing"],
+      "experts": ["alice.smith"],
+      "owners": ["data-platform-team"],
+      "tags": ["Tier.Tier1"]
     }
   }
 }

--- a/v2.0.x-SNAPSHOT/how-to-guides/mcp/vscode.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/mcp/vscode.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with VS Code
 description: Connect your OpenMetadata MCP Server to Visual Studio Code for AI-powered metadata exploration.
-sidebarTitle: Getting Started with VS Code
+sidebarTitle: VS Code
 ---
 
 # Getting Started with VS Code


### PR DESCRIPTION
## Summary

This PR updates the MCP documentation across all versioned pages (v1.12.x, v1.13.x, v2.0.x-SNAPSHOT).

### New MCP Tools Added

| Tool | Category | Available From |
|------|----------|----------------|
| `create_classification` | Govern & Classify | v1.12.10+, v1.13.x |
| `create_tag` | Govern & Classify | v1.12.10+, v1.13.x |
| `create_domain` | Govern & Classify | v1.12.10+, v1.13.x |
| `create_data_product` | Govern & Classify | v1.12.10+, v1.13.x |
| `search_company_context` | Discover | All versions |
| `get_company_context` | Inspect | All versions |
| `create_context_memory` | Knowledge | All versions |
<img width="2952" height="1554" alt="image" src="https://github.com/user-attachments/assets/26f104e6-a545-498e-be47-44d4f7645ebd" />


### Reference Page Restructure

Reorganised the MCP Tools Reference from a flat list into 7 category-based sections:

| Category | Tools |
|----------|-------|
| **Discover** | `search_metadata`, `semantic_search`, `search_company_context` |
| **Inspect** | `get_entity_details`, `get_company_context` |
| **Lineage & Impact** | `get_entity_lineage`, `create_lineage`, `root_cause_analysis` |
| **Knowledge** | `create_glossary`, `create_glossary_term`, `create_context_memory` |
| **Govern & Classify** | `create_classification`, `create_tag`, `create_domain`, `create_data_product`, `patch_entity` |
| **Data Quality** | `get_test_definitions`, `create_test_case` |
| **Metrics** | `create_metric` |

### Navigation Improvements (`docs.json`)

- MCP client pages grouped under a **"Getting Started with MCP Clients"** sub-group
- `sidebarTitle` shortened on all client pages (e.g., "Getting Started with Claude Code" → "Claude Code")
<img width="2928" height="1402" alt="image" src="https://github.com/user-attachments/assets/50365ee7-338a-48a5-9c01-f93004da5fe9" />

## Test plan
- [ ] Verify all new tool sections render correctly in Mintlify preview
- [ ] Confirm anchor links in the Available Tools table resolve correctly
- [ ] Check MCP client pages appear correctly grouped in sidebar

