### PR TITLE
Docs: Update Postgres minimum version from 12 to 15 across all deployment docs

### DIFF
--- a/snippets/components/VersionMatrix/versionMatrixData.mdx
+++ b/snippets/components/VersionMatrix/versionMatrixData.mdx
@@ -1,7 +1,7 @@
 export const VERSION_MATRIX_DATA = [
   { service: "Java", version: "21" },
   { service: "Mysql", version: "8.0.42" },
-  { service: "Postgres", version: "1.15.0" },
+  { service: "Postgres", version: "15" },
   { service: "OpenSearch", version: "3.2.0" },
   { service: "ElasticSearch", version: "9.3.0" },
 ];
@@ -9,7 +9,7 @@ export const VERSION_MATRIX_DATA = [
 export const VERSION_MATRIX_DATA_WITH_UPDATES = [
   { service: "Java", version: "21" },
   { service: "Mysql", version: "8.0.42" },
-  { service: "Postgres", version: "1.15.0" },
+  { service: "Postgres", version: "15" },
   { service: "OpenSearch", version: "3.2.0", updated: true },
   { service: "ElasticSearch", version: "9.3.0", updated: true },
 ];

--- a/v1.12.x/deployment/bare-metal.mdx
+++ b/v1.12.x/deployment/bare-metal.mdx
@@ -41,7 +41,7 @@ You can refer a sample script [here](https://github.com/open-metadata/OpenMetada
 
 </Tip>
 
-## Postgres (version 12.0 or higher)
+## Postgres (version 15 or higher)
 
 To install Postgres see the instructions for your operating system (OS) at [Postgres Download](https://www.postgresql.org/download/)
 <Tip>
@@ -174,7 +174,7 @@ We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
 - Amazon OpenSearch (ElasticSearch) engine version 9.x (minimum 9.0.0, recommended 9.3.0) or Amazon OpenSearch engine version 3.x (minimum 3.0.0, recommended 3.3.0)
-- Amazon RDS (PostgreSQL) engine version between 12 or higher
+- Amazon RDS (PostgreSQL) engine version 15 or higher
 
 For Production Systems, we recommend Amazon RDS to be in Multiple Availability Zones. For Amazon OpenSearch (or ElasticSearch) Service, we recommend Multiple Availability Zones with minimum 3 Master Nodes.
 

--- a/v1.12.x/deployment/configuration.mdx
+++ b/v1.12.x/deployment/configuration.mdx
@@ -113,7 +113,7 @@ database:
 
 ### PostgreSQL Configuration
 
-OpenMetadata uses stored generated columns which is supported in Postgres 12 and later. Ensure you have Postgres 12 or higher. We recommend you create a Postgres user with a strong password and update this section accordingly.
+OpenMetadata uses stored generated columns which is supported in Postgres 15 and later. Ensure you have Postgres 15 or higher. We recommend you create a Postgres user with a strong password and update this section accordingly.
 
 | Parameter | Description | Default Value |
 |-----------|-------------|---------------|

--- a/v1.12.x/deployment/configuration.mdx
+++ b/v1.12.x/deployment/configuration.mdx
@@ -113,7 +113,7 @@ database:
 
 ### PostgreSQL Configuration
 
-OpenMetadata uses stored generated columns which is supported in Postgres 15 and later. Ensure you have Postgres 15 or higher. We recommend you create a Postgres user with a strong password and update this section accordingly.
+OpenMetadata uses stored generated columns (supported since Postgres 12). We recommend running Postgres 15 or higher. Create a Postgres user with a strong password and update this section accordingly.
 
 | Parameter | Description | Default Value |
 |-----------|-------------|---------------|

--- a/v1.12.x/deployment/docker/advanced.mdx
+++ b/v1.12.x/deployment/docker/advanced.mdx
@@ -57,7 +57,7 @@ We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
 - Amazon OpenSearch (ElasticSearch) engine version 9.x (minimum 9.0.0, recommended 9.3.0) or Amazon OpenSearch engine version 3.x (minimum 3.0.0, recommended 3.3.0)
-- Amazon RDS (PostgreSQL) engine version 12 or higher
+- Amazon RDS (PostgreSQL) engine version 15 or higher
 
 Note:-
 When using AWS Services the SearchType Configuration for elastic search should be `opensearch`, for both cases ElasticSearch and OpenSearch,

--- a/v1.12.x/deployment/kubernetes/aks.mdx
+++ b/v1.12.x/deployment/kubernetes/aks.mdx
@@ -17,7 +17,7 @@ It is recommended to use [Azure SQL](https://azure.microsoft.com/en-in/products/
 
 We support:
 - Azure SQL (MySQL) engine version 8 or higher
-- Azure SQL (PostgreSQL) engine version 12 or higher
+- Azure SQL (PostgreSQL) engine version 15 or higher
 - Elastic Cloud (ElasticSearch version 9.x, minimum 9.0.0, recommended 9.3.0)
 
 We recommend:

--- a/v1.12.x/deployment/kubernetes/eks.mdx
+++ b/v1.12.x/deployment/kubernetes/eks.mdx
@@ -26,7 +26,7 @@ It is recommended to use [Amazon RDS](https://docs.aws.amazon.com/rds/index.html
 We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
-- Amazon RDS (PostgreSQL) engine version 12 or higher
+- Amazon RDS (PostgreSQL) engine version 15 or higher
 - Amazon OpenSearch engine version 3.x (minimum 3.0.0, recommended 3.3.0)
 
 <Tip>

--- a/v1.12.x/deployment/kubernetes/gke.mdx
+++ b/v1.12.x/deployment/kubernetes/gke.mdx
@@ -33,7 +33,7 @@ It is recommended to use GCP [Cloud SQL](https://cloud.google.com/sql/) services
 
 We support -
 - Cloud SQL (MySQL) engine version 8 or higher
-- Cloud SQL (postgreSQL) engine version 12 or higher
+- Cloud SQL (postgreSQL) engine version 15 or higher
 - ElasticSearch version 9.x (minimum 9.0.0, recommended 9.3.0)
 
 We recommend -

--- a/v1.12.x/deployment/kubernetes/on-prem.mdx
+++ b/v1.12.x/deployment/kubernetes/on-prem.mdx
@@ -23,7 +23,7 @@ This guide presumes you have an on premises Kubernetes cluster setup, and you ar
 We support
 
 - MySQL engine version 8 or higher
-- PostgreSQL engine version 12 or higher
+- PostgreSQL engine version 15 or higher
 - ElasticSearch version 9.x (minimum 9.0.0, recommended 9.3.0) or OpenSearch version 3.x (minimum 3.0.0, recommended 3.3.0)
 
 Once you have the External Database and Search Engine configured, you can update the environment variables below for OpenMetadata kubernetes deployments to connect with Database and ElasticSearch.

--- a/v1.12.x/deployment/minimum-requirements.mdx
+++ b/v1.12.x/deployment/minimum-requirements.mdx
@@ -33,7 +33,7 @@ These settings apply as well when using managed instances, such as AWS RDS or GC
 OpenMetadata currently supports -
 
 - MySQL version 8.0.42 or higher
-- PostgreSQL version 12.0 or higher
+- PostgreSQL version 15 or higher
 
 ## ElasticSearch or OpenSearch as Search Instance
 

--- a/v1.13.x/deployment/bare-metal.mdx
+++ b/v1.13.x/deployment/bare-metal.mdx
@@ -41,7 +41,7 @@ You can refer a sample script [here](https://github.com/open-metadata/OpenMetada
 
 </Tip>
 
-## Postgres (version 12.0 or higher)
+## Postgres (version 15 or higher)
 
 To install Postgres see the instructions for your operating system (OS) at [Postgres Download](https://www.postgresql.org/download/)
 <Tip>
@@ -174,7 +174,7 @@ We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
 - Amazon OpenSearch (ElasticSearch) engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
-- Amazon RDS (PostgreSQL) engine version between 12 or higher
+- Amazon RDS (PostgreSQL) engine version 15 or higher
 
 For Production Systems, we recommend Amazon RDS to be in Multiple Availability Zones. For Amazon OpenSearch (or ElasticSearch) Service, we recommend Multiple Availability Zones with minimum 3 Master Nodes.
 

--- a/v1.13.x/deployment/configuration.mdx
+++ b/v1.13.x/deployment/configuration.mdx
@@ -113,7 +113,7 @@ database:
 
 ### PostgreSQL Configuration
 
-OpenMetadata uses stored generated columns which is supported in Postgres 12 and later. Ensure you have Postgres 12 or higher. We recommend you create a Postgres user with a strong password and update this section accordingly.
+OpenMetadata uses stored generated columns which is supported in Postgres 15 and later. Ensure you have Postgres 15 or higher. We recommend you create a Postgres user with a strong password and update this section accordingly.
 
 | Parameter | Description | Default Value |
 |-----------|-------------|---------------|

--- a/v1.13.x/deployment/configuration.mdx
+++ b/v1.13.x/deployment/configuration.mdx
@@ -113,7 +113,7 @@ database:
 
 ### PostgreSQL Configuration
 
-OpenMetadata uses stored generated columns which is supported in Postgres 15 and later. Ensure you have Postgres 15 or higher. We recommend you create a Postgres user with a strong password and update this section accordingly.
+OpenMetadata uses stored generated columns (supported since Postgres 12). We recommend running Postgres 15 or higher. Create a Postgres user with a strong password and update this section accordingly.
 
 | Parameter | Description | Default Value |
 |-----------|-------------|---------------|

--- a/v1.13.x/deployment/docker/advanced.mdx
+++ b/v1.13.x/deployment/docker/advanced.mdx
@@ -57,7 +57,7 @@ We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
 - Amazon OpenSearch (ElasticSearch) engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
-- Amazon RDS (PostgreSQL) engine version 12 or higher
+- Amazon RDS (PostgreSQL) engine version 15 or higher
 
 Note:-
 When using AWS Services the SearchType Configuration for elastic search should be `opensearch`, for both cases ElasticSearch and OpenSearch,

--- a/v1.13.x/deployment/kubernetes/aks.mdx
+++ b/v1.13.x/deployment/kubernetes/aks.mdx
@@ -17,7 +17,7 @@ It is recommended to use [Azure SQL](https://azure.microsoft.com/en-in/products/
 
 We support:
 - Azure SQL (MySQL) engine version 8 or higher
-- Azure SQL (PostgreSQL) engine version 12 or higher
+- Azure SQL (PostgreSQL) engine version 15 or higher
 - Elastic Cloud (ElasticSearch version 9.x, minimum 9.0.0, recommended 9.3.0)
 
 We recommend:

--- a/v1.13.x/deployment/kubernetes/eks.mdx
+++ b/v1.13.x/deployment/kubernetes/eks.mdx
@@ -26,7 +26,7 @@ It is recommended to use [Amazon RDS](https://docs.aws.amazon.com/rds/index.html
 We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
-- Amazon RDS (PostgreSQL) engine version 12 or higher
+- Amazon RDS (PostgreSQL) engine version 15 or higher
 - Amazon OpenSearch engine version 2.X (upto 2.19)
 
 <Tip>

--- a/v1.13.x/deployment/kubernetes/gke.mdx
+++ b/v1.13.x/deployment/kubernetes/gke.mdx
@@ -33,7 +33,7 @@ It is recommended to use GCP [Cloud SQL](https://cloud.google.com/sql/) services
 
 We support -
 - Cloud SQL (MySQL) engine version 8 or higher
-- Cloud SQL (postgreSQL) engine version 12 or higher
+- Cloud SQL (postgreSQL) engine version 15 or higher
 - ElasticSearch Engine version 8.X (upto 8.10.X)
 
 We recommend -

--- a/v1.13.x/deployment/kubernetes/on-prem.mdx
+++ b/v1.13.x/deployment/kubernetes/on-prem.mdx
@@ -23,7 +23,7 @@ This guide presumes you have an on premises Kubernetes cluster setup, and you ar
 We support
 
 - MySQL engine version 8 or higher
-- PostgreSQL engine version 12 or higher
+- PostgreSQL engine version 15 or higher
 - ElasticSearch version 8.X (upto 8.11.4) or OpenSearch Version 2.X (upto 2.19)
 
 Once you have the External Database and Search Engine configured, you can update the environment variables below for OpenMetadata kubernetes deployments to connect with Database and ElasticSearch.

--- a/v1.13.x/deployment/minimum-requirements.mdx
+++ b/v1.13.x/deployment/minimum-requirements.mdx
@@ -33,7 +33,7 @@ These settings apply as well when using managed instances, such as AWS RDS or GC
 OpenMetadata currently supports -
 
 - MySQL version 8.0.42 or higher
-- PostgreSQL version 12.0 or higher
+- PostgreSQL version 15 or higher
 
 ## ElasticSearch or OpenSearch as Search Instance
 

--- a/v2.0.x-SNAPSHOT/deployment/bare-metal.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/bare-metal.mdx
@@ -41,7 +41,7 @@ You can refer a sample script [here](https://github.com/open-metadata/OpenMetada
 
 </Tip>
 
-## Postgres (version 12.0 or higher)
+## Postgres (version 15 or higher)
 
 To install Postgres see the instructions for your operating system (OS) at [Postgres Download](https://www.postgresql.org/download/)
 <Tip>
@@ -174,7 +174,7 @@ We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
 - Amazon OpenSearch (ElasticSearch) engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
-- Amazon RDS (PostgreSQL) engine version between 12 or higher
+- Amazon RDS (PostgreSQL) engine version 15 or higher
 
 For Production Systems, we recommend Amazon RDS to be in Multiple Availability Zones. For Amazon OpenSearch (or ElasticSearch) Service, we recommend Multiple Availability Zones with minimum 3 Master Nodes.
 

--- a/v2.0.x-SNAPSHOT/deployment/configuration.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/configuration.mdx
@@ -113,7 +113,7 @@ database:
 
 ### PostgreSQL Configuration
 
-OpenMetadata uses stored generated columns which is supported in Postgres 12 and later. Ensure you have Postgres 12 or higher. We recommend you create a Postgres user with a strong password and update this section accordingly.
+OpenMetadata uses stored generated columns which is supported in Postgres 15 and later. Ensure you have Postgres 15 or higher. We recommend you create a Postgres user with a strong password and update this section accordingly.
 
 | Parameter | Description | Default Value |
 |-----------|-------------|---------------|

--- a/v2.0.x-SNAPSHOT/deployment/configuration.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/configuration.mdx
@@ -113,7 +113,7 @@ database:
 
 ### PostgreSQL Configuration
 
-OpenMetadata uses stored generated columns which is supported in Postgres 15 and later. Ensure you have Postgres 15 or higher. We recommend you create a Postgres user with a strong password and update this section accordingly.
+OpenMetadata uses stored generated columns (supported since Postgres 12). We recommend running Postgres 15 or higher. Create a Postgres user with a strong password and update this section accordingly.
 
 | Parameter | Description | Default Value |
 |-----------|-------------|---------------|

--- a/v2.0.x-SNAPSHOT/deployment/docker/advanced.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/docker/advanced.mdx
@@ -57,7 +57,7 @@ We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
 - Amazon OpenSearch (ElasticSearch) engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
-- Amazon RDS (PostgreSQL) engine version 12 or higher
+- Amazon RDS (PostgreSQL) engine version 15 or higher
 
 Note:-
 When using AWS Services the SearchType Configuration for elastic search should be `opensearch`, for both cases ElasticSearch and OpenSearch,

--- a/v2.0.x-SNAPSHOT/deployment/kubernetes/aks.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/kubernetes/aks.mdx
@@ -17,7 +17,7 @@ It is recommended to use [Azure SQL](https://azure.microsoft.com/en-in/products/
 
 We support:
 - Azure SQL (MySQL) engine version 8 or higher
-- Azure SQL (PostgreSQL) engine version 12 or higher
+- Azure SQL (PostgreSQL) engine version 15 or higher
 - Elastic Cloud (ElasticSearch version 9.x, minimum 9.0.0, recommended 9.3.0)
 
 We recommend:

--- a/v2.0.x-SNAPSHOT/deployment/kubernetes/eks.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/kubernetes/eks.mdx
@@ -26,7 +26,7 @@ It is recommended to use [Amazon RDS](https://docs.aws.amazon.com/rds/index.html
 We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
-- Amazon RDS (PostgreSQL) engine version 12 or higher
+- Amazon RDS (PostgreSQL) engine version 15 or higher
 - Amazon OpenSearch engine version 2.X (upto 2.19)
 
 <Tip>

--- a/v2.0.x-SNAPSHOT/deployment/kubernetes/gke.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/kubernetes/gke.mdx
@@ -33,7 +33,7 @@ It is recommended to use GCP [Cloud SQL](https://cloud.google.com/sql/) services
 
 We support -
 - Cloud SQL (MySQL) engine version 8 or higher
-- Cloud SQL (postgreSQL) engine version 12 or higher
+- Cloud SQL (postgreSQL) engine version 15 or higher
 - ElasticSearch Engine version 8.X (upto 8.10.X)
 
 We recommend -

--- a/v2.0.x-SNAPSHOT/deployment/kubernetes/on-prem.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/kubernetes/on-prem.mdx
@@ -23,7 +23,7 @@ This guide presumes you have an on premises Kubernetes cluster setup, and you ar
 We support
 
 - MySQL engine version 8 or higher
-- PostgreSQL engine version 12 or higher
+- PostgreSQL engine version 15 or higher
 - ElasticSearch version 8.X (upto 8.11.4) or OpenSearch Version 2.X (upto 2.19)
 
 Once you have the External Database and Search Engine configured, you can update the environment variables below for OpenMetadata kubernetes deployments to connect with Database and ElasticSearch.

--- a/v2.0.x-SNAPSHOT/deployment/minimum-requirements.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/minimum-requirements.mdx
@@ -33,7 +33,7 @@ These settings apply as well when using managed instances, such as AWS RDS or GC
 OpenMetadata currently supports -
 
 - MySQL version 8.0.42 or higher
-- PostgreSQL version 12.0 or higher
+- PostgreSQL version 15 or higher
 
 ## ElasticSearch or OpenSearch as Search Instance
 


### PR DESCRIPTION
## Summary

- Fixes a typo in the Version Compatibility Matrix where Postgres was incorrectly listed as `1.15.0` — corrected to `15`
- Updates minimum PostgreSQL version from `12` to `15` across all deployment docs (v1.12.x, v1.13.x, v2.0.x-SNAPSHOT), confirmed by DevOps team as the build/test version

## Files Changed

**Version Matrix (typo fix)**
- `snippets/components/VersionMatrix/versionMatrixData.mdx`
<img width="2904" height="1552" alt="image" src="https://github.com/user-attachments/assets/ec991b51-1b6c-40c1-8a13-bf52b6a1a974" />

**v1.12.x**, **v1.13.x**, and **v2.0.x-SNAPSHOT**
- `/deployment/minimum-requirements.mdx`
- `/deployment/bare-metal.mdx`
- `/deployment/configuration.mdx`
- `/deployment/docker/advanced.mdx`
- `/deployment/kubernetes/aks.mdx`
- `/deployment/kubernetes/eks.mdx`
- `/deployment/kubernetes/gke.mdx`
- `/deployment/kubernetes/on-prem.mdx`


