### PR TITLE
Docs: Fix auto-classification docs for v1.13.x

### DIFF
--- a/v1.13.x/how-to-guides/data-governance/classification/auto-classification.mdx
+++ b/v1.13.x/how-to-guides/data-governance/classification/auto-classification.mdx
@@ -30,8 +30,6 @@ Auto-Classification uses two complementary detection approaches:
 
   <img src="/public/images/how-to-guides/governance/auto-pii3.png" alt="Sample data showing sensitive values that triggered auto-classification" />
 
-- **Custom Recognizers (Column Name target)**: In addition to the built-in scanner, configure your own recognizers that match against column names. Unlike the built-in scanner — which uses a fixed set of PII regex rules — custom column-name recognizers let you define your own terms or patterns and attach them to any classification tag. These apply tags without needing sample data.
-
 ## Tag Mapping
 
 Tag mapping lets you link two tags so that applying one automatically applies the other. When two related tags are associated, any time the first tag is applied to a data asset, the second tag is applied automatically — keeping classifications consistent across taxonomies without extra manual steps.

--- a/v1.13.x/how-to-guides/data-governance/classification/auto-classification.mdx
+++ b/v1.13.x/how-to-guides/data-governance/classification/auto-classification.mdx
@@ -30,6 +30,8 @@ Auto-Classification uses two complementary detection approaches:
 
   <img src="/public/images/how-to-guides/governance/auto-pii3.png" alt="Sample data showing sensitive values that triggered auto-classification" />
 
+- **Custom Recognizers (Column Name target)**: In addition to the built-in scanner, configure your own recognizers that match against column names. Unlike the built-in scanner — which uses a fixed set of PII regex rules — custom column-name recognizers let you define your own terms or patterns and attach them to any classification tag. These apply tags without needing sample data.
+
 ## Tag Mapping
 
 Tag mapping lets you link two tags so that applying one automatically applies the other. When two related tags are associated, any time the first tag is applied to a data asset, the second tag is applied automatically — keeping classifications consistent across taxonomies without extra manual steps.

--- a/v1.13.x/how-to-guides/data-governance/classification/auto-classification/auto-pii-tagging.mdx
+++ b/v1.13.x/how-to-guides/data-governance/classification/auto-classification/auto-pii-tagging.mdx
@@ -20,9 +20,17 @@ Note that if a column is already tagged as `PII`, we will ignore its execution.
 
 ## Troubleshooting
 
+### Recognizer ran but tag was not applied
+
+If the auto-classification logs show a recognizer attempted to classify a column but no tag appears:
+
+- **Sampled values are masked or anonymized** — the content recognizer found no match above the confidence threshold. Switch the recognizer `Target` to **Column Name** to tag based on the column name alone, regardless of data content.
+- **Confidence score too low** — the recognizer ran but scored below the threshold. Lower the confidence threshold or add context to boost the score.
+- **Column already tagged as PII** — columns with an existing `PII` tag are skipped. Check the column's existing tags.
+
 <Tip>
 
-In OpenMetadata, the auto-classification feature primarily applies the PII classification, tagging data as either Sensitive or Non-Sensitive. The General classification, which includes tags like Address, Name, etc., is not available in the OpenMetadata. This functionality is present in the OpenMetadata and is expected to be included in the open-source release starting from version 1.7.1.
+In OpenMetadata, the auto-classification feature primarily applies the PII classification, tagging data as either Sensitive or Non-Sensitive. The General classification, which includes tags like Address, Name, etc., is not available in OpenMetadata. This functionality is present in the OpenMetadata and is expected to be included in the open-source release starting from version 1.7.1.
 
 </Tip>
 

--- a/v1.13.x/how-to-guides/data-governance/classification/auto-classification/auto-pii-tagging.mdx
+++ b/v1.13.x/how-to-guides/data-governance/classification/auto-classification/auto-pii-tagging.mdx
@@ -12,9 +12,10 @@ Auto PII tagging for Sensitive/NonSensitive at the column level is performed bas
 
 1. **Column Name Scanner**: We validate the column names of the table against a set of regex rules that help us identify
     common English patterns to identify email addresses, SSN, bank accounts, etc.
