### PR TITLE
Docs: Fix connector stage badges across database, pipeline, messaging, and search services

### DIFF
--- a/snippets/v1.12.x/connectors/pipeline/connectors-list.mdx
+++ b/snippets/v1.12.x/connectors/pipeline/connectors-list.mdx
@@ -1,6 +1,6 @@
 <CardGroup cols="2">
 <Card title="Airbyte" icon="/public/images/connectors/airbyte.webp" href="/v1.12.x/connectors/pipeline/airbyte" horizontal >
-  <div className="prod-beta-chip beta"><img src="/public/images/icons/beta-icon.svg" alt="beta" noZoom /> <div>BETA</div></div>
+  <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
   </Card>
 <Card title="Airflow" icon="/public/images/connectors/airflow.webp" href="/v1.12.x/connectors/pipeline/airflow" horizontal >
   <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
@@ -12,7 +12,7 @@
   <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
   </Card>
 <Card title="dbt Cloud" icon="/public/images/connectors/dbtcloud.webp" href="/v1.12.x/connectors/pipeline/dbtcloud" horizontal >
-  <div className="prod-beta-chip beta"><img src="/public/images/icons/beta-icon.svg" alt="beta" noZoom /> <div>BETA</div></div>
+  <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
   </Card>
 <Card title="Domo" icon="/public/images/connectors/domo.webp" href="/v1.12.x/connectors/pipeline/domo-pipeline" horizontal >
   <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
@@ -33,7 +33,7 @@
   <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
   </Card>
 <Card title="OpenLineage" icon="/public/images/connectors/openlineage.png" href="/v1.12.x/connectors/pipeline/openlineage" horizontal >
-  <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
+  <div className="prod-beta-chip beta"><img src="/public/images/icons/beta-icon.svg" alt="beta" noZoom /> <div>BETA</div></div>
   </Card>
 <Card title="Spline" icon="/public/images/connectors/spline.webp" href="/v1.12.x/connectors/pipeline/spline" horizontal >
   <div className="prod-beta-chip beta"><img src="/public/images/icons/beta-icon.svg" alt="beta" noZoom /> <div>BETA</div></div>

--- a/snippets/v1.13.x/connectors/pipeline/connectors-list.mdx
+++ b/snippets/v1.13.x/connectors/pipeline/connectors-list.mdx
@@ -1,6 +1,6 @@
 <CardGroup cols="2">
 <Card title="Airbyte" icon="/public/images/connectors/airbyte.webp" href="/v1.13.x/connectors/pipeline/airbyte" horizontal >
-  <div className="prod-beta-chip beta"><img src="/public/images/icons/beta-icon.svg" alt="beta" noZoom /> <div>BETA</div></div>
+  <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
   </Card>
 <Card title="Airflow" icon="/public/images/connectors/airflow.webp" href="/v1.13.x/connectors/pipeline/airflow" horizontal >
   <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
@@ -12,7 +12,7 @@
   <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
   </Card>
 <Card title="dbt Cloud" icon="/public/images/connectors/dbtcloud.webp" href="/v1.13.x/connectors/pipeline/dbtcloud" horizontal >
-  <div className="prod-beta-chip beta"><img src="/public/images/icons/beta-icon.svg" alt="beta" noZoom /> <div>BETA</div></div>
+  <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
   </Card>
 <Card title="Domo" icon="/public/images/connectors/domo.webp" href="/v1.13.x/connectors/pipeline/domo-pipeline" horizontal >
   <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
@@ -33,7 +33,7 @@
   <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
   </Card>
 <Card title="OpenLineage" icon="/public/images/connectors/openlineage.png" href="/v1.13.x/connectors/pipeline/openlineage" horizontal >
-  <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
+  <div className="prod-beta-chip beta"><img src="/public/images/icons/beta-icon.svg" alt="beta" noZoom /> <div>BETA</div></div>
   </Card>
 <Card title="Spline" icon="/public/images/connectors/spline.webp" href="/v1.13.x/connectors/pipeline/spline" horizontal >
   <div className="prod-beta-chip beta"><img src="/public/images/icons/beta-icon.svg" alt="beta" noZoom /> <div>BETA</div></div>

