### PR TITLE
Docs: Document all Event Type filter values for system governance notifications

### DIFF
--- a/v1.12.x/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
+++ b/v1.12.x/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
@@ -114,8 +114,37 @@ Stay informed about metadata changes, governance events, and collaboration activ
 
     * **Owner:** Filter events based on the designated owner of the asset.
     * **Entity FQN:** Filter by the Fully Qualified Name of the entity.
-    * **Event Type:** Filter by the specific action that occurred (for example, Created, Updated, Deleted).
     * **Updater Name:** Filter based on the user or service that executed the change.
+    * **Event Type:** Filter by the specific action that occurred. For more details about the various event types, see the table below.
+
+    | Event Type | What it means |
+    |---|---|
+    | `Entity Created` | A new asset is created. |
+    | `Entity Updated` | A create/update request changes at least one field on the asset. |
+    | `Entity Fields Changed` | A metadata field changed outside a direct edit. For example, weekly or daily usage statistics were recalculated. |
+    | `Entity No Change` | A create/update request was processed but produced no actual difference from the asset's current state—for example, a re-ingestion run that found identical metadata. These no-change events are not recorded in the change log that alerts evaluate, so an alert filtered to this event type will never trigger. |
+    | `Entity Soft Deleted` | An asset is moved to the deleted (recoverable) state. |
+    | `Entity Deleted` | An asset is permanently removed. |
+    | `Entity Restored` | A soft-deleted asset is brought back. |
+    | `Thread Created` | A new conversation thread is started on an asset. |
+    | `Thread Updated` | An existing conversation thread is edited. |
+    | `Post Created` | A reply is added to a thread. |
+    | `Post Updated` | An existing reply is edited. |
+    | `Task Created` | A task thread is opened. See the task types listed under the Task source above. |
+    | `Task Updated` | A task's details are edited. |
+    | `Task Resolved` | A task is marked resolved. |
+    | `Task Closed` | A task is closed without resolution. |
+    | `Logical Test Case Added` | A test case is added to a logical test suite. |
+    | `Suggestion Created` | A new suggestion is created for an asset's description or tag. |
+    | `Suggestion Updated` | An existing suggestion is edited. |
+    | `Suggestion Accepted` | A suggestion is accepted and applied to the asset. |
+    | `Suggestion Rejected` | A suggestion is rejected. |
+    | `Suggestion Deleted` | A suggestion is deleted. |
+    | `User Login` | A login to OpenMetadata occurs. |
+    | `User Logout` | A logout from OpenMetadata occurs. |
+    | `Entity Lineage Added` | A lineage edge is added to or from the asset. |
+    | `Entity Lineage Deleted` | A lineage edge is removed. |
+    | `Entity Lineage Updated` | An existing lineage edge is changed—for example, column-level lineage details. |
     * **Domain:** Filter events based on the Data Domain the entity belongs to.
     * **Filter By Updater Is Bot:** Filter to include or exclude changes made by automated ingestion or system processes.
 

--- a/v1.12.x/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
+++ b/v1.12.x/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
@@ -115,6 +115,8 @@ Stay informed about metadata changes, governance events, and collaboration activ
     * **Owner:** Filter events based on the designated owner of the asset.
     * **Entity FQN:** Filter by the Fully Qualified Name of the entity.
     * **Updater Name:** Filter based on the user or service that executed the change.
+    * **Domain:** Filter events based on the Data Domain the entity belongs to.
+    * **Filter By Updater Is Bot:** Filter to include or exclude changes made by automated ingestion or system processes.
     * **Event Type:** Filter by the specific action that occurred. For more details about the various event types, see the table below.
 
     | Event Type | What it means |
@@ -145,8 +147,6 @@ Stay informed about metadata changes, governance events, and collaboration activ
     | `Entity Lineage Added` | A lineage edge is added to or from the asset. |
     | `Entity Lineage Deleted` | A lineage edge is removed. |
     | `Entity Lineage Updated` | An existing lineage edge is changed—for example, column-level lineage details. |
