### PR TITLE
Docs: Add ingestionImage version pinning best practice and version mismatch troubleshooting

### DIFF
--- a/v1.12.x/deployment/ingestion/kubernetes.mdx
+++ b/v1.12.x/deployment/ingestion/kubernetes.mdx
@@ -88,6 +88,11 @@ This setup uses custom CRDs for guaranteed exit handler execution and failure di
 
 ### Helm Values Configuration
 
+
+<Warning>
+Always pin `ingestionImage` to the same version as your OpenMetadata server — never use `:latest`. The `:latest` tag moves whenever a new release is published; any Kubernetes node without the previous image cached will silently pull the newer version on the next scheduled job, causing a server/client version mismatch. The ingestion major version must match the server major version (for example, a 1.12.x server requires a 1.12.x ingestion image).
+</Warning>
+
 ```yaml
 # Enable the OMJob Operator
 omjobOperator:
@@ -210,6 +215,11 @@ This setup uses standard Kubernetes Jobs and CronJobs without any custom CRDs.
 3. **Ingestion image** accessible from your cluster (`docker.getcollate.io/openmetadata/ingestion-base`)
 
 ### Helm Values Configuration
+
+
+<Warning>
+Always pin `ingestionImage` to the same version as your OpenMetadata server — never use `:latest`. The `:latest` tag moves whenever a new release is published; any Kubernetes node without the previous image cached will silently pull the newer version on the next scheduled job, causing a server/client version mismatch. The ingestion major version must match the server major version (for example, a 1.12.x server requires a 1.12.x ingestion image).
+</Warning>
 
 ```yaml
 openmetadata:

--- a/v1.12.x/deployment/ingestion/kubernetes/troubleshooting.mdx
+++ b/v1.12.x/deployment/ingestion/kubernetes/troubleshooting.mdx
@@ -57,6 +57,27 @@ kubectl logs job/<pipeline-name> -c main
 
 ## Troubleshooting
 
+### Server/Client Version Mismatch
+
+If you see an error like `server version X does not match client version Y`, the ingestion job is running a different version of the ingestion library than the OpenMetadata server expects.
+
+**Most common cause:** `ingestionImage` is set to `:latest` in your Helm values. When a new OpenMetadata release is published, `:latest` moves to that version. Any Kubernetes node without the old image cached will pull the new one on the next job run, silently upgrading the ingestion client while your server stays on the previous version.
+
+**Fix:** Pin `ingestionImage` to the exact version of your server:
+
+```yaml
+k8s:
+  ingestionImage: "docker.getcollate.io/openmetadata/ingestion-base:1.12.8"
+```
+
+Replace `1.12.8` with your actual server version. The ingestion major version must match the server major version — for example, a 1.12.x server requires a 1.12.x ingestion image.
+
+After updating, redeploy OpenMetadata:
+
+```bash
+helm upgrade openmetadata open-metadata/openmetadata -f values.yaml -n openmetadata
+```
+
 ### Pipeline stuck in "Queued" state
 
 If the pipeline cannot start and remains in "Queued" state, check if the pod can be scheduled:

--- a/v1.13.x/deployment/ingestion/kubernetes.mdx
+++ b/v1.13.x/deployment/ingestion/kubernetes.mdx
@@ -88,6 +88,11 @@ This setup uses custom CRDs for guaranteed exit handler execution and failure di
 
 ### Helm Values Configuration
 
+
+<Warning>
+Always pin `ingestionImage` to the same version as your OpenMetadata server — never use `:latest`. The `:latest` tag moves whenever a new release is published; any Kubernetes node without the previous image cached will silently pull the newer version on the next scheduled job, causing a server/client version mismatch. The ingestion major version must match the server major version (for example, a 1.12.x server requires a 1.12.x ingestion image).
+</Warning>
+
 ```yaml
 # Enable the OMJob Operator
 omjobOperator:
@@ -210,6 +215,11 @@ This setup uses standard Kubernetes Jobs and CronJobs without any custom CRDs.
 3. **Ingestion image** accessible from your cluster (`docker.getcollate.io/openmetadata/ingestion-base`)
 
 ### Helm Values Configuration
+
+
+<Warning>
+Always pin `ingestionImage` to the same version as your OpenMetadata server — never use `:latest`. The `:latest` tag moves whenever a new release is published; any Kubernetes node without the previous image cached will silently pull the newer version on the next scheduled job, causing a server/client version mismatch. The ingestion major version must match the server major version (for example, a 1.12.x server requires a 1.12.x ingestion image).
+</Warning>
 
 ```yaml
 openmetadata:

--- a/v1.13.x/deployment/ingestion/kubernetes/troubleshooting.mdx
+++ b/v1.13.x/deployment/ingestion/kubernetes/troubleshooting.mdx
@@ -57,6 +57,27 @@ kubectl logs job/<pipeline-name> -c main
 
 ## Troubleshooting
 