--- a/snippets/v2.0.x-SNAPSHOT/connectors/pipeline/connectors-list.mdx
+++ b/snippets/v2.0.x-SNAPSHOT/connectors/pipeline/connectors-list.mdx
@@ -1,6 +1,6 @@
 <CardGroup cols="2">
 <Card title="Airbyte" icon="/public/images/connectors/airbyte.webp" href="/v2.0.x-SNAPSHOT/connectors/pipeline/airbyte" horizontal >
-  <div className="prod-beta-chip beta"><img src="/public/images/icons/beta-icon.svg" alt="beta" noZoom /> <div>BETA</div></div>
+  <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
   </Card>
 <Card title="Airflow" icon="/public/images/connectors/airflow.webp" href="/v2.0.x-SNAPSHOT/connectors/pipeline/airflow" horizontal >
   <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
@@ -12,7 +12,7 @@
   <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
   </Card>
 <Card title="dbt Cloud" icon="/public/images/connectors/dbtcloud.webp" href="/v2.0.x-SNAPSHOT/connectors/pipeline/dbtcloud" horizontal >
-  <div className="prod-beta-chip beta"><img src="/public/images/icons/beta-icon.svg" alt="beta" noZoom /> <div>BETA</div></div>
+  <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
   </Card>
 <Card title="Domo" icon="/public/images/connectors/domo.webp" href="/v2.0.x-SNAPSHOT/connectors/pipeline/domo-pipeline" horizontal >
   <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
@@ -33,7 +33,7 @@
   <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
   </Card>
 <Card title="OpenLineage" icon="/public/images/connectors/openlineage.png" href="/v2.0.x-SNAPSHOT/connectors/pipeline/openlineage" horizontal >
-  <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
+  <div className="prod-beta-chip beta"><img src="/public/images/icons/beta-icon.svg" alt="beta" noZoom /> <div>BETA</div></div>
   </Card>
 <Card title="Spline" icon="/public/images/connectors/spline.webp" href="/v2.0.x-SNAPSHOT/connectors/pipeline/spline" horizontal >
   <div className="prod-beta-chip beta"><img src="/public/images/icons/beta-icon.svg" alt="beta" noZoom /> <div>BETA</div></div>

--- a/snippets/v2.0.x-SNAPSHOT/connectors/pipeline/connectors-list.mdx
+++ b/snippets/v2.0.x-SNAPSHOT/connectors/pipeline/connectors-list.mdx
@@ -33,7 +33,7 @@
   <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
   </Card>
 <Card title="OpenLineage" icon="/public/images/connectors/openlineage.png" href="/v2.0.x-SNAPSHOT/connectors/pipeline/openlineage" horizontal >
-  <div className="prod-beta-chip beta"><img src="/public/images/icons/beta-icon.svg" alt="beta" noZoom /> <div>BETA</div></div>
+  <div className="prod-beta-chip prod"><img src="/public/images/icons/prod-icon.svg" alt="prod" noZoom /> <div>PROD</div></div>
   </Card>
 <Card title="Spline" icon="/public/images/connectors/spline.webp" href="/v2.0.x-SNAPSHOT/connectors/pipeline/spline" horizontal >
   <div className="prod-beta-chip beta"><img src="/public/images/icons/beta-icon.svg" alt="beta" noZoom /> <div>BETA</div></div>

--- a/v1.12.x/connectors/database/couchbase.mdx
+++ b/v1.12.x/connectors/database/couchbase.mdx
@@ -14,7 +14,7 @@ import Related from '/snippets/v1.12.x/connectors/database/related.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/couchbase.webp'
 name="Couchbase"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata"]}
 unavailableFeatures={["Owners", "Tags", "Stored Procedures", "Query Usage", "Lineage", "Column-level Lineage", "Data Profiler", "Data Quality", "dbt", "Sample Data", "Auto-Classification"]} />
 In this section, we provide guides and references to use the Couchbase connector.

--- a/v1.12.x/connectors/database/couchbase/yaml.mdx
+++ b/v1.12.x/connectors/database/couchbase/yaml.mdx
@@ -19,7 +19,7 @@ import SourceConfig from '/snippets/connectors/yaml/database/source-config.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/couchbase.webp'
 name="Couchbase"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata"]}
 unavailableFeatures={["Owners", "Tags", "Stored Procedures", "Query Usage", "Lineage", "Column-level Lineage", "Data Profiler", "Data Quality", "dbt", "Sample Data", "Auto-Classification"]} />
 In this section, we provide guides and references to use the Couchbase connector.

