### PR TITLE
Docs: [MSSQL] document VIEW DEFINITION grant required for view lineage

### DIFF
--- a/v1.12.x/connectors/database/mssql.mdx
+++ b/v1.12.x/connectors/database/mssql.mdx
@@ -42,13 +42,13 @@ GRANT SELECT TO Mary;
 ### View Definitions
 
 <Warning>
-The `VIEW DEFINITION` permission is **required for view lineage**. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
+**View lineage requires** the `VIEW DEFINITION` (database-level) or `VIEW ANY DEFINITION` (server-level) permission. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
 </Warning>
 
 ```sql
--- Run in every database you want to ingest
+-- Database-level: grant to the database user, in every database you ingest
 GRANT VIEW DEFINITION TO Mary;
--- Or grant once at the server level to cover all databases
+-- Or server-level: grant to the login (not the contained user) to cover all databases
 GRANT VIEW ANY DEFINITION TO [login_name];
 ```
 ### Usage & Lineage consideration

--- a/v1.12.x/connectors/database/mssql.mdx
+++ b/v1.12.x/connectors/database/mssql.mdx
@@ -39,6 +39,18 @@ CREATE USER Mary WITH PASSWORD = '********';
 -- Grant SELECT on table
 GRANT SELECT TO Mary;
 ```
+### View Definitions
+
+<Warning>
+The `VIEW DEFINITION` permission is **required for view lineage**. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
+</Warning>
+
+```sql
+-- Run in every database you want to ingest
+GRANT VIEW DEFINITION TO Mary;
+-- Or grant once at the server level to cover all databases
+GRANT VIEW ANY DEFINITION TO [login_name];
+```
 ### Usage & Lineage consideration
 To perform the query analysis for Usage and Lineage computation, we fetch the query logs from `sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` &  `sys.dm_exec_sql_text` system tables. To access these tables your user must have `VIEW SERVER STATE` privilege.
 ```sql

--- a/v1.12.x/connectors/database/mssql/yaml.mdx
+++ b/v1.12.x/connectors/database/mssql/yaml.mdx
@@ -50,13 +50,13 @@ GRANT SELECT TO Mary;
 ### View Definitions
 
 <Warning>
-The `VIEW DEFINITION` permission is **required for view lineage**. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
+**View lineage requires** the `VIEW DEFINITION` (database-level) or `VIEW ANY DEFINITION` (server-level) permission. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
 </Warning>
 
 ```sql
--- Run in every database you want to ingest
+-- Database-level: grant to the database user, in every database you ingest
 GRANT VIEW DEFINITION TO Mary;
--- Or grant once at the server level to cover all databases
+-- Or server-level: grant to the login (not the contained user) to cover all databases
 GRANT VIEW ANY DEFINITION TO [login_name];
 ```
 ### Usage & Lineage consideration

--- a/v1.12.x/connectors/database/mssql/yaml.mdx
+++ b/v1.12.x/connectors/database/mssql/yaml.mdx
@@ -47,6 +47,18 @@ CREATE USER Mary WITH PASSWORD = '********';
 -- Grant SELECT on table
 GRANT SELECT TO Mary;
 ```
+### View Definitions
+
+<Warning>
+The `VIEW DEFINITION` permission is **required for view lineage**. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
+</Warning>
+
+```sql
+-- Run in every database you want to ingest
+GRANT VIEW DEFINITION TO Mary;
+-- Or grant once at the server level to cover all databases
+GRANT VIEW ANY DEFINITION TO [login_name];
+```
 ### Usage & Lineage consideration
 To perform the query analysis for Usage and Lineage computation, we fetch the query logs from `sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` &  `sys.dm_exec_sql_text` system tables. To access these tables your user must have `VIEW SERVER STATE` privilege.
 ```sql

--- a/v1.13.x/connectors/database/mssql.mdx
+++ b/v1.13.x/connectors/database/mssql.mdx
@@ -42,13 +42,13 @@ GRANT SELECT TO Mary;
 ### View Definitions
 
 <Warning>
-The `VIEW DEFINITION` permission is **required for view lineage**. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
+**View lineage requires** the `VIEW DEFINITION` (database-level) or `VIEW ANY DEFINITION` (server-level) permission. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
 </Warning>
 
 ```sql
--- Run in every database you want to ingest
+-- Database-level: grant to the database user, in every database you ingest
 GRANT VIEW DEFINITION TO Mary;
--- Or grant once at the server level to cover all databases
+-- Or server-level: grant to the login (not the contained user) to cover all databases
 GRANT VIEW ANY DEFINITION TO [login_name];
 ```
 ### Usage & Lineage consideration

--- a/v1.13.x/connectors/database/mssql.mdx
+++ b/v1.13.x/connectors/database/mssql.mdx
@@ -39,6 +39,18 @@ CREATE USER Mary WITH PASSWORD = '********';
 -- Grant SELECT on table
 GRANT SELECT TO Mary;
 ```
+### View Definitions
+
+<Warning>
+The `VIEW DEFINITION` permission is **required for view lineage**. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
+</Warning>
+
+```sql
+-- Run in every database you want to ingest
+GRANT VIEW DEFINITION TO Mary;
+-- Or grant once at the server level to cover all databases
+GRANT VIEW ANY DEFINITION TO [login_name];
+```
 ### Usage & Lineage consideration
 To perform the query analysis for Usage and Lineage computation, we fetch the query logs from `sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` &  `sys.dm_exec_sql_text` system tables. To access these tables your user must have `VIEW SERVER STATE` privilege.
 ```sql

--- a/v1.13.x/connectors/database/mssql/yaml.mdx
+++ b/v1.13.x/connectors/database/mssql/yaml.mdx
@@ -50,13 +50,13 @@ GRANT SELECT TO Mary;
 ### View Definitions
 
 <Warning>
