### PR TITLE
Docs: Document Trigger permission enforcement and Kill/EditAll requirement for ingestion pipelines

### DIFF
--- a/v1.12.x/how-to-guides/admin-guide/roles-policies/authorization.mdx
+++ b/v1.12.x/how-to-guides/admin-guide/roles-policies/authorization.mdx
@@ -159,6 +159,12 @@ A role bundles multiple policies that match a specific job function. For example
 | Overlooking Bot and MCP resources | Automated integrations can access or move data if over-permissioned | Treat bot and MCP permissions with the same care as human user permissions |
 | Leaving out `Ingestion Runner` in pipeline roles | Engineers can create pipelines but can't run them | Always pair `Ingestion Pipeline` (`Create`) with `Ingestion Runner` (`Trigger`) |
 
+<Warning>
+**Important**: This has been enforced since OpenMetadata 1.12.9. Triggering an ingestion pipeline through the API (`POST /v1/services/ingestionPipelines/trigger/{id}`) now requires the `Trigger` operation to be explicitly granted — `EditAll` no longer covers it. The upgrade automatically added `Trigger` to the default bot policies (`Ingestion`, `Lineage`, `Profiler`, `Quality`, `Usage`) and the default Data Steward role.
+
+If you have a custom role or policy that grants `EditAll` on `Ingestion Pipeline` without an explicit `Trigger` grant, add `Trigger` to it after upgrading — otherwise pipeline triggers will start failing silently for anyone assigned that role. Scheduled runs are unaffected. This only applies to manually or programmatically triggered runs.
+</Warning>
+
 ## Roles Based Access Controls (RBAC) Search
 
 By default, every user can search for and find any data asset in OpenMetadata, regardless of whether they have permission to access it. If you want search results to reflect each user's permissions, turn on RBAC search – this ensures users only see assets their role allows them to access.

--- a/v1.13.x/how-to-guides/admin-guide/roles-policies/authorization.mdx
+++ b/v1.13.x/how-to-guides/admin-guide/roles-policies/authorization.mdx
@@ -159,6 +159,12 @@ A role bundles multiple policies that match a specific job function. For example
 | Overlooking Bot and MCP resources | Automated integrations can access or move data if over-permissioned | Treat bot and MCP permissions with the same care as human user permissions |
 | Leaving out `Ingestion Runner` in pipeline roles | Engineers can create pipelines but can't run them | Always pair `Ingestion Pipeline` (`Create`) with `Ingestion Runner` (`Trigger`) |
 
+<Warning>
+**Important**: This has been enforced since OpenMetadata 1.12.9. Triggering an ingestion pipeline through the API (`POST /v1/services/ingestionPipelines/trigger/{id}`) now requires the `Trigger` operation to be explicitly granted — `EditAll` no longer covers it. The upgrade automatically added `Trigger` to the default bot policies (`Ingestion`, `Lineage`, `Profiler`, `Quality`, `Usage`) and the default Data Steward role.
+
+If you have a custom role or policy that grants `EditAll` on `Ingestion Pipeline` without an explicit `Trigger` grant, add `Trigger` to it after upgrading — otherwise pipeline triggers will start failing silently for anyone assigned that role. Scheduled runs are unaffected. This only applies to manually or programmatically triggered runs.
+</Warning>
+
 ## Roles Based Access Controls (RBAC) Search
 
 By default, every user can search for and find any data asset in OpenMetadata, regardless of whether they have permission to access it. If you want search results to reflect each user's permissions, turn on RBAC search – this ensures users only see assets their role allows them to access.

--- a/v1.13.x/how-to-guides/admin-guide/roles-policies/resource-scope.mdx
+++ b/v1.13.x/how-to-guides/admin-guide/roles-policies/resource-scope.mdx
@@ -71,6 +71,10 @@ Operations define what action a user can take on a resource. The table below cov
 | `AuditLogs` | Access the system activity log | High | Admins, compliance officers |
 | `CreateScim` / `EditScim` / `DeleteScim` / `ViewScim` | Manage identity provisioning through Okta or Azure AD | Critical | Admins only |
 
+<Note>
+**`Trigger` for Ingestion Pipelines in v1.13.x**: The `Trigger` operation is not registered in the Ingestion Pipeline resource descriptor in this version. To grant a user permission to trigger ingestion pipelines, assign `Trigger` under **All Resources** in the policy editor — scoping it to "Ingestion Pipeline" alone will have no effect. This limitation is resolved in v2.0.x.
+</Note>
+
 ## Viewing Permissions Hierarchy
 
 Viewing permissions follow a hierarchy – each level adds more detail than the one below it. Grant only the lowest level the user genuinely needs.

--- a/v2.0.x-SNAPSHOT/how-to-guides/admin-guide/roles-policies/authorization.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/admin-guide/roles-policies/authorization.mdx
@@ -159,6 +159,12 @@ A role bundles multiple policies that match a specific job function. For example
 | Overlooking Bot and MCP resources | Automated integrations can access or move data if over-permissioned | Treat bot and MCP permissions with the same care as human user permissions |
 | Leaving out `Ingestion Runner` in pipeline roles | Engineers can create pipelines but can't run them | Always pair `Ingestion Pipeline` (`Create`) with `Ingestion Runner` (`Trigger`) |
 