--- a/v1.12.x/connectors/database/greenplum.mdx
+++ b/v1.12.x/connectors/database/greenplum.mdx
@@ -14,7 +14,7 @@ import Related from '/snippets/v1.12.x/connectors/database/related.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/greenplum.webp'
 name="Greenplum"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata", "Data Profiler", "Data Quality", "dbt", "View Lineage", "Sample Data", "Auto-Classification"]}
 unavailableFeatures={["Query Usage", "Owners", "Tags", "Stored Procedures", "Lineage", "Column-level Lineage"]} />
 In this section, we provide guides and references to use the Greenplum connector.

--- a/v1.12.x/connectors/database/greenplum/yaml.mdx
+++ b/v1.12.x/connectors/database/greenplum/yaml.mdx
@@ -23,7 +23,7 @@ import DataQuality from '/snippets/connectors/yaml/data-quality.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/greenplum.webp'
 name="Greenplum"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata", "Data Profiler", "Data Quality", "dbt", "view Lineage", "Sample Data", "Auto-Classification"]}
 unavailableFeatures={["Query Usage", "Owners", "Tags", "Stored Procedures", "Lineage", "Column-level Lineage"]} />
 In this section, we provide guides and references to use the Greenplum connector.

--- a/v1.12.x/connectors/database/sas.mdx
+++ b/v1.12.x/connectors/database/sas.mdx
@@ -12,7 +12,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 <ConnectorDetailsHeader
 icon='/public/images/connectors/sas.webp'
 name="SAS"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata"]}
 unavailableFeatures={["Query Usage", "Data Profiler", "Data Quality", "Lineage", "Column-level Lineage", "dbt", "Stored Procedures", "Owners", "Tags", "Sample Data", "Auto-Classification"]} />
 In this section, we provide guides and references to use the SAS connector.

--- a/v1.12.x/connectors/database/sas/yaml.mdx
+++ b/v1.12.x/connectors/database/sas/yaml.mdx
@@ -15,7 +15,7 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/sas.webp'
 name="SAS"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata"]}
 unavailableFeatures={["Query Usage", "Data Profiler", "Data Quality", "Lineage", "Column-level Lineage", "dbt", "Stored Procedures", "Owners", "Tags", "Sample Data", "Auto-Classification"]} />
 In this section, we provide guides and references to use the SAS connector.

--- a/v1.12.x/connectors/database/teradata.mdx
+++ b/v1.12.x/connectors/database/teradata.mdx
@@ -14,7 +14,7 @@ import Related from '/snippets/v1.12.x/connectors/database/related.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/teradata.webp'
 name="Teradata"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata", "Data Profiler", "View Lineage", "View Column-level Lineage", "Sample Data", "Auto-Classification"]}
 unavailableFeatures={["Query Usage", "Data Quality", "Owners", "Tags", "Stored Procedures", "dbt"]} />
 In this section, we provide guides and references to use the Teradata connector.

--- a/v1.12.x/connectors/database/teradata/yaml.mdx
+++ b/v1.12.x/connectors/database/teradata/yaml.mdx
@@ -19,7 +19,7 @@ import DataQuality from '/snippets/connectors/yaml/data-quality.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/teradata.webp'
 name="Teradata"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata", "Data Profiler", "Data Quality", "View Lineage", "View Column-level Lineage", "Sample Data", "Auto-Classification"]}
 unavailableFeatures={["Query Usage", "Owners", "Tags", "Stored Procedures", "dbt"]} />
 In this section, we provide guides and references to use the Teradata connector.

--- a/v1.12.x/connectors/pipeline/flink.mdx
+++ b/v1.12.x/connectors/pipeline/flink.mdx
@@ -12,7 +12,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 <ConnectorDetailsHeader
 icon='/public/images/connectors/flink.png'
 name="Flink"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Pipelines", "Pipeline Status", "Usage"]}
 unavailableFeatures={["Owners", "Tags", "Lineage"]} />
 In this section, we provide guides and references to use the Apache Flink connector.

--- a/v1.12.x/connectors/pipeline/flink/yaml.mdx
+++ b/v1.12.x/connectors/pipeline/flink/yaml.mdx
@@ -19,7 +19,7 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/flink.png'
 name="Flink"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Pipelines", "Pipeline Status", "Usage"]}
 unavailableFeatures={["Owners", "Lineage", "Tags"]} />
 In this section, we provide guides and references to use the Flink connector.