+### Server/Client Version Mismatch
+
+If you see an error like `server version X does not match client version Y`, the ingestion job is running a different version of the ingestion library than the OpenMetadata server expects.
+
+**Most common cause:** `ingestionImage` is set to `:latest` in your Helm values. When a new OpenMetadata release is published, `:latest` moves to that version. Any Kubernetes node without the old image cached will pull the new one on the next job run, silently upgrading the ingestion client while your server stays on the previous version.
+
+**Fix:** Pin `ingestionImage` to the exact version of your server:
+
+```yaml
+k8s:
+  ingestionImage: "docker.getcollate.io/openmetadata/ingestion-base:1.12.8"
+```
+
+Replace `1.12.8` with your actual server version. The ingestion major version must match the server major version — for example, a 1.12.x server requires a 1.12.x ingestion image.
+
+After updating, redeploy OpenMetadata:
+
+```bash
+helm upgrade openmetadata open-metadata/openmetadata -f values.yaml -n openmetadata
+```
+
 ### Pipeline stuck in "Queued" state
 
 If the pipeline cannot start and remains in "Queued" state, check if the pod can be scheduled:

--- a/v2.0.x-SNAPSHOT/deployment/ingestion/kubernetes.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/ingestion/kubernetes.mdx
@@ -88,6 +88,11 @@ This setup uses custom CRDs for guaranteed exit handler execution and failure di
 
 ### Helm Values Configuration
 
+
+<Warning>
+Always pin `ingestionImage` to the same version as your OpenMetadata server — never use `:latest`. The `:latest` tag moves whenever a new release is published; any Kubernetes node without the previous image cached will silently pull the newer version on the next scheduled job, causing a server/client version mismatch. The ingestion major version must match the server major version (for example, a 1.12.x server requires a 1.12.x ingestion image).
+</Warning>
+
 ```yaml
 # Enable the OMJob Operator
 omjobOperator:
@@ -210,6 +215,11 @@ This setup uses standard Kubernetes Jobs and CronJobs without any custom CRDs.
 3. **Ingestion image** accessible from your cluster (`docker.getcollate.io/openmetadata/ingestion-base`)
 
 ### Helm Values Configuration
+
+
+<Warning>
+Always pin `ingestionImage` to the same version as your OpenMetadata server — never use `:latest`. The `:latest` tag moves whenever a new release is published; any Kubernetes node without the previous image cached will silently pull the newer version on the next scheduled job, causing a server/client version mismatch. The ingestion major version must match the server major version (for example, a 1.12.x server requires a 1.12.x ingestion image).
+</Warning>
 
 ```yaml
 openmetadata:

--- a/v2.0.x-SNAPSHOT/deployment/ingestion/kubernetes/troubleshooting.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/ingestion/kubernetes/troubleshooting.mdx
@@ -57,6 +57,27 @@ kubectl logs job/<pipeline-name> -c main
 
 ## Troubleshooting
 
+### Server/Client Version Mismatch
+
+If you see an error like `server version X does not match client version Y`, the ingestion job is running a different version of the ingestion library than the OpenMetadata server expects.
+
+**Most common cause:** `ingestionImage` is set to `:latest` in your Helm values. When a new OpenMetadata release is published, `:latest` moves to that version. Any Kubernetes node without the old image cached will pull the new one on the next job run, silently upgrading the ingestion client while your server stays on the previous version.
+
+**Fix:** Pin `ingestionImage` to the exact version of your server:
+
+```yaml
+k8s:
+  ingestionImage: "docker.getcollate.io/openmetadata/ingestion-base:1.12.8"
+```
+
+Replace `1.12.8` with your actual server version. The ingestion major version must match the server major version — for example, a 1.12.x server requires a 1.12.x ingestion image.
+
+After updating, redeploy OpenMetadata:
+
+```bash
+helm upgrade openmetadata open-metadata/openmetadata -f values.yaml -n openmetadata
+```
+
 ### Pipeline stuck in "Queued" state
 
 If the pipeline cannot start and remains in "Queued" state, check if the pod can be scheduled:


### PR DESCRIPTION
## Summary

Addresses a common production issue where users running the Kubernetes native orchestrator hit a server/client version mismatch after a new OpenMetadata release is published.

**Root cause:** `ingestionImage` defaults to `:latest`, which moves silently when a new release ships. Any Kubernetes node without the previous image cached pulls the new version on the next scheduled job — upgrading the ingestion client while the server stays on the old version.

**Changes:**
- Added a `<Warning>` callout before the Helm Values Configuration YAML block in both Setup Option 1 (OMJob Operator) and Setup Option 2 (Native Jobs) in `kubernetes.mdx`
<img width="2956" height="1266" alt="image" src="https://github.com/user-attachments/assets/67b9f175-39a2-4557-9415-6bd6789ea672" />

- Added a **Server/Client Version Mismatch** troubleshooting section to `troubleshooting.mdx` with symptom, cause, and fix (pin `ingestionImage` to match server version)
<img width="2972" height="1542" alt="image" src="https://github.com/user-attachments/assets/896e1359-d9bd-4d66-ad86-36100f004401" />

- Applied across all three versions: v1.12.x, v1.13.x, v2.0.x-SNAPSHOT

## Test plan
- [ ] Verify the Warning appears correctly before both YAML config blocks in the Kubernetes orchestrator guide
- [ ] Verify the troubleshooting section renders with correct code blocks and version links across all three versions
