### PR TITLE
Fix: homepage search input intermittently failing to open / stuck open on close

### DIFF
--- a/globals.css
+++ b/globals.css
@@ -798,7 +798,7 @@ body:has(.homepage-container) #assistant-entry {
 
 .homepage-search-input {
   width: 100%;
-  padding: 18px 58px 18px 70px;
+  padding: 18px 58px 18px 28px;
   border: 2px solid #EAECF5;
   border-radius: 100px;
   font-size: 16px;
@@ -821,28 +821,6 @@ body:has(.homepage-container) #assistant-entry {
   outline: none;
   background-color: #FFFFFF;
   box-shadow: 0 0 0 3px rgba(84, 105, 212, 0.1);
-}
-
-.ask-ai-icon-button {
-  position: absolute;
-  left: 26px;
-  top: 12px;
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 20;
-  pointer-events: auto;
-}
-
-.ask-ai-icon {
-  color: #9CA3AF;
-  pointer-events: auto;
-  width: 40px !important;
-  height: 40px !important;
 }
 
 .search-shortcut {

--- a/v1.12.x/index.mdx
+++ b/v1.12.x/index.mdx
@@ -23,37 +23,18 @@ import { Integrations } from "/snippets/v1.12.x/components/ConnectorGrid/Integra
   type="text"
   id="homepage-search"
   className="homepage-search-input"
-  placeholder=" |   Search for connectors, how to guides and more"
-  onClick={() => {
-    const searchBar = document.getElementById('search-bar-entry');
-    if (searchBar) {
-      searchBar.click();
-    }
-  }}
-  onFocus={() => {
-    const searchBar = document.getElementById('search-bar-entry');
-    if (searchBar) {
-      searchBar.click();
-    }
-  }}
-  readOnly
-/>
-<button
- type="button"
-  className="ask-ai-icon-button"
+  placeholder="Search for connectors, how to guides and more"
   onMouseDown={(e) => {
-    e.stopPropagation();
     e.preventDefault();
   }}
   onClick={(e) => {
-    e.stopPropagation();
     e.preventDefault();
-    // Trigger the assistant using keyboard shortcut (Cmd+I / Ctrl+I)
+    // Trigger the native search dialog using its keyboard shortcut (Cmd+K / Ctrl+K)
     const event = new KeyboardEvent('keydown', {
-      key: 'i',
-      code: 'KeyI',
-      keyCode: 73,
-      which: 73,
+      key: 'k',
+      code: 'KeyK',
+      keyCode: 75,
+      which: 75,
       ctrlKey: !navigator.platform.includes('Mac'),
       metaKey: navigator.platform.includes('Mac'),
       bubbles: true,
@@ -61,10 +42,25 @@ import { Integrations } from "/snippets/v1.12.x/components/ConnectorGrid/Integra
     });
     document.dispatchEvent(event);
   }}
-  aria-label="Toggle assistant panel"
->
-<Icon icon="/public/images/icons/ask-ai-home.svg" className="ask-ai-icon" />
-</button>
+  onKeyDown={(e) => {
+    // Keep this reachable for keyboard-only users
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      const event = new KeyboardEvent('keydown', {
+        key: 'k',
+        code: 'KeyK',
+        keyCode: 75,
+        which: 75,
+        ctrlKey: !navigator.platform.includes('Mac'),
+        metaKey: navigator.platform.includes('Mac'),
+        bubbles: true,
+        cancelable: true
+      });
+      document.dispatchEvent(event);
+    }
+  }}
+  readOnly
+/>
 <span className="search-shortcut">⌘K</span>
 </div>
 

--- a/v1.13.x/index.mdx
+++ b/v1.13.x/index.mdx
@@ -23,37 +23,18 @@ import { Integrations } from "/snippets/v1.13.x/components/ConnectorGrid/Integra
   type="text"
   id="homepage-search"
   className="homepage-search-input"