--- a/v1.12.x/connectors/search/opensearch.mdx
+++ b/v1.12.x/connectors/search/opensearch.mdx
@@ -12,7 +12,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 <ConnectorDetailsHeader
 icon='/public/images/connectors/opensearch.webp'
 name="OpenSearch"
-stage="PROD"
+stage="BETA"
 availableFeatures={["Search Indexes", "Sample Data"]}
 unavailableFeatures={[]} />
 In this section, we provide guides and references to use the OpenSearch connector.

--- a/v1.12.x/connectors/search/opensearch/yaml.mdx
+++ b/v1.12.x/connectors/search/opensearch/yaml.mdx
@@ -19,7 +19,7 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/opensearch.webp'
 name="OpenSearch"
-stage="PROD"
+stage="BETA"
 availableFeatures={["Search Indexes", "Sample Data"]}
 unavailableFeatures={[]} />
 In this section, we provide guides and references to use the OpenSearch connector.

--- a/v1.13.x/connectors/database/couchbase.mdx
+++ b/v1.13.x/connectors/database/couchbase.mdx
@@ -14,7 +14,7 @@ import Related from '/snippets/v1.13.x/connectors/database/related.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/couchbase.webp'
 name="Couchbase"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata"]}
 unavailableFeatures={["Owners", "Tags", "Stored Procedures", "Query Usage", "Lineage", "Column-level Lineage", "Data Profiler", "Data Quality", "dbt", "Sample Data", "Auto-Classification"]} />
 In this section, we provide guides and references to use the Couchbase connector.

--- a/v1.13.x/connectors/database/couchbase/yaml.mdx
+++ b/v1.13.x/connectors/database/couchbase/yaml.mdx
@@ -19,7 +19,7 @@ import SourceConfig from '/snippets/connectors/yaml/database/source-config.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/couchbase.webp'
 name="Couchbase"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata"]}
 unavailableFeatures={["Owners", "Tags", "Stored Procedures", "Query Usage", "Lineage", "Column-level Lineage", "Data Profiler", "Data Quality", "dbt", "Sample Data", "Auto-Classification"]} />
 In this section, we provide guides and references to use the Couchbase connector.

--- a/v1.13.x/connectors/database/greenplum.mdx
+++ b/v1.13.x/connectors/database/greenplum.mdx
@@ -14,7 +14,7 @@ import Related from '/snippets/v1.13.x/connectors/database/related.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/greenplum.webp'
 name="Greenplum"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata", "Data Profiler", "Data Quality", "dbt", "View Lineage", "Sample Data", "Auto-Classification"]}
 unavailableFeatures={["Query Usage", "Owners", "Tags", "Stored Procedures", "Lineage", "Column-level Lineage"]} />
 In this section, we provide guides and references to use the Greenplum connector.

--- a/v1.13.x/connectors/database/greenplum/yaml.mdx
+++ b/v1.13.x/connectors/database/greenplum/yaml.mdx
@@ -23,7 +23,7 @@ import DataQuality from '/snippets/connectors/yaml/data-quality.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/greenplum.webp'
 name="Greenplum"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata", "Data Profiler", "Data Quality", "dbt", "view Lineage", "Sample Data", "Auto-Classification"]}
 unavailableFeatures={["Query Usage", "Owners", "Tags", "Stored Procedures", "Lineage", "Column-level Lineage"]} />
 In this section, we provide guides and references to use the Greenplum connector.

--- a/v1.13.x/connectors/database/sas.mdx
+++ b/v1.13.x/connectors/database/sas.mdx
@@ -12,7 +12,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 <ConnectorDetailsHeader
 icon='/public/images/connectors/sas.webp'
 name="SAS"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata"]}
 unavailableFeatures={["Query Usage", "Data Profiler", "Data Quality", "Lineage", "Column-level Lineage", "dbt", "Stored Procedures", "Owners", "Tags", "Sample Data", "Auto-Classification"]} />
 In this section, we provide guides and references to use the SAS connector.

--- a/v1.13.x/connectors/database/sas/yaml.mdx
+++ b/v1.13.x/connectors/database/sas/yaml.mdx
@@ -15,7 +15,7 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/sas.webp'
 name="SAS"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata"]}
 unavailableFeatures={["Query Usage", "Data Profiler", "Data Quality", "Lineage", "Column-level Lineage", "dbt", "Stored Procedures", "Owners", "Tags", "Sample Data", "Auto-Classification"]} />
 In this section, we provide guides and references to use the SAS connector.