-    * **Domain:** Filter events based on the Data Domain the entity belongs to.
-    * **Filter By Updater Is Bot:** Filter to include or exclude changes made by automated ingestion or system processes.
 
     Use the **Include** toggle to define the logic for the filter condition:
     * **Include (Toggle ON)**: If the event meets the filter condition, the alert is **sent**.

--- a/v1.12.x/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
+++ b/v1.12.x/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
@@ -132,8 +132,6 @@ Stay informed about metadata changes, governance events, and collaboration activ
     | `Thread Updated` | An existing conversation thread is edited. |
     | `Post Created` | A reply is added to a thread. |
     | `Post Updated` | An existing reply is edited. |
-    | `Task Created` | A task thread is opened. See the task types listed under the Task source above. |
-    | `Task Updated` | A task's details are edited. |
     | `Task Resolved` | A task is marked resolved. |
     | `Task Closed` | A task is closed without resolution. |
     | `Logical Test Case Added` | A test case is added to a logical test suite. |
@@ -144,9 +142,6 @@ Stay informed about metadata changes, governance events, and collaboration activ
     | `Suggestion Deleted` | A suggestion is deleted. |
     | `User Login` | A login to OpenMetadata occurs. |
     | `User Logout` | A logout from OpenMetadata occurs. |
-    | `Entity Lineage Added` | A lineage edge is added to or from the asset. |
-    | `Entity Lineage Deleted` | A lineage edge is removed. |
-    | `Entity Lineage Updated` | An existing lineage edge is changed—for example, column-level lineage details. |
 
     Use the **Include** toggle to define the logic for the filter condition:
     * **Include (Toggle ON)**: If the event meets the filter condition, the alert is **sent**.

--- a/v1.13.x/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
+++ b/v1.13.x/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
@@ -114,6 +114,8 @@ Stay informed about metadata changes, governance events, and collaboration activ
     * **Owner:** Filter events based on the designated owner of the asset.
     * **Entity FQN:** Filter by the Fully Qualified Name of the entity.
     * **Updater Name:** Filter based on the user or service that executed the change.
+    * **Domain:** Filter events based on the Data Domain the entity belongs to.
+    * **Filter By Updater Is Bot:** Filter to include or exclude changes made by automated ingestion or system processes.
     * **Event Type:** Filter by the specific action that occurred. For more details about the various event types, see the table below.
 
     | Event Type | What it means |
@@ -144,8 +146,6 @@ Stay informed about metadata changes, governance events, and collaboration activ
     | `Entity Lineage Added` | A lineage edge is added to or from the asset. |
     | `Entity Lineage Deleted` | A lineage edge is removed. |
     | `Entity Lineage Updated` | An existing lineage edge is changed—for example, column-level lineage details. |
-    * **Domain:** Filter events based on the Data Domain the entity belongs to.
-    * **Filter By Updater Is Bot:** Filter to include or exclude changes made by automated ingestion or system processes.
 
     Use the **Include** toggle to define the logic for the filter condition:
     * **Include (Toggle ON)**: If the event meets the filter condition, the alert is **sent**.

--- a/v1.13.x/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
+++ b/v1.13.x/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
@@ -131,8 +131,6 @@ Stay informed about metadata changes, governance events, and collaboration activ
     | `Thread Updated` | An existing conversation thread is edited. |
     | `Post Created` | A reply is added to a thread. |
     | `Post Updated` | An existing reply is edited. |
-    | `Task Created` | A task thread is opened. See the task types listed under the Task source above. |
-    | `Task Updated` | A task's details are edited. |
     | `Task Resolved` | A task is marked resolved. |
     | `Task Closed` | A task is closed without resolution. |
     | `Logical Test Case Added` | A test case is added to a logical test suite. |
@@ -143,9 +141,6 @@ Stay informed about metadata changes, governance events, and collaboration activ
     | `Suggestion Deleted` | A suggestion is deleted. |
     | `User Login` | A login to OpenMetadata occurs. |
     | `User Logout` | A logout from OpenMetadata occurs. |
