### PR TITLE
feat: add documentation for release 1.12.12 

### DIFF
--- a/snippets/releases/1.12.12.mdx
+++ b/snippets/releases/1.12.12.mdx
@@ -20,13 +20,13 @@ OpenMetadata 1.12.12 is a maintenance release delivering security patches, searc
 
 - **Cap oversized dataModel column trees at index time** [#29212](https://github.com/open-metadata/OpenMetadata/pull/29212): Containers/tables with pathologically large dataModel schemas (hundreds of thousands of columns) produced multi-hundred-MB search documents that could OOM the server on read/reindex. The oversized-doc guard now also strips nested column children and derived `columnNames`/`columnNamesFuzzy` once a doc is still over the cap after lineage stripping. Top-level columns and the full schema (via the entity API) are preserved.
 - **Column tag filtering in advanced search** [#28871](https://github.com/open-metadata/OpenMetadata/pull/28871): Added column-tag filtering to advanced search.
-- **Defer row fetch in audit logs list query** [#28850](https://github.com/open-metadata/OpenMetadata/pull/28850): Avoids a full-row scan when listing audit logs.
+- **Defer row fetch in audit logs list query** [#28851](https://github.com/open-metadata/OpenMetadata/pull/28851): Avoids a full-row scan when listing audit logs.
 - **AuditLogConsumer dropping events on offset gaps** [#29252](https://github.com/open-metadata/OpenMetadata/pull/29252): `change_event.offset` is AUTO_INCREMENT/SERIAL and only visible at commit, so under concurrent writes a lower offset can become visible after a higher one. The consumer no longer skips audit events across these offset gaps.
 
 ### 🧬 Lineage
 
 - **Render traced edges and nodes** [#29195](https://github.com/open-metadata/OpenMetadata/pull/29195): Lineage now visually renders traced edges and nodes.
-- **Restore edges in lineage PNG export** [#29124](https://github.com/open-metadata/OpenMetadata/pull/29124): Edges are restored after canvas re-render in the lineage PNG export.
+- **Restore edges in lineage PNG export** [#29250](https://github.com/open-metadata/OpenMetadata/pull/29250): Edges are restored after canvas re-render in the lineage PNG export.
 - **Fix selector for export lineage** [5b4fe8c](https://github.com/open-metadata/OpenMetadata/commit/5b4fe8c446): Fixed the selector used for lineage export.
 - **Correct nodeDepth for fetched nodes** [#27477](https://github.com/open-metadata/OpenMetadata/pull/27477): Updates nodeDepth on fetched nodes using the base nodeDepth (Issue #25388).
 
@@ -40,7 +40,7 @@ OpenMetadata 1.12.12 is a maintenance release delivering security patches, searc
 ### 🔐 Authentication
 
 - **MCP OAuth login fails with 400 on id_token fragment** [#29228](https://github.com/open-metadata/OpenMetadata/pull/29228): Fixed `/mcp/callback` handling of the active-session shortcut and implicit-flow `id_token` returned in the URL fragment by SSO.
-- **OIDC/SAML self-signup persists mapped email claim** [#29189](https://github.com/open-metadata/OpenMetadata/pull/29189): Self-signup now persists the mapped email claim from OIDC/SAML.
+- **OIDC/SAML self-signup persists mapped email claim** [#29227](https://github.com/open-metadata/OpenMetadata/pull/29227): Self-signup now persists the mapped email claim from OIDC/SAML.
 
 ### 🛡️ Data Governance & Quality
 

--- a/snippets/releases/1.12.12.mdx
+++ b/snippets/releases/1.12.12.mdx
@@ -2,7 +2,11 @@
 
 You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.12-release).
 
-## 🔒 Security
+## Changelog
+
+OpenMetadata 1.12.12 is a maintenance release delivering security patches, search and performance improvements, lineage and UI enhancements, and connector updates.
+
+### 🔒 Security
 
 - **sudo upgraded for CVE-2026-35535** [#29343](https://github.com/open-metadata/OpenMetadata/pull/29343): Upgraded sudo in the ingestion image to patch CVE-2026-35535.
 - **Spring, Micrometer & OpenTelemetry CVE patches** [#29111](https://github.com/open-metadata/OpenMetadata/pull/29111): Spring 6.2.18 → 6.2.19 (CVE-2026-41850, CVE-2026-41851), Micrometer 1.14.5 → 1.15.12, and pinned OpenTelemetry to patch reported CVEs.
@@ -12,48 +16,50 @@ You can find the GitHub release [here](https://github.com/open-metadata/OpenMeta
 - **markdown-it bumped** [#29057](https://github.com/open-metadata/OpenMetadata/pull/29057): markdown-it 14.1.1 → 14.2.0.
 - **UI dependency vulnerability fixes** [#29223](https://github.com/open-metadata/OpenMetadata/pull/29223): Addressed assorted UI vulnerabilities, including undici 6.25.0 → 6.27.0 and form-data updates.
 
-## 🔍 Search & Performance
+### 🔍 Search & Performance
 
 - **Cap oversized dataModel column trees at index time** [#29212](https://github.com/open-metadata/OpenMetadata/pull/29212): Containers/tables with pathologically large dataModel schemas (hundreds of thousands of columns) produced multi-hundred-MB search documents that could OOM the server on read/reindex. The oversized-doc guard now also strips nested column children and derived `columnNames`/`columnNamesFuzzy` once a doc is still over the cap after lineage stripping. Top-level columns and the full schema (via the entity API) are preserved.
 - **Column tag filtering in advanced search** [#28871](https://github.com/open-metadata/OpenMetadata/pull/28871): Added column-tag filtering to advanced search.
 - **Defer row fetch in audit logs list query** [#28850](https://github.com/open-metadata/OpenMetadata/pull/28850): Avoids a full-row scan when listing audit logs.
 - **AuditLogConsumer dropping events on offset gaps** [#29252](https://github.com/open-metadata/OpenMetadata/pull/29252): `change_event.offset` is AUTO_INCREMENT/SERIAL and only visible at commit, so under concurrent writes a lower offset can become visible after a higher one. The consumer no longer skips audit events across these offset gaps.
 
-## 🧬 Lineage
+### 🧬 Lineage
 
 - **Render traced edges and nodes** [#29195](https://github.com/open-metadata/OpenMetadata/pull/29195): Lineage now visually renders traced edges and nodes.
 - **Restore edges in lineage PNG export** [#29124](https://github.com/open-metadata/OpenMetadata/pull/29124): Edges are restored after canvas re-render in the lineage PNG export.
 - **Fix selector for export lineage** [5b4fe8c](https://github.com/open-metadata/OpenMetadata/commit/5b4fe8c446): Fixed the selector used for lineage export.
 - **Correct nodeDepth for fetched nodes** [#27477](https://github.com/open-metadata/OpenMetadata/pull/27477): Updates nodeDepth on fetched nodes using the base nodeDepth (Issue #25388).
 
-## 📖 Glossary
+### 📖 Glossary
 
 - **Approve/reject buttons missing after Expand All** [#29292](https://github.com/open-metadata/OpenMetadata/pull/29292): The Expand-All tree fetch omitted the `reviewers` field, so nested In-Review terms lost their approve/reject buttons. Reviewers are now requested so the buttons remain for nested terms.
 - **Approval re-triggers on approved-term rename** [1755135](https://github.com/open-metadata/OpenMetadata/commit/1755135e6e): Renaming an already-approved term now records name/parent on the change description so the approval workflow re-triggers correctly.
 - **Keep approvals valid after move** [#29234](https://github.com/open-metadata/OpenMetadata/pull/29234): Approvals remain valid after a glossary term is moved.
 - **Cascade glossary rename to child terms in search index** [#29134](https://github.com/open-metadata/OpenMetadata/pull/29134): Renaming a glossary now updates the denormalized `glossary.name` / `glossary.fullyQualifiedName` on every child term's search-index doc.
 
-## 🔐 Authentication
+### 🔐 Authentication
 
 - **MCP OAuth login fails with 400 on id_token fragment** [#29228](https://github.com/open-metadata/OpenMetadata/pull/29228): Fixed `/mcp/callback` handling of the active-session shortcut and implicit-flow `id_token` returned in the URL fragment by SSO.
 - **OIDC/SAML self-signup persists mapped email claim** [#29189](https://github.com/open-metadata/OpenMetadata/pull/29189): Self-signup now persists the mapped email claim from OIDC/SAML.
 
-## 🛡️ Data Governance & Quality
+### 🛡️ Data Governance & Quality
 
 - **Preserve data products across domain deletes** [#29138](https://github.com/open-metadata/OpenMetadata/pull/29138): When a data product's domain was changed and the original domain was then recursively hard-deleted, the data product was incorrectly deleted via a stale domain→dataProduct relationship. The stale relationship is now removed so data products are preserved.
 - **Delete orphaned test cases + guard test-definition deletion** [#29081](https://github.com/open-metadata/OpenMetadata/pull/29081): Orphaned test cases (whose testDefinition relationship was removed) can now be hard-deleted, and test-definition deletion is guarded against the missing relationship.
 
-## ⚙️ Apps & Ingestion
+### ⚙️ Apps & Ingestion
 
 - **Sync IngestionPipeline scheduleInterval on app schedule changes** [#28702](https://github.com/open-metadata/OpenMetadata/pull/28702): When an external app's schedule changes (scheduled→manual or a cron edit), the backing IngestionPipeline `scheduleInterval` is now synced so K8s/Argo/Hybrid runners pick up the new schedule.
 - **Skip CSV consolidation without a previous version** [#29088](https://github.com/open-metadata/OpenMetadata/pull/29088): Avoids CSV consolidation when there is no previous version to consolidate against.
 
-## 🎛️ UI
+### 🎛️ UI
 
 - **Scope "between" operator fix to numeric custom properties** [#29334](https://github.com/open-metadata/OpenMetadata/pull/29334): The `between` operator now correctly sends the upper bound for numeric custom properties only (Issue #27482).
 
-## 🔌 Connectors
+### 🔌 Connectors
 
 - **Snowflake: create Query entities in ACCESS_HISTORY lineage** [#29125](https://github.com/open-metadata/OpenMetadata/pull/29125): The opt-in ACCESS_HISTORY lineage path now emits a `CreateQueryRequest` per edge so the originating SQL surfaces as Query entities, and fixes a probe issue.
 - **Snowflake: forward-port ACCESS_HISTORY lineage + cache fixes** [#29036](https://github.com/open-metadata/OpenMetadata/pull/29036): Forward-ports the opt-in ACCESS_HISTORY lineage path and cache fixes.
 - **Metabase: StarRocks SQL dialect for lineage** [#29033](https://github.com/open-metadata/OpenMetadata/pull/29033): StarRocks connections now route to the StarRocks SQL dialect so StarRocks-specific syntax in Metabase native queries (e.g. `to_bitmap()`, `bitmap_union_count()`) parses correctly for lineage (Issue #28934).
+
+</Update>

--- a/snippets/releases/1.12.12.mdx
+++ b/snippets/releases/1.12.12.mdx
@@ -14,7 +14,8 @@ OpenMetadata 1.12.12 is a maintenance release delivering security patches, searc
 - **handlebars bumped for CVE-2026-55760** [#29221](https://github.com/open-metadata/OpenMetadata/pull/29221): Updated handlebars to 4.5.2 to patch a path-traversal vulnerability.
 - **form-data bumped** [#29349](https://github.com/open-metadata/OpenMetadata/pull/29349): Updated the `form-data` package to address reported vulnerabilities.
 - **markdown-it bumped** [#29057](https://github.com/open-metadata/OpenMetadata/pull/29057): markdown-it 14.1.1 → 14.2.0.
-- **UI dependency vulnerability fixes** [#29223](https://github.com/open-metadata/OpenMetadata/pull/29223): Addressed assorted UI vulnerabilities, including undici 6.25.0 → 6.27.0 and form-data updates.
+- **UI dependency vulnerability fixes** [#29223](https://github.com/open-metadata/OpenMetadata/pull/29223): Addressed assorted UI vulnerabilities, including Vite and form-data 3.0.4 → 3.0.5 updates.
+- **undici & form-data bumped** [#29241](https://github.com/open-metadata/OpenMetadata/pull/29241): Bumps undici 6.25.0 → 6.27.0 and form-data to 4.0.5.
 
 ### 🔍 Search & Performance
 

--- a/snippets/releases/1.12.12.mdx
+++ b/snippets/releases/1.12.12.mdx
@@ -1,0 +1,59 @@
+<Update label="1.12.12 Release" description="24th June 2026">
+
+You can find the GitHub release [here](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.12-release).
+
+## 🔒 Security
+
+- **sudo upgraded for CVE-2026-35535** [#29343](https://github.com/open-metadata/OpenMetadata/pull/29343): Upgraded sudo in the ingestion image to patch CVE-2026-35535.
+- **Spring, Micrometer & OpenTelemetry CVE patches** [#29111](https://github.com/open-metadata/OpenMetadata/pull/29111): Spring 6.2.18 → 6.2.19 (CVE-2026-41850, CVE-2026-41851), Micrometer 1.14.5 → 1.15.12, and pinned OpenTelemetry to patch reported CVEs.
+- **ws bumped for CVE-2026-48779** [#29122](https://github.com/open-metadata/OpenMetadata/pull/29122): Updated `ws` to 8.21.0.
+- **handlebars bumped for CVE-2026-55760** [#29221](https://github.com/open-metadata/OpenMetadata/pull/29221): Updated handlebars to 4.5.2 to patch a path-traversal vulnerability.
+- **form-data bumped** [#29349](https://github.com/open-metadata/OpenMetadata/pull/29349): Updated the `form-data` package to address reported vulnerabilities.
+- **markdown-it bumped** [#29057](https://github.com/open-metadata/OpenMetadata/pull/29057): markdown-it 14.1.1 → 14.2.0.
+- **UI dependency vulnerability fixes** [#29223](https://github.com/open-metadata/OpenMetadata/pull/29223): Addressed assorted UI vulnerabilities, including undici 6.25.0 → 6.27.0 and form-data updates.
+
+## 🔍 Search & Performance
+
+- **Cap oversized dataModel column trees at index time** [#29212](https://github.com/open-metadata/OpenMetadata/pull/29212): Containers/tables with pathologically large dataModel schemas (hundreds of thousands of columns) produced multi-hundred-MB search documents that could OOM the server on read/reindex. The oversized-doc guard now also strips nested column children and derived `columnNames`/`columnNamesFuzzy` once a doc is still over the cap after lineage stripping. Top-level columns and the full schema (via the entity API) are preserved.
+- **Column tag filtering in advanced search** [#28871](https://github.com/open-metadata/OpenMetadata/pull/28871): Added column-tag filtering to advanced search.
+- **Defer row fetch in audit logs list query** [#28850](https://github.com/open-metadata/OpenMetadata/pull/28850): Avoids a full-row scan when listing audit logs.
+- **AuditLogConsumer dropping events on offset gaps** [#29252](https://github.com/open-metadata/OpenMetadata/pull/29252): `change_event.offset` is AUTO_INCREMENT/SERIAL and only visible at commit, so under concurrent writes a lower offset can become visible after a higher one. The consumer no longer skips audit events across these offset gaps.
+
+## 🧬 Lineage
+
+- **Render traced edges and nodes** [#29195](https://github.com/open-metadata/OpenMetadata/pull/29195): Lineage now visually renders traced edges and nodes.
+- **Restore edges in lineage PNG export** [#29124](https://github.com/open-metadata/OpenMetadata/pull/29124): Edges are restored after canvas re-render in the lineage PNG export.
+- **Fix selector for export lineage** [5b4fe8c](https://github.com/open-metadata/OpenMetadata/commit/5b4fe8c446): Fixed the selector used for lineage export.
+- **Correct nodeDepth for fetched nodes** [#27477](https://github.com/open-metadata/OpenMetadata/pull/27477): Updates nodeDepth on fetched nodes using the base nodeDepth (Issue #25388).
+
+## 📖 Glossary
+
+- **Approve/reject buttons missing after Expand All** [#29292](https://github.com/open-metadata/OpenMetadata/pull/29292): The Expand-All tree fetch omitted the `reviewers` field, so nested In-Review terms lost their approve/reject buttons. Reviewers are now requested so the buttons remain for nested terms.
+- **Approval re-triggers on approved-term rename** [1755135](https://github.com/open-metadata/OpenMetadata/commit/1755135e6e): Renaming an already-approved term now records name/parent on the change description so the approval workflow re-triggers correctly.
+- **Keep approvals valid after move** [#29234](https://github.com/open-metadata/OpenMetadata/pull/29234): Approvals remain valid after a glossary term is moved.
+- **Cascade glossary rename to child terms in search index** [#29134](https://github.com/open-metadata/OpenMetadata/pull/29134): Renaming a glossary now updates the denormalized `glossary.name` / `glossary.fullyQualifiedName` on every child term's search-index doc.
+
+## 🔐 Authentication
+
+- **MCP OAuth login fails with 400 on id_token fragment** [#29228](https://github.com/open-metadata/OpenMetadata/pull/29228): Fixed `/mcp/callback` handling of the active-session shortcut and implicit-flow `id_token` returned in the URL fragment by SSO.
+- **OIDC/SAML self-signup persists mapped email claim** [#29189](https://github.com/open-metadata/OpenMetadata/pull/29189): Self-signup now persists the mapped email claim from OIDC/SAML.
+
+## 🛡️ Data Governance & Quality
+
+- **Preserve data products across domain deletes** [#29138](https://github.com/open-metadata/OpenMetadata/pull/29138): When a data product's domain was changed and the original domain was then recursively hard-deleted, the data product was incorrectly deleted via a stale domain→dataProduct relationship. The stale relationship is now removed so data products are preserved.
+- **Delete orphaned test cases + guard test-definition deletion** [#29081](https://github.com/open-metadata/OpenMetadata/pull/29081): Orphaned test cases (whose testDefinition relationship was removed) can now be hard-deleted, and test-definition deletion is guarded against the missing relationship.
+
+## ⚙️ Apps & Ingestion
+
+- **Sync IngestionPipeline scheduleInterval on app schedule changes** [#28702](https://github.com/open-metadata/OpenMetadata/pull/28702): When an external app's schedule changes (scheduled→manual or a cron edit), the backing IngestionPipeline `scheduleInterval` is now synced so K8s/Argo/Hybrid runners pick up the new schedule.
+- **Skip CSV consolidation without a previous version** [#29088](https://github.com/open-metadata/OpenMetadata/pull/29088): Avoids CSV consolidation when there is no previous version to consolidate against.
+
+## 🎛️ UI
+
+- **Scope "between" operator fix to numeric custom properties** [#29334](https://github.com/open-metadata/OpenMetadata/pull/29334): The `between` operator now correctly sends the upper bound for numeric custom properties only (Issue #27482).
+
+## 🔌 Connectors
+
+- **Snowflake: create Query entities in ACCESS_HISTORY lineage** [#29125](https://github.com/open-metadata/OpenMetadata/pull/29125): The opt-in ACCESS_HISTORY lineage path now emits a `CreateQueryRequest` per edge so the originating SQL surfaces as Query entities, and fixes a probe issue.
+- **Snowflake: forward-port ACCESS_HISTORY lineage + cache fixes** [#29036](https://github.com/open-metadata/OpenMetadata/pull/29036): Forward-ports the opt-in ACCESS_HISTORY lineage path and cache fixes.
+- **Metabase: StarRocks SQL dialect for lineage** [#29033](https://github.com/open-metadata/OpenMetadata/pull/29033): StarRocks connections now route to the StarRocks SQL dialect so StarRocks-specific syntax in Metabase native queries (e.g. `to_bitmap()`, `bitmap_union_count()`) parses correctly for lineage (Issue #28934).

--- a/v1.12.x/releases.mdx
+++ b/v1.12.x/releases.mdx
@@ -4,7 +4,7 @@ description: Discover the latest OpenMetadata releases, new features, bug fixes,
 sidebarTitle: Latest Release
 ---
 
-import ReleaseNotes from '/snippets/releases/1.12.11.mdx';
+import ReleaseNotes from '/snippets/releases/1.12.12.mdx';
 
 # Latest Release 🎉
 

--- a/v1.12.x/releases/all-releases.mdx
+++ b/v1.12.x/releases/all-releases.mdx
@@ -13,22 +13,28 @@ import ReleaseNotes6 from '/snippets/releases/1.12.7.mdx';
 import ReleaseNotes7 from '/snippets/releases/1.12.8.mdx';
 import ReleaseNotes8 from '/snippets/releases/1.12.9.mdx';
 import ReleaseNotes9 from '/snippets/releases/1.12.10.mdx';
-import ReleaseNotes from '/snippets/releases/1.12.11.mdx';
-
+import ReleaseNotes10 from '/snippets/releases/1.12.11.mdx';
+import ReleaseNotes11 from '/snippets/releases/1.12.12.mdx';
 
 # Releases
 
 <Tip>
-The OpenMetadata community is on a monthly release cadence. At every 4-5 weeks we will be releasing a new version.
+  The OpenMetadata community is on a monthly release cadence. At every 4-5 weeks
+  we will be releasing a new version.
 </Tip>
 
 <CardGroup>
-<Card icon="party-horn" title="Upgrade OpenMetadata" href="/v1.12.x/deployment/upgrade">
-Learn how to upgrade your OpenMetadata instance to 1.12.11!
-</Card>
+  <Card
+    icon="party-horn"
+    title="Upgrade OpenMetadata"
+    href="/v1.12.x/deployment/upgrade">
+    Learn how to upgrade your OpenMetadata instance to 1.12.11!
+  </Card>
 </CardGroup>
 
-<ReleaseNotes />
+<ReleaseNotes11 />
+
+<ReleaseNotes10 />
 
 <ReleaseNotes9 />
 

--- a/v1.12.x/releases/all-releases.mdx
+++ b/v1.12.x/releases/all-releases.mdx
@@ -28,7 +28,7 @@ import ReleaseNotes11 from '/snippets/releases/1.12.12.mdx';
     icon="party-horn"
     title="Upgrade OpenMetadata"
     href="/v1.12.x/deployment/upgrade">
-    Learn how to upgrade your OpenMetadata instance to 1.12.11!
+    Learn how to upgrade your OpenMetadata instance to 1.12.12!
   </Card>
 </CardGroup>
 

--- a/v1.13.x/releases/1.12-release.mdx
+++ b/v1.13.x/releases/1.12-release.mdx
@@ -14,8 +14,11 @@ import ReleaseNotes7 from '/snippets/releases/1.12.8.mdx';
 import ReleaseNotes8 from '/snippets/releases/1.12.9.mdx';
 import ReleaseNotes9 from '/snippets/releases/1.12.10.mdx';
 import ReleaseNotes10 from '/snippets/releases/1.12.11.mdx';
+import ReleaseNotes11 from '/snippets/releases/1.12.12.mdx';
 
 # 1.12 Releases
+
+<ReleaseNotes11 />
 
 <ReleaseNotes10 />
 

--- a/v1.13.x/releases/all-releases.mdx
+++ b/v1.13.x/releases/all-releases.mdx
@@ -15,21 +15,27 @@ import ReleaseNotes7 from '/snippets/releases/1.12.8.mdx';
 import ReleaseNotes8 from '/snippets/releases/1.12.9.mdx';
 import ReleaseNotes9 from '/snippets/releases/1.12.10.mdx';
 import ReleaseNotes10 from '/snippets/releases/1.12.11.mdx';
-
+import ReleaseNotes11 from '/snippets/releases/1.12.12.mdx';
 
 # Releases
 
 <Tip>
-The OpenMetadata community is on a monthly release cadence. At every 4-5 weeks we will be releasing a new version.
+  The OpenMetadata community is on a monthly release cadence. At every 4-5 weeks
+  we will be releasing a new version.
 </Tip>
 
 <CardGroup>
-<Card icon="party-horn" title="Upgrade OpenMetadata" href="/v1.13.x/deployment/upgrade">
-Learn how to upgrade your OpenMetadata instance to 1.13.0!
-</Card>
+  <Card
+    icon="party-horn"
+    title="Upgrade OpenMetadata"
+    href="/v1.13.x/deployment/upgrade">
+    Learn how to upgrade your OpenMetadata instance to 1.13.0!
+  </Card>
 </CardGroup>
 
 <ReleaseNotes />
+
+<ReleaseNotes11 />
 
 <ReleaseNotes10 />
 

--- a/v2.0.x-SNAPSHOT/releases/1.12-release.mdx
+++ b/v2.0.x-SNAPSHOT/releases/1.12-release.mdx
@@ -14,8 +14,11 @@ import ReleaseNotes7 from '/snippets/releases/1.12.8.mdx';
 import ReleaseNotes8 from '/snippets/releases/1.12.9.mdx';
 import ReleaseNotes9 from '/snippets/releases/1.12.10.mdx';
 import ReleaseNotes10 from '/snippets/releases/1.12.11.mdx';
+import ReleaseNotes11 from '/snippets/releases/1.12.12.mdx';
 
 # 1.12 Releases
+
+<ReleaseNotes11 />
 
 <ReleaseNotes10 />
 

--- a/v2.0.x-SNAPSHOT/releases/all-releases.mdx
+++ b/v2.0.x-SNAPSHOT/releases/all-releases.mdx
@@ -15,21 +15,27 @@ import ReleaseNotes7 from '/snippets/releases/1.12.8.mdx';
 import ReleaseNotes8 from '/snippets/releases/1.12.9.mdx';
 import ReleaseNotes9 from '/snippets/releases/1.12.10.mdx';
 import ReleaseNotes10 from '/snippets/releases/1.12.11.mdx';
-
+import ReleaseNotes11 from '/snippets/releases/1.12.12.mdx';
 
 # Releases
 
 <Tip>
-The OpenMetadata community is on a monthly release cadence. At every 4-5 weeks we will be releasing a new version.
+  The OpenMetadata community is on a monthly release cadence. At every 4-5 weeks
+  we will be releasing a new version.
 </Tip>
 
 <CardGroup>
-<Card icon="party-horn" title="Upgrade OpenMetadata" href="/v2.0.x-SNAPSHOT/deployment/upgrade">
-Learn how to upgrade your OpenMetadata instance to 2.0.0!
-</Card>
+  <Card
+    icon="party-horn"
+    title="Upgrade OpenMetadata"
+    href="/v2.0.x-SNAPSHOT/deployment/upgrade">
+    Learn how to upgrade your OpenMetadata instance to 2.0.0!
+  </Card>
 </CardGroup>
 
 <ReleaseNotes />
+
+<ReleaseNotes11 />
 
 <ReleaseNotes10 />
 


### PR DESCRIPTION
This pull request adds the release notes for version 1.12.12 and updates all relevant documentation pages to reference and display the new release. The changes ensure that users can access the latest release notes from the main and historical releases pages across all supported documentation versions.

**Release notes and documentation updates:**

* Added the full release notes for version 1.12.12, including security patches, search and performance improvements, lineage visualization updates, glossary workflow fixes, authentication improvements, data governance changes, ingestion syncs, UI fixes, and connector enhancements.

**Documentation version updates:**

* Updated the "Latest Release" page to reference `1.12.12` instead of `1.12.11`.
* Updated the "All Releases" pages for `v1.12.x`, `v1.13.x`, and `v2.0.x-SNAPSHOT` to import and display the `1.12.12` release notes. [[1]](diffhunk://#diff-aa70a832736e3ffb01f94be216fd6f0841ac23f8d7c06fdd862aa94bcad2340aL16-R37) [[2]](diffhunk://#diff-5bc233c1aa12a8e80f7c1bb45572a1fb2edfd99d9e7a3fe4a7298a4fe62cfaa4L18-R39) [[3]](diffhunk://#diff-c9524e1d663f56c80558c3ba7b6264b78461bc8b1c771cbb30de0b9d1e970347L18-R39)
* Updated the `1.12-release.mdx` pages for `v1.13.x` and `v2.0.x-SNAPSHOT` to include the `1.12.12` release notes in the release history.