--- a/v1.13.x/connectors/database/teradata.mdx
+++ b/v1.13.x/connectors/database/teradata.mdx
@@ -14,7 +14,7 @@ import Related from '/snippets/v1.13.x/connectors/database/related.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/teradata.webp'
 name="Teradata"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata", "Data Profiler", "View Lineage", "View Column-level Lineage", "Sample Data", "Auto-Classification"]}
 unavailableFeatures={["Query Usage", "Data Quality", "Owners", "Tags", "Stored Procedures", "dbt"]} />
 In this section, we provide guides and references to use the Teradata connector.

--- a/v1.13.x/connectors/database/teradata/yaml.mdx
+++ b/v1.13.x/connectors/database/teradata/yaml.mdx
@@ -19,7 +19,7 @@ import DataQuality from '/snippets/connectors/yaml/data-quality.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/teradata.webp'
 name="Teradata"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata", "Data Profiler", "Data Quality", "View Lineage", "View Column-level Lineage", "Sample Data", "Auto-Classification"]}
 unavailableFeatures={["Query Usage", "Owners", "Tags", "Stored Procedures", "dbt"]} />
 In this section, we provide guides and references to use the Teradata connector.

--- a/v1.13.x/connectors/messaging/pubsub.mdx
+++ b/v1.13.x/connectors/messaging/pubsub.mdx
@@ -13,7 +13,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 <ConnectorDetailsHeader
 icon='/public/images/connectors/pubsub.svg'
 name="Google Pub/Sub"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Topics"]}
 unavailableFeatures={["Sample Data"]} />
 

--- a/v1.13.x/connectors/messaging/pubsub/yaml.mdx
+++ b/v1.13.x/connectors/messaging/pubsub/yaml.mdx
@@ -20,7 +20,7 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/pubsub.svg'
 name="Google Pub/Sub"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Topics"]}
 unavailableFeatures={["Sample Data"]} />
 

--- a/v1.13.x/connectors/pipeline/flink.mdx
+++ b/v1.13.x/connectors/pipeline/flink.mdx
@@ -12,7 +12,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 <ConnectorDetailsHeader
 icon='/public/images/connectors/flink.png'
 name="Flink"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Pipelines", "Pipeline Status", "Usage"]}
 unavailableFeatures={["Owners", "Tags", "Lineage"]} />
 In this section, we provide guides and references to use the Apache Flink connector.

--- a/v1.13.x/connectors/pipeline/flink/yaml.mdx
+++ b/v1.13.x/connectors/pipeline/flink/yaml.mdx
@@ -19,7 +19,7 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/flink.png'
 name="Flink"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Pipelines", "Pipeline Status", "Usage"]}
 unavailableFeatures={["Owners", "Lineage", "Tags"]} />
 In this section, we provide guides and references to use the Flink connector.

--- a/v1.13.x/connectors/search/opensearch.mdx
+++ b/v1.13.x/connectors/search/opensearch.mdx
@@ -12,7 +12,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 <ConnectorDetailsHeader
 icon='/public/images/connectors/opensearch.webp'
 name="OpenSearch"
-stage="PROD"
+stage="BETA"
 availableFeatures={["Search Indexes", "Sample Data"]}
 unavailableFeatures={[]} />
 In this section, we provide guides and references to use the OpenSearch connector.

--- a/v1.13.x/connectors/search/opensearch/yaml.mdx
+++ b/v1.13.x/connectors/search/opensearch/yaml.mdx
@@ -19,7 +19,7 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/opensearch.webp'
 name="OpenSearch"
-stage="PROD"
+stage="BETA"
 availableFeatures={["Search Indexes", "Sample Data"]}
 unavailableFeatures={[]} />
 In this section, we provide guides and references to use the OpenSearch connector.

--- a/v2.0.x-SNAPSHOT/connectors/database/couchbase.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/couchbase.mdx
@@ -14,7 +14,7 @@ import Related from '/snippets/v2.0.x-SNAPSHOT/connectors/database/related.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/couchbase.webp'
 name="Couchbase"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata"]}
 unavailableFeatures={["Owners", "Tags", "Stored Procedures", "Query Usage", "Lineage", "Column-level Lineage", "Data Profiler", "Data Quality", "dbt", "Sample Data", "Auto-Classification"]} />
 In this section, we provide guides and references to use the Couchbase connector.