-    | `Entity Lineage Added` | A lineage edge is added to or from the asset. |
-    | `Entity Lineage Deleted` | A lineage edge is removed. |
-    | `Entity Lineage Updated` | An existing lineage edge is changed—for example, column-level lineage details. |
 
     Use the **Include** toggle to define the logic for the filter condition:
     * **Include (Toggle ON)**: If the event meets the filter condition, the alert is **sent**.

--- a/v1.13.x/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
+++ b/v1.13.x/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
@@ -113,8 +113,37 @@ Stay informed about metadata changes, governance events, and collaboration activ
 
     * **Owner:** Filter events based on the designated owner of the asset.
     * **Entity FQN:** Filter by the Fully Qualified Name of the entity.
-    * **Event Type:** Filter by the specific action that occurred (for example, Created, Updated, Deleted).
     * **Updater Name:** Filter based on the user or service that executed the change.
+    * **Event Type:** Filter by the specific action that occurred. For more details about the various event types, see the table below.
+
+    | Event Type | What it means |
+    |---|---|
+    | `Entity Created` | A new asset is created. |
+    | `Entity Updated` | A create/update request changes at least one field on the asset. |
+    | `Entity Fields Changed` | A metadata field changed outside a direct edit. For example, weekly or daily usage statistics were recalculated. |
+    | `Entity No Change` | A create/update request was processed but produced no actual difference from the asset's current state—for example, a re-ingestion run that found identical metadata. These no-change events are not recorded in the change log that alerts evaluate, so an alert filtered to this event type will never trigger. |
+    | `Entity Soft Deleted` | An asset is moved to the deleted (recoverable) state. |
+    | `Entity Deleted` | An asset is permanently removed. |
+    | `Entity Restored` | A soft-deleted asset is brought back. |
+    | `Thread Created` | A new conversation thread is started on an asset. |
+    | `Thread Updated` | An existing conversation thread is edited. |
+    | `Post Created` | A reply is added to a thread. |
+    | `Post Updated` | An existing reply is edited. |
+    | `Task Created` | A task thread is opened. See the task types listed under the Task source above. |
+    | `Task Updated` | A task's details are edited. |
+    | `Task Resolved` | A task is marked resolved. |
+    | `Task Closed` | A task is closed without resolution. |
+    | `Logical Test Case Added` | A test case is added to a logical test suite. |
+    | `Suggestion Created` | A new suggestion is created for an asset's description or tag. |
+    | `Suggestion Updated` | An existing suggestion is edited. |
+    | `Suggestion Accepted` | A suggestion is accepted and applied to the asset. |
+    | `Suggestion Rejected` | A suggestion is rejected. |
+    | `Suggestion Deleted` | A suggestion is deleted. |
+    | `User Login` | A login to OpenMetadata occurs. |
+    | `User Logout` | A logout from OpenMetadata occurs. |
+    | `Entity Lineage Added` | A lineage edge is added to or from the asset. |
+    | `Entity Lineage Deleted` | A lineage edge is removed. |
+    | `Entity Lineage Updated` | An existing lineage edge is changed—for example, column-level lineage details. |
     * **Domain:** Filter events based on the Data Domain the entity belongs to.
     * **Filter By Updater Is Bot:** Filter to include or exclude changes made by automated ingestion or system processes.
 

--- a/v2.0.x-SNAPSHOT/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
@@ -114,8 +114,37 @@ Stay informed about metadata changes, governance events, and collaboration activ
 
     * **Owner:** Filter events based on the designated owner of the asset.
     * **Entity FQN:** Filter by the Fully Qualified Name of the entity.
-    * **Event Type:** Filter by the specific action that occurred (for example, Created, Updated, Deleted).
     * **Updater Name:** Filter based on the user or service that executed the change.