-  placeholder=" |   Search for connectors, how to guides and more"
-  onClick={() => {
-    const searchBar = document.getElementById('search-bar-entry');
-    if (searchBar) {
-      searchBar.click();
-    }
-  }}
-  onFocus={() => {
-    const searchBar = document.getElementById('search-bar-entry');
-    if (searchBar) {
-      searchBar.click();
-    }
-  }}
-  readOnly
-/>
-<button
- type="button"
-  className="ask-ai-icon-button"
+  placeholder="Search for connectors, how to guides and more"
   onMouseDown={(e) => {
-    e.stopPropagation();
     e.preventDefault();
   }}
   onClick={(e) => {
-    e.stopPropagation();
     e.preventDefault();
-    // Trigger the assistant using keyboard shortcut (Cmd+I / Ctrl+I)
+    // Trigger the native search dialog using its keyboard shortcut (Cmd+K / Ctrl+K)
     const event = new KeyboardEvent('keydown', {
-      key: 'i',
-      code: 'KeyI',
-      keyCode: 73,
-      which: 73,
+      key: 'k',
+      code: 'KeyK',
+      keyCode: 75,
+      which: 75,
       ctrlKey: !navigator.platform.includes('Mac'),
       metaKey: navigator.platform.includes('Mac'),
       bubbles: true,
@@ -61,10 +42,25 @@ import { Integrations } from "/snippets/v1.13.x/components/ConnectorGrid/Integra
     });
     document.dispatchEvent(event);
   }}
-  aria-label="Toggle assistant panel"
->
-<Icon icon="/public/images/icons/ask-ai-home.svg" className="ask-ai-icon" />
-</button>
+  onKeyDown={(e) => {
+    // Keep this reachable for keyboard-only users
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      const event = new KeyboardEvent('keydown', {
+        key: 'k',
+        code: 'KeyK',
+        keyCode: 75,
+        which: 75,
+        ctrlKey: !navigator.platform.includes('Mac'),
+        metaKey: navigator.platform.includes('Mac'),
+        bubbles: true,
+        cancelable: true
+      });
+      document.dispatchEvent(event);
+    }
+  }}
+  readOnly
+/>
 <span className="search-shortcut">⌘K</span>
 </div>
 

--- a/v2.0.x-SNAPSHOT/index.mdx
+++ b/v2.0.x-SNAPSHOT/index.mdx
@@ -23,37 +23,18 @@ import { Integrations } from "/snippets/v2.0.x-SNAPSHOT/components/ConnectorGrid
   type="text"
   id="homepage-search"
   className="homepage-search-input"
-  placeholder=" |   Search for connectors, how to guides and more"
-  onClick={() => {
-    const searchBar = document.getElementById('search-bar-entry');
-    if (searchBar) {
-      searchBar.click();
-    }
-  }}
-  onFocus={() => {
-    const searchBar = document.getElementById('search-bar-entry');
-    if (searchBar) {
-      searchBar.click();
-    }
-  }}
-  readOnly
-/>
-<button
- type="button"
-  className="ask-ai-icon-button"
+  placeholder="Search for connectors, how to guides and more"
   onMouseDown={(e) => {
-    e.stopPropagation();
     e.preventDefault();
   }}
   onClick={(e) => {
-    e.stopPropagation();
     e.preventDefault();
-    // Trigger the assistant using keyboard shortcut (Cmd+I / Ctrl+I)
+    // Trigger the native search dialog using its keyboard shortcut (Cmd+K / Ctrl+K)
     const event = new KeyboardEvent('keydown', {
-      key: 'i',
-      code: 'KeyI',
-      keyCode: 73,
-      which: 73,
+      key: 'k',
+      code: 'KeyK',
+      keyCode: 75,
+      which: 75,
       ctrlKey: !navigator.platform.includes('Mac'),
       metaKey: navigator.platform.includes('Mac'),
       bubbles: true,
@@ -61,10 +42,25 @@ import { Integrations } from "/snippets/v2.0.x-SNAPSHOT/components/ConnectorGrid
     });
     document.dispatchEvent(event);
   }}
-  aria-label="Toggle assistant panel"
->
-<Icon icon="/public/images/icons/ask-ai-home.svg" className="ask-ai-icon" />
-</button>
+  onKeyDown={(e) => {
+    // Keep this reachable for keyboard-only users
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      const event = new KeyboardEvent('keydown', {
+        key: 'k',
+        code: 'KeyK',
+        keyCode: 75,
+        which: 75,
+        ctrlKey: !navigator.platform.includes('Mac'),
+        metaKey: navigator.platform.includes('Mac'),
+        bubbles: true,
+        cancelable: true
+      });
+      document.dispatchEvent(event);
+    }
+  }}
+  readOnly
+/>
 <span className="search-shortcut">⌘K</span>
 </div>
 


### PR DESCRIPTION
The search bar was trying to click a hidden button to open the dialog, but that button sometimes wasn't ready yet on page load. It was also re-opening itself every time the dialog closed because of a focus loop.

Fixed by dispatching the native ⌘K shortcut instead, and preventing the input from grabbing focus so the loop can't happen.