--- a/v2.0.x-SNAPSHOT/connectors/database/couchbase/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/couchbase/yaml.mdx
@@ -19,7 +19,7 @@ import SourceConfig from '/snippets/connectors/yaml/database/source-config.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/couchbase.webp'
 name="Couchbase"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata"]}
 unavailableFeatures={["Owners", "Tags", "Stored Procedures", "Query Usage", "Lineage", "Column-level Lineage", "Data Profiler", "Data Quality", "dbt", "Sample Data", "Auto-Classification"]} />
 In this section, we provide guides and references to use the Couchbase connector.

--- a/v2.0.x-SNAPSHOT/connectors/database/greenplum.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/greenplum.mdx
@@ -14,7 +14,7 @@ import Related from '/snippets/v2.0.x-SNAPSHOT/connectors/database/related.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/greenplum.webp'
 name="Greenplum"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata", "Data Profiler", "Data Quality", "dbt", "View Lineage", "Sample Data", "Auto-Classification"]}
 unavailableFeatures={["Query Usage", "Owners", "Tags", "Stored Procedures", "Lineage", "Column-level Lineage"]} />
 In this section, we provide guides and references to use the Greenplum connector.

--- a/v2.0.x-SNAPSHOT/connectors/database/greenplum/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/greenplum/yaml.mdx
@@ -23,7 +23,7 @@ import DataQuality from '/snippets/connectors/yaml/data-quality.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/greenplum.webp'
 name="Greenplum"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata", "Data Profiler", "Data Quality", "dbt", "view Lineage", "Sample Data", "Auto-Classification"]}
 unavailableFeatures={["Query Usage", "Owners", "Tags", "Stored Procedures", "Lineage", "Column-level Lineage"]} />
 In this section, we provide guides and references to use the Greenplum connector.

--- a/v2.0.x-SNAPSHOT/connectors/database/sas.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/sas.mdx
@@ -12,7 +12,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 <ConnectorDetailsHeader
 icon='/public/images/connectors/sas.webp'
 name="SAS"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata"]}
 unavailableFeatures={["Query Usage", "Data Profiler", "Data Quality", "Lineage", "Column-level Lineage", "dbt", "Stored Procedures", "Owners", "Tags", "Sample Data", "Auto-Classification"]} />
 In this section, we provide guides and references to use the SAS connector.

--- a/v2.0.x-SNAPSHOT/connectors/database/sas/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/sas/yaml.mdx
@@ -15,7 +15,7 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/sas.webp'
 name="SAS"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata"]}
 unavailableFeatures={["Query Usage", "Data Profiler", "Data Quality", "Lineage", "Column-level Lineage", "dbt", "Stored Procedures", "Owners", "Tags", "Sample Data", "Auto-Classification"]} />
 In this section, we provide guides and references to use the SAS connector.

--- a/v2.0.x-SNAPSHOT/connectors/database/teradata.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/teradata.mdx
@@ -14,7 +14,7 @@ import Related from '/snippets/v2.0.x-SNAPSHOT/connectors/database/related.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/teradata.webp'
 name="Teradata"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata", "Data Profiler", "View Lineage", "View Column-level Lineage", "Sample Data", "Auto-Classification"]}
 unavailableFeatures={["Query Usage", "Data Quality", "Owners", "Tags", "Stored Procedures", "dbt"]} />
 In this section, we provide guides and references to use the Teradata connector.

--- a/v2.0.x-SNAPSHOT/connectors/database/teradata/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/teradata/yaml.mdx
@@ -19,7 +19,7 @@ import DataQuality from '/snippets/connectors/yaml/data-quality.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/teradata.webp'
 name="Teradata"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Metadata", "Data Profiler", "Data Quality", "View Lineage", "View Column-level Lineage", "Sample Data", "Auto-Classification"]}
 unavailableFeatures={["Query Usage", "Owners", "Tags", "Stored Procedures", "dbt"]} />
 In this section, we provide guides and references to use the Teradata connector.

--- a/v2.0.x-SNAPSHOT/connectors/messaging/pubsub.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/messaging/pubsub.mdx
@@ -13,7 +13,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 <ConnectorDetailsHeader
 icon='/public/images/connectors/pubsub.svg'
 name="Google Pub/Sub"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Topics"]}
 unavailableFeatures={["Sample Data"]} />
 

