### PR TITLE
Update to get latest URL always when new release is updated

### DIFF
--- a/.github/workflows/bump-latest-version.yml
+++ b/.github/workflows/bump-latest-version.yml
@@ -33,9 +33,10 @@ jobs:
             .find(r => r.source === '/latest/:slug*')
             .destination.match(/\/(v[\d.x]+)\//)[1];
           if (cur === nv) { console.log(`Already pointing to ${nv} — nothing to do.`); process.exit(0); }
+          const versionedSource = /^\/v\d+\.\d+\.x(?:\/|$)/;
           let n = 0;
           docs.redirects = docs.redirects.map(r => {
-            if (r.destination.startsWith(`/${cur}/`) && !r.source.startsWith(`/${cur}/`)) {
+            if (r.destination.startsWith(`/${cur}/`) && !versionedSource.test(r.source)) {
               n++;
               return { ...r, destination: r.destination.replace(`/${cur}/`, `/${nv}/`) };
             }

--- a/.github/workflows/bump-latest-version.yml
+++ b/.github/workflows/bump-latest-version.yml
@@ -1,0 +1,61 @@
+name: Bump /latest redirects
+
+on:
+  workflow_dispatch:
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect latest version from directory listing
+        run: |
+          # Find all vX.Y.x dirs (excludes -SNAPSHOT), pick the highest by version sort
+          VERSION=$(ls -d v*.x 2>/dev/null | grep -v SNAPSHOT | sort -V | tail -1)
+          if [ -z "$VERSION" ]; then
+            echo "No versioned directories found." && exit 1
+          fi
+          echo "Detected latest version: $VERSION"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Update docs.json redirects
+        run: |
+          node - <<'EOF'
+          const fs = require('fs');
+          const nv = process.env.VERSION;
+          const docs = JSON.parse(fs.readFileSync('docs.json', 'utf8'));
+          const cur = docs.redirects
+            .find(r => r.source === '/latest/:slug*')
+            .destination.match(/\/(v[\d.x]+)\//)[1];
+          if (cur === nv) { console.log(`Already pointing to ${nv} — nothing to do.`); process.exit(0); }
+          let n = 0;
+          docs.redirects = docs.redirects.map(r => {
+            if (r.destination.startsWith(`/${cur}/`) && !r.source.startsWith(`/${cur}/`)) {
+              n++;
+              return { ...r, destination: r.destination.replace(`/${cur}/`, `/${nv}/`) };
+            }
+            return r;
+          });
+          fs.writeFileSync('docs.json', JSON.stringify(docs, null, 2) + '\n');
+          console.log(`Updated ${n} redirects: ${cur} → ${nv}`);
+          EOF
+        env:
+          VERSION: ${{ env.VERSION }}
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: "bump-latest-${{ env.VERSION }}"
+          base: main
+          commit-message: "Docs: Bump /latest redirects to ${{ env.VERSION }}"
+          title: "Docs: Bump /latest redirects to ${{ env.VERSION }}"
+          body: |
+            Automated: bumps all unversioned redirects in `docs.json` to point to `${{ env.VERSION }}`.
+
+            Version-internal redirects (e.g. old-version/… → old-version/…) are left untouched.

--- a/docs.json
+++ b/docs.json
@@ -6930,19 +6930,19 @@
   "redirects": [
     {
       "source": "/v1.9.x/:slug*",
-      "destination": "/v1.12.x/:slug*"
+      "destination": "/v1.13.x/:slug*"
     },
     {
       "source": "/v1.3.x/:slug*",
-      "destination": "/v1.12.x/:slug*"
+      "destination": "/v1.13.x/:slug*"
     },
     {
       "source": "/latest/:slug*",
-      "destination": "/v1.12.x/:slug*"
+      "destination": "/v1.13.x/:slug*"
     },
     {
       "source": "/connectors/troubleshoot",
-      "destination": "/v1.12.x/connectors"
+      "destination": "/v1.13.x/connectors"
     },
     {
       "source": "/v1.12.x/connectors/troubleshoot",
@@ -6954,27 +6954,27 @@
     },
     {
       "source": "/connectors/:slug*",
-      "destination": "/v1.12.x/connectors/:slug*"
+      "destination": "/v1.13.x/connectors/:slug*"
     },
     {
       "source": "/deployment/:slug*",
-      "destination": "/v1.12.x/deployment/:slug*"
+      "destination": "/v1.13.x/deployment/:slug*"
     },
     {
       "source": "/developers/:slug*",
-      "destination": "/v1.12.x/developers/:slug*"
+      "destination": "/v1.13.x/developers/:slug*"
     },
     {
       "source": "/features/:slug*",
-      "destination": "/v1.12.x/features/:slug*"
+      "destination": "/v1.13.x/features/:slug*"
     },
     {
       "source": "/how-to-guides/:slug*",
-      "destination": "/v1.12.x/how-to-guides/:slug*"
+      "destination": "/v1.13.x/how-to-guides/:slug*"
     },
     {
       "source": "/quick-start/:slug*",
-      "destination": "/v1.12.x/quick-start/:slug*"
+      "destination": "/v1.13.x/quick-start/:slug*"
     },
     {
       "source": "/releases/:slug*",
@@ -6991,7 +6991,7 @@
     },
     {
       "source": "/api-reference/:slug*",
-      "destination": "/v1.12.x/api-reference/:slug*"
+      "destination": "/v1.13.x/api-reference/:slug*"
     },
     {
       "source": "/main-concepts/*",
@@ -7057,7 +7057,6 @@
       "source": "/v1.12.x/main-concepts/metadata-standard/apis",
       "destination": "/v1.12.x/api-reference/main-concepts/metadata-standard/apis"
     },
-    
     {
       "source": "/v1.12.x/connectors/ingestion/workflows/dbt",
       "destination": "/v1.12.x/connectors/database/dbt"
@@ -7114,7 +7113,6 @@
       "source": "/v1.12.x/connectors/ingestion/workflows/dbt/dbt-troubleshooting",
       "destination": "/v1.12.x/connectors/database/dbt/dbt-troubleshooting"
     },
-    
     {
       "source": "/v1.13.x/connectors/ingestion/workflows/dbt",
       "destination": "/v1.13.x/connectors/database/dbt"
@@ -7191,7 +7189,7 @@
     },
     {
       "source": "/latest/connectors/database/iceberg",
-      "destination": "/v1.12.x/connectors/database/deltalake"
+      "destination": "/v1.13.x/connectors/database/deltalake"
     },
     {
       "source": "/v1.12.x/connectors/database/iceberg",

--- a/docs.json
+++ b/docs.json
@@ -6930,11 +6930,11 @@
   "redirects": [
     {
       "source": "/v1.9.x/:slug*",
-      "destination": "/v1.13.x/:slug*"
+      "destination": "/v1.12.x/:slug*"
     },
     {
       "source": "/v1.3.x/:slug*",
-      "destination": "/v1.13.x/:slug*"
+      "destination": "/v1.12.x/:slug*"
     },
     {
       "source": "/latest/:slug*",


### PR DESCRIPTION
**Problem**
Every time a new OpenMetadata version is released, the unversioned redirects in docs.json (e.g. `/latest/*`, `/connectors/*`, `/deployment/*`) had to be manually updated to point to the new version. This was ~13 entries that needed changing by hand.

**Solution**
Adds a GitHub Actions workflow (`.github/workflows/bump-latest-version.yml`) that automates this update as part of the release process.

**How it works:**
After the SNAPSHOT directory is renamed to the final version (e.g. v2.0.x-SNAPSHOT → v2.0.x) and merged to main, we need to run the workflow from the Actions tab — no inputs needed. It:

- Scans the repo for v*.x directories (ignoring -SNAPSHOT), picks the highest by version sort
- Detects the current /latest target from the existing redirect in docs.json
- Updates all unversioned redirects to point to the new version, leaving version-internal redirects (e.g. /v1.13.x/connectors/troubleshoot → /v1.13.x/connectors) untouched
- Opens a PR with the changes for review before they go live 
- Also updates docs.json to point the current unversioned redirects from v1.12.x → v1.13.x, which was missed in the v1.13.x release.