-2. **Entity Recognition**: If the sample data ingestion is enabled, we'll validate the sample rows against an Entity
-    Recognition engine that will bring up any sensitive information from a list of [supported entities](https://microsoft.github.io/presidio/supported_entities/).
-    In that case, the `confidence` parameter lets you tune the minimum score required to tag a column as `PII.Sensitive`.
+2. **Entity Recognition**: The workflow always samples rows directly from the source and validates them against an Entity
+    Recognition engine that identifies sensitive information from a list of [supported entities](https://microsoft.github.io/presidio/supported_entities/).
+    The `confidence` parameter lets you tune the minimum score required to tag a column as `PII.Sensitive`.
+    The **Store Sample Data** toggle controls whether those sampled rows are persisted in OpenMetadata — it does not affect whether classification runs.
 
 Note that if a column is already tagged as `PII`, we will ignore its execution.
 

--- a/v1.13.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
+++ b/v1.13.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
@@ -23,7 +23,7 @@ The Auto Classification Workflow enables automatic tagging of sensitive informat
 | `storeSampleData`             | Option to enable or disable storing sample data for each table.                | Boolean   | `false`                 |
 | `enableAutoClassification`    | Enables automatic tagging of columns that might contain sensitive information. | Boolean   | `true`                  |
 | `confidence`                  | Confidence level for tagging columns as sensitive. Value ranges from 0 to 100. | Number    | `80`                    |
-| `sampleDataCount`             | Number of sample rows fetched per table for classification.                    | Integer   | `50`                    |
+| `sampleDataCount`             | Maximum rows sampled per table for classification. Capped at 50 — setting a higher value has no effect. `storeSampleData` controls whether sampled rows are saved to OpenMetadata. | Integer   | `50`                    |
 | `classificationLanguage`      | Language for auto-classification recognizers. Use `any` to run all recognizers regardless of language. For a specific language, only matching recognizers run. | String    | `en`                    |
 
 ## Key Parameters Explained
@@ -39,7 +39,7 @@ The Auto Classification Workflow enables automatic tagging of sensitive informat
 
 ### `storeSampleData`
 - The workflow always samples rows directly from the source for classification. This toggle controls whether those sampled rows are persisted in OpenMetadata.
-- Setting this to `true` stores up to `sampleDataCount` rows per table. Classification runs regardless of this setting.
+- Setting this to `true` stores up to 50 rows per table, or fewer if `sampleDataCount` is set lower. Classification runs regardless of this setting.
 
 ### `classificationFilterPattern`
 

--- a/v1.13.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
+++ b/v1.13.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
@@ -20,10 +20,11 @@ The Auto Classification Workflow enables automatic tagging of sensitive informat
 | `databaseFilterPattern`       | Regex to fetch databases matching the specified pattern.                       | Object    | N/A                     |
 | `includeViews`                | Option to include or exclude views during metadata ingestion.                  | Boolean   | `true`                  |
 | `useFqnForFiltering`          | Determines whether filtering is applied to the Fully Qualified Name (FQN) instead of raw names. | Boolean   | `false`                 |
-| `storeSampleData`             | Option to enable or disable storing sample data for each table.                | Boolean   | `true`                  |
-| `enableAutoClassification`    | Enables automatic tagging of columns that might contain sensitive information. | Boolean   | `false`                 |
+| `storeSampleData`             | Option to enable or disable storing sample data for each table.                | Boolean   | `false`                 |
+| `enableAutoClassification`    | Enables automatic tagging of columns that might contain sensitive information. | Boolean   | `true`                  |
 | `confidence`                  | Confidence level for tagging columns as sensitive. Value ranges from 0 to 100. | Number    | `80`                    |
-| `sampleDataCount`             | Number of sample rows to ingest when Store Sample Data is enabled.             | Integer   | `50`                    |
+| `sampleDataCount`             | Number of sample rows fetched per table for classification.                    | Integer   | `50`                    |
+| `classificationLanguage`      | Language for auto-classification recognizers. Use `any` to run all recognizers regardless of language. For a specific language, only matching recognizers run. | String    | `en`                    |
 
 ## Key Parameters Explained
 
@@ -37,8 +38,8 @@ The Auto Classification Workflow enables automatic tagging of sensitive informat
   - A lower confidence value (e.g., `70`) identifies more sensitive columns but may result in false positives.
 
 ### `storeSampleData`
-- Controls whether sample rows are stored during ingestion.
-- If enabled, the specified number of rows (`sampleDataCount`) will be fetched for each table.
+- The workflow always samples rows directly from the source for classification. This toggle controls whether those sampled rows are persisted in OpenMetadata.
+- Setting this to `true` stores up to `sampleDataCount` rows per table. Classification runs regardless of this setting.
 
 ### `classificationFilterPattern`
 
@@ -120,17 +121,8 @@ source:
           - abc
 
 processor:
-   type: "orm-profiler"
-   config:
-    tableConfig:
-      - fullyQualifiedName: local_bigquery.hello-world-1234.super_schema.abc
-        profileSample: 85
-        partitionConfig:
-          partitionQueryDuration: 180
-        columnConfig:
-          excludeColumns:
-            - a
-            - b
+  type: "tag-pii-processor"
+  config: {}
 
 sink:
   type: metadata-rest

--- a/v1.13.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
+++ b/v1.13.x/how-to-guides/data-governance/classification/auto-classification/external-workflow.mdx
@@ -20,7 +20,7 @@ The Auto Classification Workflow enables automatic tagging of sensitive informat
 | `databaseFilterPattern`       | Regex to fetch databases matching the specified pattern.                       | Object    | N/A                     |
 | `includeViews`                | Option to include or exclude views during metadata ingestion.                  | Boolean   | `true`                  |
 | `useFqnForFiltering`          | Determines whether filtering is applied to the Fully Qualified Name (FQN) instead of raw names. | Boolean   | `false`                 |
-| `storeSampleData`             | Option to enable or disable storing sample data for each table.                | Boolean   | `false`                 |
+| `storeSampleData`             | Controls whether sampled rows are persisted to OpenMetadata after classification. Rows are always sampled for classification regardless of this setting. | Boolean   | `false`                 |
 | `enableAutoClassification`    | Enables automatic tagging of columns that might contain sensitive information. | Boolean   | `true`                  |
 | `confidence`                  | Confidence level for tagging columns as sensitive. Value ranges from 0 to 100. | Number    | `80`                    |
 | `sampleDataCount`             | Maximum rows sampled per table for classification. Capped at 50 — setting a higher value has no effect. `storeSampleData` controls whether sampled rows are saved to OpenMetadata. | Integer   | `50`                    |
@@ -108,7 +108,7 @@ source:
   sourceConfig:
     config:
       type: AutoClassification
-      storeSampleData: true
+      storeSampleData: false
       enableAutoClassification: true
       databaseFilterPattern:
         includes:


### PR DESCRIPTION
## Summary
- Adds troubleshooting entry for when a recognizer runs but no tag is applied (masked data, low confidence score, column already tagged)
- Fixes typo: "not available in the OpenMetadata" to "not available in OpenMetadata"

## Related
- Mirrors changes made in docs-collate PR: open-metadata/docs-collate#464

## Test plan
- [ ] Verify pages render correctly in v1.13.x preview
- [ ] Confirm no broken links