-The `VIEW DEFINITION` permission is **required for view lineage**. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
+**View lineage requires** the `VIEW DEFINITION` (database-level) or `VIEW ANY DEFINITION` (server-level) permission. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
 </Warning>
 
 ```sql
--- Run in every database you want to ingest
+-- Database-level: grant to the database user, in every database you ingest
 GRANT VIEW DEFINITION TO Mary;
--- Or grant once at the server level to cover all databases
+-- Or server-level: grant to the login (not the contained user) to cover all databases
 GRANT VIEW ANY DEFINITION TO [login_name];
 ```
 ### Usage & Lineage consideration

--- a/v1.13.x/connectors/database/mssql/yaml.mdx
+++ b/v1.13.x/connectors/database/mssql/yaml.mdx
@@ -47,6 +47,18 @@ CREATE USER Mary WITH PASSWORD = '********';
 -- Grant SELECT on table
 GRANT SELECT TO Mary;
 ```
+### View Definitions
+
+<Warning>
+The `VIEW DEFINITION` permission is **required for view lineage**. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
+</Warning>
+
+```sql
+-- Run in every database you want to ingest
+GRANT VIEW DEFINITION TO Mary;
+-- Or grant once at the server level to cover all databases
+GRANT VIEW ANY DEFINITION TO [login_name];
+```
 ### Usage & Lineage consideration
 To perform the query analysis for Usage and Lineage computation, we fetch the query logs from `sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` &  `sys.dm_exec_sql_text` system tables. To access these tables your user must have `VIEW SERVER STATE` privilege.
 ```sql

--- a/v2.0.x-SNAPSHOT/connectors/database/mssql.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/mssql.mdx
@@ -42,13 +42,13 @@ GRANT SELECT TO Mary;
 ### View Definitions
 
 <Warning>
-The `VIEW DEFINITION` permission is **required for view lineage**. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
+**View lineage requires** the `VIEW DEFINITION` (database-level) or `VIEW ANY DEFINITION` (server-level) permission. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
 </Warning>
 
 ```sql
--- Run in every database you want to ingest
+-- Database-level: grant to the database user, in every database you ingest
 GRANT VIEW DEFINITION TO Mary;
--- Or grant once at the server level to cover all databases
+-- Or server-level: grant to the login (not the contained user) to cover all databases
 GRANT VIEW ANY DEFINITION TO [login_name];
 ```
 ### Usage & Lineage consideration

--- a/v2.0.x-SNAPSHOT/connectors/database/mssql.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/mssql.mdx
@@ -39,6 +39,18 @@ CREATE USER Mary WITH PASSWORD = '********';
 -- Grant SELECT on table
 GRANT SELECT TO Mary;
 ```
+### View Definitions
+
+<Warning>
+The `VIEW DEFINITION` permission is **required for view lineage**. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
+</Warning>
+
+```sql
+-- Run in every database you want to ingest
+GRANT VIEW DEFINITION TO Mary;
+-- Or grant once at the server level to cover all databases
+GRANT VIEW ANY DEFINITION TO [login_name];
+```
 ### Usage & Lineage consideration
 To perform the query analysis for Usage and Lineage computation, we fetch the query logs from `sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` &  `sys.dm_exec_sql_text` system tables. To access these tables your user must have `VIEW SERVER STATE` privilege.
 ```sql

--- a/v2.0.x-SNAPSHOT/connectors/database/mssql/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/mssql/yaml.mdx
@@ -50,13 +50,13 @@ GRANT SELECT TO Mary;
 ### View Definitions
 
 <Warning>
-The `VIEW DEFINITION` permission is **required for view lineage**. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
+**View lineage requires** the `VIEW DEFINITION` (database-level) or `VIEW ANY DEFINITION` (server-level) permission. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
 </Warning>
 
 ```sql
--- Run in every database you want to ingest
+-- Database-level: grant to the database user, in every database you ingest
 GRANT VIEW DEFINITION TO Mary;
--- Or grant once at the server level to cover all databases
+-- Or server-level: grant to the login (not the contained user) to cover all databases
 GRANT VIEW ANY DEFINITION TO [login_name];
 ```
 ### Usage & Lineage consideration

--- a/v2.0.x-SNAPSHOT/connectors/database/mssql/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/mssql/yaml.mdx
@@ -47,6 +47,18 @@ CREATE USER Mary WITH PASSWORD = '********';
 -- Grant SELECT on table
 GRANT SELECT TO Mary;
 ```
+### View Definitions
+
+<Warning>
+The `VIEW DEFINITION` permission is **required for view lineage**. Without it, SQL Server returns each view's definition as `NULL` and raises no error, so views are ingested without their SQL and **no view lineage is created**. Table metadata is not affected.
+</Warning>
+
+```sql
+-- Run in every database you want to ingest
+GRANT VIEW DEFINITION TO Mary;
+-- Or grant once at the server level to cover all databases
+GRANT VIEW ANY DEFINITION TO [login_name];
+```
 ### Usage & Lineage consideration
 To perform the query analysis for Usage and Lineage computation, we fetch the query logs from `sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` &  `sys.dm_exec_sql_text` system tables. To access these tables your user must have `VIEW SERVER STATE` privilege.
 ```sql


### PR DESCRIPTION
Fixes https://github.com/open-metadata/OpenMetadata/issues/29449

SQL Server returns `sys.sql_modules.definition` as `NULL` without `VIEW DEFINITION`, so view lineage silently fails while tables are unaffected. Add a "View Definitions & View Lineage" requirements subsection to the MSSQL connector pages (index, hybrid-runner, yaml) across all versions.