+    * **Event Type:** Filter by the specific action that occurred. For more details about the various event types, see the table below.
+
+    | Event Type | What it means |
+    |---|---|
+    | `Entity Created` | A new asset is created. |
+    | `Entity Updated` | A create/update request changes at least one field on the asset. |
+    | `Entity Fields Changed` | A metadata field changed outside a direct edit. For example, weekly or daily usage statistics were recalculated. |
+    | `Entity No Change` | A create/update request was processed but produced no actual difference from the asset's current state—for example, a re-ingestion run that found identical metadata. These no-change events are not recorded in the change log that alerts evaluate, so an alert filtered to this event type will never trigger. |
+    | `Entity Soft Deleted` | An asset is moved to the deleted (recoverable) state. |
+    | `Entity Deleted` | An asset is permanently removed. |
+    | `Entity Restored` | A soft-deleted asset is brought back. |
+    | `Thread Created` | A new conversation thread is started on an asset. |
+    | `Thread Updated` | An existing conversation thread is edited. |
+    | `Post Created` | A reply is added to a thread. |
+    | `Post Updated` | An existing reply is edited. |
+    | `Task Created` | A task thread is opened. See the task types listed under the Task source above. |
+    | `Task Updated` | A task's details are edited. |
+    | `Task Resolved` | A task is marked resolved. |
+    | `Task Closed` | A task is closed without resolution. |
+    | `Logical Test Case Added` | A test case is added to a logical test suite. |
+    | `Suggestion Created` | A new suggestion is created for an asset's description or tag. |
+    | `Suggestion Updated` | An existing suggestion is edited. |
+    | `Suggestion Accepted` | A suggestion is accepted and applied to the asset. |
+    | `Suggestion Rejected` | A suggestion is rejected. |
+    | `Suggestion Deleted` | A suggestion is deleted. |
+    | `User Login` | A login to OpenMetadata occurs. |
+    | `User Logout` | A logout from OpenMetadata occurs. |
+    | `Entity Lineage Added` | A lineage edge is added to or from the asset. |
+    | `Entity Lineage Deleted` | A lineage edge is removed. |
+    | `Entity Lineage Updated` | An existing lineage edge is changed—for example, column-level lineage details. |
     * **Domain:** Filter events based on the Data Domain the entity belongs to.
     * **Filter By Updater Is Bot:** Filter to include or exclude changes made by automated ingestion or system processes.
 

--- a/v2.0.x-SNAPSHOT/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/data-quality-observability/alerts-notifications/system-governance-notifications.mdx
@@ -115,6 +115,8 @@ Stay informed about metadata changes, governance events, and collaboration activ
     * **Owner:** Filter events based on the designated owner of the asset.
     * **Entity FQN:** Filter by the Fully Qualified Name of the entity.
     * **Updater Name:** Filter based on the user or service that executed the change.
+    * **Domain:** Filter events based on the Data Domain the entity belongs to.
+    * **Filter By Updater Is Bot:** Filter to include or exclude changes made by automated ingestion or system processes.
     * **Event Type:** Filter by the specific action that occurred. For more details about the various event types, see the table below.
 
     | Event Type | What it means |
@@ -145,8 +147,6 @@ Stay informed about metadata changes, governance events, and collaboration activ
     | `Entity Lineage Added` | A lineage edge is added to or from the asset. |
     | `Entity Lineage Deleted` | A lineage edge is removed. |
     | `Entity Lineage Updated` | An existing lineage edge is changed—for example, column-level lineage details. |
-    * **Domain:** Filter events based on the Data Domain the entity belongs to.
-    * **Filter By Updater Is Bot:** Filter to include or exclude changes made by automated ingestion or system processes.
 
     Use the **Include** toggle to define the logic for the filter condition:
     * **Include (Toggle ON)**: If the event meets the filter condition, the alert is **sent**.


### PR DESCRIPTION
## Summary

The **Event Type** filter in the system governance notifications alert setup was documented with just a one-liner. This PR replaces it with a full reference table listing all 26 event types, with a plain-language description for each, verified against `openmetadata-spec/src/main/resources/json/schema/type/changeEventType.json`.
<img width="2978" height="1660" alt="image" src="https://github.com/user-attachments/assets/a54e58d6-8047-4c3a-a1d9-39e16f78de21" />


Applies to: v1.12.x, v1.13.x, v2.0.x-SNAPSHOT

## Test plan
- [ ] Verify the Event Type table renders correctly in all three versions
- [ ] Verify Event Type appears last in the filter list after Filter By Updater Is Bot
