### PR TITLE
Docs: Update Elasticsearch/OpenSearch version requirements for v1.13.x and v2.0.x-SNAPSHOT

### DIFF
--- a/v1.13.x/deployment/bare-metal.mdx
+++ b/v1.13.x/deployment/bare-metal.mdx
@@ -53,14 +53,14 @@ You can refer a sample script [here](https://github.com/open-metadata/OpenMetada
 </Tip>
 
 
-## Elasticsearch (version 8.X)
+## Elasticsearch / OpenSearch
 
-OpenMetadata supports ElasticSearch version up to 8.11.4. To install or upgrade Elasticsearch to a supported version please see the instructions for your operating system at
+OpenMetadata supports ElasticSearch version 9.x (minimum 9.0.0, recommended 9.3.0) and OpenSearch version 3.x (minimum 3.0.0, recommended 3.3.0). The 9.x Elasticsearch client is not compatible with 8.x or older servers. To install or upgrade Elasticsearch to a supported version please see the instructions for your operating system at
 [Installing ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html).
 
-Please follow the instructions here to [install ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/setup.html).
+Please follow the instructions here to [install ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html).
 
-If you are using AWS OpenSearch Service, OpenMetadata Supports AWS OpenSearch Service engine version up to 2.19. For more information on AWS OpenSearch Service, please visit the official docs [here](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html).
+If you are using AWS OpenSearch Service, OpenMetadata supports AWS OpenSearch Service engine version 3.x (minimum 3.0.0, recommended 3.3.0). Note that AWS OpenSearch Service currently supports up to OpenSearch 3.3. For more information on AWS OpenSearch Service, please visit the official docs [here](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html).
 
 ## Airflow or other workflow schedulers
 
@@ -173,7 +173,7 @@ If you are running OpenMetadata in AWS, it is recommended to use [Amazon RDS](ht
 We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
-- Amazon OpenSearch (ElasticSearch) engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
+- Amazon OpenSearch (ElasticSearch) engine version 9.x (minimum 9.0.0, recommended 9.3.0) or Amazon OpenSearch engine version 3.x (minimum 3.0.0, recommended 3.3.0)
 - Amazon RDS (PostgreSQL) engine version 15 or higher
 
 For Production Systems, we recommend Amazon RDS to be in Multiple Availability Zones. For Amazon OpenSearch (or ElasticSearch) Service, we recommend Multiple Availability Zones with minimum 3 Master Nodes.

--- a/v1.13.x/deployment/docker/advanced.mdx
+++ b/v1.13.x/deployment/docker/advanced.mdx
@@ -56,7 +56,7 @@ If you are running OpenMetadata in AWS, it is recommended to use [Amazon RDS](ht
 We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
-- Amazon OpenSearch (ElasticSearch) engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
+- Amazon OpenSearch (ElasticSearch) engine version 9.x (minimum 9.0.0, recommended 9.3.0) or Amazon OpenSearch engine version 3.x (minimum 3.0.0, recommended 3.3.0)
 - Amazon RDS (PostgreSQL) engine version 15 or higher
 
 Note:-

--- a/v1.13.x/deployment/kubernetes/eks.mdx
+++ b/v1.13.x/deployment/kubernetes/eks.mdx
@@ -27,7 +27,7 @@ We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
 - Amazon RDS (PostgreSQL) engine version 15 or higher
-- Amazon OpenSearch engine version 2.X (upto 2.19)
+- Amazon OpenSearch engine version 3.x (minimum 3.0.0, recommended 3.3.0)
 
 <Tip>
 When using AWS Services the SearchType Configuration for elastic search should be `opensearch`, for both cases ElasticSearch and OpenSearch, as you can see in the ElasticSearch configuration example below.

--- a/v1.13.x/deployment/kubernetes/gke.mdx
+++ b/v1.13.x/deployment/kubernetes/gke.mdx
@@ -34,7 +34,7 @@ It is recommended to use GCP [Cloud SQL](https://cloud.google.com/sql/) services
 We support -
 - Cloud SQL (MySQL) engine version 8 or higher
 - Cloud SQL (postgreSQL) engine version 15 or higher
-- ElasticSearch Engine version 8.X (upto 8.10.X)
+- ElasticSearch version 9.x (minimum 9.0.0, recommended 9.3.0)
 
 We recommend -
 - CloudSQL to be Multi Zone Available

--- a/v1.13.x/deployment/kubernetes/on-prem.mdx
+++ b/v1.13.x/deployment/kubernetes/on-prem.mdx
@@ -24,7 +24,7 @@ We support
 
 - MySQL engine version 8 or higher
 - PostgreSQL engine version 15 or higher
-- ElasticSearch version 8.X (upto 8.11.4) or OpenSearch Version 2.X (upto 2.19)
+- ElasticSearch version 9.x (minimum 9.0.0, recommended 9.3.0) or OpenSearch version 3.x (minimum 3.0.0, recommended 3.3.0)
 
 Once you have the External Database and Search Engine configured, you can update the environment variables below for OpenMetadata kubernetes deployments to connect with Database and ElasticSearch.
 

--- a/v1.13.x/deployment/minimum-requirements.mdx
+++ b/v1.13.x/deployment/minimum-requirements.mdx
@@ -47,8 +47,8 @@ Our minimum specs recommendation for ElasticSearch / OpenSearch deployment is
 
 OpenMetadata currently supports -
 
-- ElasticSearch version 8.X till 8.11.4
-- OpenSearch version 2.19
+- ElasticSearch version 9.x (minimum 9.0.0, recommended 9.3.0)
+- OpenSearch version 3.x (minimum 3.0.0, recommended 3.3.0)
 
 These settings apply as well when using managed instances, such as AWS OpenSearch Service or Elastic Cloud on GCP, AWS, Azure.
 

--- a/v2.0.x-SNAPSHOT/deployment/bare-metal.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/bare-metal.mdx
@@ -53,14 +53,14 @@ You can refer a sample script [here](https://github.com/open-metadata/OpenMetada
 </Tip>
 
 
-## Elasticsearch (version 8.X)
+## Elasticsearch / OpenSearch
 
-OpenMetadata supports ElasticSearch version up to 8.11.4. To install or upgrade Elasticsearch to a supported version please see the instructions for your operating system at
+OpenMetadata supports ElasticSearch version 9.x (minimum 9.0.0, recommended 9.3.0) and OpenSearch version 3.x (minimum 3.0.0, recommended 3.3.0). The 9.x Elasticsearch client is not compatible with 8.x or older servers. To install or upgrade Elasticsearch to a supported version please see the instructions for your operating system at
 [Installing ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html).
 
-Please follow the instructions here to [install ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/setup.html).
+Please follow the instructions here to [install ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html).
 
-If you are using AWS OpenSearch Service, OpenMetadata Supports AWS OpenSearch Service engine version up to 2.19. For more information on AWS OpenSearch Service, please visit the official docs [here](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html).
+If you are using AWS OpenSearch Service, OpenMetadata supports AWS OpenSearch Service engine version 3.x (minimum 3.0.0, recommended 3.3.0). Note that AWS OpenSearch Service currently supports up to OpenSearch 3.3. For more information on AWS OpenSearch Service, please visit the official docs [here](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html).
 
 ## Airflow or other workflow schedulers
 
@@ -173,7 +173,7 @@ If you are running OpenMetadata in AWS, it is recommended to use [Amazon RDS](ht
 We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
-- Amazon OpenSearch (ElasticSearch) engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
+- Amazon OpenSearch (ElasticSearch) engine version 9.x (minimum 9.0.0, recommended 9.3.0) or Amazon OpenSearch engine version 3.x (minimum 3.0.0, recommended 3.3.0)
 - Amazon RDS (PostgreSQL) engine version 15 or higher
 
 For Production Systems, we recommend Amazon RDS to be in Multiple Availability Zones. For Amazon OpenSearch (or ElasticSearch) Service, we recommend Multiple Availability Zones with minimum 3 Master Nodes.

--- a/v2.0.x-SNAPSHOT/deployment/docker/advanced.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/docker/advanced.mdx
@@ -56,7 +56,7 @@ If you are running OpenMetadata in AWS, it is recommended to use [Amazon RDS](ht
 We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
-- Amazon OpenSearch (ElasticSearch) engine version up to 8.11.4 or Amazon OpenSearch engine version up to 2.19
+- Amazon OpenSearch (ElasticSearch) engine version 9.x (minimum 9.0.0, recommended 9.3.0) or Amazon OpenSearch engine version 3.x (minimum 3.0.0, recommended 3.3.0)
 - Amazon RDS (PostgreSQL) engine version 15 or higher
 
 Note:-

--- a/v2.0.x-SNAPSHOT/deployment/kubernetes/eks.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/kubernetes/eks.mdx
@@ -27,7 +27,7 @@ We support
 
 - Amazon RDS (MySQL) engine version 8 or higher
 - Amazon RDS (PostgreSQL) engine version 15 or higher
-- Amazon OpenSearch engine version 2.X (upto 2.19)
+- Amazon OpenSearch engine version 3.x (minimum 3.0.0, recommended 3.3.0)
 
 <Tip>
 When using AWS Services the SearchType Configuration for elastic search should be `opensearch`, for both cases ElasticSearch and OpenSearch, as you can see in the ElasticSearch configuration example below.

--- a/v2.0.x-SNAPSHOT/deployment/kubernetes/gke.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/kubernetes/gke.mdx
@@ -34,7 +34,7 @@ It is recommended to use GCP [Cloud SQL](https://cloud.google.com/sql/) services
 We support -
 - Cloud SQL (MySQL) engine version 8 or higher
 - Cloud SQL (postgreSQL) engine version 15 or higher
-- ElasticSearch Engine version 8.X (upto 8.10.X)
+- ElasticSearch version 9.x (minimum 9.0.0, recommended 9.3.0)
 
 We recommend -
 - CloudSQL to be Multi Zone Available

--- a/v2.0.x-SNAPSHOT/deployment/kubernetes/on-prem.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/kubernetes/on-prem.mdx
@@ -24,7 +24,7 @@ We support
 
 - MySQL engine version 8 or higher
 - PostgreSQL engine version 15 or higher
-- ElasticSearch version 8.X (upto 8.11.4) or OpenSearch Version 2.X (upto 2.19)
+- ElasticSearch version 9.x (minimum 9.0.0, recommended 9.3.0) or OpenSearch version 3.x (minimum 3.0.0, recommended 3.3.0)
 
 Once you have the External Database and Search Engine configured, you can update the environment variables below for OpenMetadata kubernetes deployments to connect with Database and ElasticSearch.
 

--- a/v2.0.x-SNAPSHOT/deployment/minimum-requirements.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/minimum-requirements.mdx
@@ -47,8 +47,8 @@ Our minimum specs recommendation for ElasticSearch / OpenSearch deployment is
 
 OpenMetadata currently supports -
 
-- ElasticSearch version 8.X till 8.11.4
-- OpenSearch version 2.19
+- ElasticSearch version 9.x (minimum 9.0.0, recommended 9.3.0)
+- OpenSearch version 3.x (minimum 3.0.0, recommended 3.3.0)
 
 These settings apply as well when using managed instances, such as AWS OpenSearch Service or Elastic Cloud on GCP, AWS, Azure.
 


### PR DESCRIPTION
## Summary

- Brings v1.13.x and v2.0.x-SNAPSHOT deployment docs in line with v1.12.x for Elasticsearch and OpenSearch version requirements
- Elasticsearch: `8.X up to 8.11.4` → `9.x (minimum 9.0.0, recommended 9.3.0)`
- OpenSearch: `2.19` → `3.x (minimum 3.0.0, recommended 3.3.0)`

## Files Updated (×2 versions each)

- `deployment/minimum-requirements.mdx`
- `deployment/bare-metal.mdx` (section heading + 2 version references)
- `deployment/docker/advanced.mdx`
- `deployment/kubernetes/on-prem.mdx`
- `deployment/kubernetes/eks.mdx`
- `deployment/kubernetes/gke.mdx`

> `aks.mdx` was already correct in both versions — no change needed.

## Test plan

- [ ] Verify version strings match v1.12.x across all updated files
- [ ] Confirm no remaining `8.11.4`, `2.19`, or `8.10.X` references in v1.13.x or v2.0.x-SNAPSHOT deployment docs