+<Warning>
+**Important**: This has been enforced since OpenMetadata 1.12.9. Triggering an ingestion pipeline through the API (`POST /v1/services/ingestionPipelines/trigger/{id}`) now requires the `Trigger` operation to be explicitly granted — `EditAll` no longer covers it. The upgrade automatically added `Trigger` to the default bot policies (`Ingestion`, `Lineage`, `Profiler`, `Quality`, `Usage`) and the default Data Steward role.
+
+If you have a custom role or policy that grants `EditAll` on `Ingestion Pipeline` without an explicit `Trigger` grant, add `Trigger` to it after upgrading — otherwise pipeline triggers will start failing silently for anyone assigned that role. Scheduled runs are unaffected. This only applies to manually or programmatically triggered runs.
+</Warning>
+
 ## Roles Based Access Controls (RBAC) Search
 
 By default, every user can search for and find any data asset in OpenMetadata, regardless of whether they have permission to access it. If you want search results to reflect each user's permissions, turn on RBAC search – this ensures users only see assets their role allows them to access.

--- a/v2.0.x-SNAPSHOT/how-to-guides/admin-guide/roles-policies/resource-scope.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/admin-guide/roles-policies/resource-scope.mdx
@@ -58,14 +58,15 @@ Operations define what action a user can take on a resource. The table below cov
 | `Create` | Create a new asset | Medium | Data engineers, admins |
 | `BulkCreate` | Create many assets at once | Medium | Data engineers, admins |
 | `Delete` | Permanently delete an asset | Critical | Admins only |
-| `EditAll` | Full edit access – overrides all other edit operations | High | Data engineers, admins |
+| `EditAll` | Full edit access – overrides all other edit operations. Also required to kill/stop ingestion pipelines. | High | Data engineers, admins |
 | `EditDescription` / `EditDisplayName` | Edit descriptions and display names | Low | Data stewards and above |
 | `EditTags` / `EditGlossaryTerms` | Apply labels like PII or Sensitive; assign glossary terms | Medium–High | Data stewards, admins |
 | `EditLineage` / `EditEntityRelationship` | Change lineage and relationships between assets | Medium | Data engineers |
 | `EditOwners` / `EditTeams` / `EditUsers` | Change who owns or manages an asset | High | Admins |
 | `EditPolicy` / `EditRole` | Change access control rules and roles | Critical | Admins only |
 | `CreateTests` / `EditTests` | Create and update data quality tests | Medium | Data engineers |
-| `Deploy` / `Trigger` / `Kill` | Deploy, run, or stop a pipeline or workflow | High | Data engineers, admins |
+| `Deploy` / `Trigger` | Deploy or run a pipeline or workflow | High | Data engineers, admins |
+| `Kill` | Stop a running pipeline. For ingestion pipelines, `EditAll` is required — `Kill` alone is not sufficient. | High | Data engineers with `EditAll`, admins |
 | `GenerateToken` | Create API access tokens | Critical | Admins only |
 | `Impersonate` | Act as another user | Critical | Admins only |
 | `AuditLogs` | Access the system activity log | High | Admins, compliance officers |


### PR DESCRIPTION
## Summary

- Adds a `<Warning>` callout to `authorization.mdx` (all 3 versions) explaining that since OpenMetadata 1.12.9, triggering an ingestion pipeline requires an explicit `Trigger` grant — `EditAll` no longer covers it. Custom roles using `EditAll` without `Trigger` will silently fail on manual/programmatic pipeline triggers. 
<img width="2974" height="1574" alt="image" src="https://github.com/user-attachments/assets/9f91d5de-96a4-4a9a-930b-a47a24619610" />

- Updates `resource-scope.mdx` (v2.0.x-SNAPSHOT): splits `Kill` into its own row noting that `EditAll` is required to stop ingestion pipelines; updates the `EditAll` row description accordingly.
![Uploading image.png…]()

- Adds a `<Note>` to `resource-scope.mdx` (v1.13.x): `Trigger` for ingestion pipelines must be granted under **All Resources** in this version — the resource descriptor fix that enables scoped grants is not present until v2.0.x.

## Source references
- [OpenMetadata PR #28109](https://github.com/open-metadata/OpenMetadata/pull/28109) — introduced Trigger enforcement in 1.12.9
- [OpenMetadata PR #29530](https://github.com/open-metadata/OpenMetadata/pull/29530) — added Trigger to resource descriptor + EditAll for Kill (main/v2.0.x)

## Test plan
- [ ] Verify Warning callout renders correctly after the Common Mistakes table in all 3 versions of authorization.mdx
- [ ] Verify Kill row split and EditAll note render correctly in v2.0.x-SNAPSHOT resource-scope.mdx
- [ ] Verify Note renders correctly in v1.13.x resource-scope.mdx