--- a/v2.0.x-SNAPSHOT/connectors/messaging/pubsub/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/messaging/pubsub/yaml.mdx
@@ -20,7 +20,7 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/pubsub.svg'
 name="Google Pub/Sub"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Topics"]}
 unavailableFeatures={["Sample Data"]} />
 

--- a/v2.0.x-SNAPSHOT/connectors/pipeline/flink.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/pipeline/flink.mdx
@@ -12,7 +12,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 <ConnectorDetailsHeader
 icon='/public/images/connectors/flink.png'
 name="Flink"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Pipelines", "Pipeline Status", "Usage"]}
 unavailableFeatures={["Owners", "Tags", "Lineage"]} />
 In this section, we provide guides and references to use the Apache Flink connector.

--- a/v2.0.x-SNAPSHOT/connectors/pipeline/flink/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/pipeline/flink/yaml.mdx
@@ -19,7 +19,7 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/flink.png'
 name="Flink"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Pipelines", "Pipeline Status", "Usage"]}
 unavailableFeatures={["Owners", "Lineage", "Tags"]} />
 In this section, we provide guides and references to use the Flink connector.

--- a/v2.0.x-SNAPSHOT/connectors/search/opensearch.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/search/opensearch.mdx
@@ -12,7 +12,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 <ConnectorDetailsHeader
 icon='/public/images/connectors/opensearch.webp'
 name="OpenSearch"
-stage="PROD"
+stage="BETA"
 availableFeatures={["Search Indexes", "Sample Data"]}
 unavailableFeatures={[]} />
 In this section, we provide guides and references to use the OpenSearch connector.

--- a/v2.0.x-SNAPSHOT/connectors/search/opensearch.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/search/opensearch.mdx
@@ -12,7 +12,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 <ConnectorDetailsHeader
 icon='/public/images/connectors/opensearch.webp'
 name="OpenSearch"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Search Indexes", "Sample Data"]}
 unavailableFeatures={[]} />
 In this section, we provide guides and references to use the OpenSearch connector.

--- a/v2.0.x-SNAPSHOT/connectors/search/opensearch/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/search/opensearch/yaml.mdx
@@ -19,7 +19,7 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/opensearch.webp'
 name="OpenSearch"
-stage="PROD"
+stage="BETA"
 availableFeatures={["Search Indexes", "Sample Data"]}
 unavailableFeatures={[]} />
 In this section, we provide guides and references to use the OpenSearch connector.

--- a/v2.0.x-SNAPSHOT/connectors/search/opensearch/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/search/opensearch/yaml.mdx
@@ -19,7 +19,7 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 <ConnectorDetailsHeader
 icon='/public/images/connectors/opensearch.webp'
 name="OpenSearch"
-stage="BETA"
+stage="PROD"
 availableFeatures={["Search Indexes", "Sample Data"]}
 unavailableFeatures={[]} />
 In this section, we provide guides and references to use the OpenSearch connector.


### PR DESCRIPTION
## Summary

Fixes stage badge mismatches between connector catalog pages (connectors-list) and individual connector detail pages across all three doc versions (v1.12.x, v1.13.x, v2.0.x-SNAPSHOT). Ground truth was verified against the `BETA_SERVICES` array in the OpenMetadata UI source (`ServiceType.constant.ts`).

### Database Connectors (BETA → PROD)
- **Teradata** — confirmed PROD in UI
- **Couchbase** — confirmed PROD in UI
- **Greenplum** — confirmed PROD in UI
- **SAS** — confirmed PROD in UI

### Pipeline Connectors
- **Flink** — detail page BETA → PROD (not in BETA_SERVICES)
- **OpenLineage** — connectors-list PROD → BETA (confirmed beta in UI)
- **Airbyte** — connectors-list BETA → PROD (not in BETA_SERVICES)
- **dbt Cloud** — connectors-list BETA → PROD (not in BETA_SERVICES)

### Messaging Connectors
- **Pub/Sub** — detail page BETA → PROD (not in BETA_SERVICES; v1.13.x and v2.0.x only)

### Search Connectors
- **OpenSearch** — detail page PROD → BETA (confirmed beta in UI)

## Test plan
- [ ] Verify connector catalog pages show correct PROD/BETA badges
- [ ] Verify individual connector detail pages match the catalog badges
- [ ] Check all three versions (v1.12.x, v1.13.x, v2.0.x-SNAPSHOT)
