### PR TITLE
Docs: Fix Tableau entity mapping — Workbooks map to Dashboard, Views map to Chart

### DIFF
--- a/v1.12.x/connectors/dashboard/tableau.mdx
+++ b/v1.12.x/connectors/dashboard/tableau.mdx
@@ -51,10 +51,10 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 The Tableau connector maps Tableau assets to OpenMetadata entities as follows:
 | Tableau Asset | OpenMetadata Entity | Description |
 |---|---|---|
-| **Dashboard Views** (sheetType="dashboard") | **Dashboard** | Tableau dashboard views are mapped to OpenMetadata Dashboard entities. These are the actual interactive dashboards in Tableau. |
-| **Sheet Views** (worksheets, stories, etc.) | **Chart** | Tableau worksheet views and other sheet types are mapped to OpenMetadata Chart entities. |
-| **Workbooks** | **Project Hierarchy** | Workbook information is preserved in the project field as `{ProjectName}/{WorkbookName}` to maintain the container relationship. |
-| **Data Sources** | **Data Models** | Tableau data sources are mapped to OpenMetadata Data Model entities. |
+| **Workbooks** | **Dashboard** | Tableau workbooks are mapped to OpenMetadata Dashboard entities. |
+| **Views** (worksheets, dashboard views, stories — all sheet types) | **Chart** | All Tableau views are mapped to OpenMetadata Chart entities, regardless of their sheet type. |
+| **Data Sources** (embedded and published) | **Data Models** | Tableau data sources are mapped to OpenMetadata Data Model entities. |
+| **Projects** | **Project field** | The Tableau project name is stored in the project field of the Dashboard. |
 ### Example Structure
 **Tableau Structure:**
 ```
@@ -66,15 +66,16 @@ Project: Sales Team
 ```
 **OpenMetadata Structure:**
 ```
-Dashboard: "Revenue Overview" (Project: "Sales Team/Sales Analysis")
+Dashboard: "Sales Analysis" (Project: "Sales Team")
+├── Chart: "Revenue Overview"
 ├── Chart: "Monthly Sales"
 └── Chart: "Sales Story"
 ```
 This mapping ensures that:
-- Tableau dashboards appear as OpenMetadata dashboards (not charts)
-- Workbook context is preserved in the project hierarchy
-- URLs point directly to the specific dashboard views
-- Chrome Extension compatibility is maintained
+- Tableau workbooks appear as OpenMetadata dashboards
+- All views (worksheets, dashboard views, stories) appear as charts under that dashboard
+- Tableau project names are preserved in the project field
+- URLs point directly to the specific views
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"Tableau"} selectServicePath={"/public/images/connectors/tableau/select-service.png"} addNewServicePath={"/public/images/connectors/tableau/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/tableau/service-connection.png"} />
 # Connection Details

--- a/v1.13.x/connectors/dashboard/tableau.mdx
+++ b/v1.13.x/connectors/dashboard/tableau.mdx
@@ -51,10 +51,10 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 The Tableau connector maps Tableau assets to OpenMetadata entities as follows:
 | Tableau Asset | OpenMetadata Entity | Description |
 |---|---|---|
-| **Dashboard Views** (sheetType="dashboard") | **Dashboard** | Tableau dashboard views are mapped to OpenMetadata Dashboard entities. These are the actual interactive dashboards in Tableau. |
-| **Sheet Views** (worksheets, stories, etc.) | **Chart** | Tableau worksheet views and other sheet types are mapped to OpenMetadata Chart entities. |
-| **Workbooks** | **Project Hierarchy** | Workbook information is preserved in the project field as `{ProjectName}/{WorkbookName}` to maintain the container relationship. |
-| **Data Sources** | **Data Models** | Tableau data sources are mapped to OpenMetadata Data Model entities. |
+| **Workbooks** | **Dashboard** | Tableau workbooks are mapped to OpenMetadata Dashboard entities. |
+| **Views** (worksheets, dashboard views, stories — all sheet types) | **Chart** | All Tableau views are mapped to OpenMetadata Chart entities, regardless of their sheet type. |
+| **Data Sources** (embedded and published) | **Data Models** | Tableau data sources are mapped to OpenMetadata Data Model entities. |
+| **Projects** | **Project field** | The Tableau project name is stored in the project field of the Dashboard. |
 ### Example Structure
 **Tableau Structure:**
 ```
@@ -66,15 +66,16 @@ Project: Sales Team
 ```
 **OpenMetadata Structure:**
 ```
-Dashboard: "Revenue Overview" (Project: "Sales Team/Sales Analysis")
+Dashboard: "Sales Analysis" (Project: "Sales Team")
+├── Chart: "Revenue Overview"
 ├── Chart: "Monthly Sales"
 └── Chart: "Sales Story"
 ```
 This mapping ensures that:
-- Tableau dashboards appear as OpenMetadata dashboards (not charts)
-- Workbook context is preserved in the project hierarchy
-- URLs point directly to the specific dashboard views
-- Chrome Extension compatibility is maintained
+- Tableau workbooks appear as OpenMetadata dashboards
+- All views (worksheets, dashboard views, stories) appear as charts under that dashboard
+- Tableau project names are preserved in the project field
+- URLs point directly to the specific views
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"Tableau"} selectServicePath={"/public/images/connectors/tableau/select-service.png"} addNewServicePath={"/public/images/connectors/tableau/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/tableau/service-connection.png"} />
 # Connection Details

--- a/v2.0.x-SNAPSHOT/connectors/dashboard/tableau.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/dashboard/tableau.mdx
@@ -51,10 +51,10 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 The Tableau connector maps Tableau assets to OpenMetadata entities as follows:
 | Tableau Asset | OpenMetadata Entity | Description |
 |---|---|---|
-| **Dashboard Views** (sheetType="dashboard") | **Dashboard** | Tableau dashboard views are mapped to OpenMetadata Dashboard entities. These are the actual interactive dashboards in Tableau. |
-| **Sheet Views** (worksheets, stories, etc.) | **Chart** | Tableau worksheet views and other sheet types are mapped to OpenMetadata Chart entities. |
-| **Workbooks** | **Project Hierarchy** | Workbook information is preserved in the project field as `{ProjectName}/{WorkbookName}` to maintain the container relationship. |
-| **Data Sources** | **Data Models** | Tableau data sources are mapped to OpenMetadata Data Model entities. |
+| **Workbooks** | **Dashboard** | Tableau workbooks are mapped to OpenMetadata Dashboard entities. |
+| **Views** (worksheets, dashboard views, stories — all sheet types) | **Chart** | All Tableau views are mapped to OpenMetadata Chart entities, regardless of their sheet type. |
+| **Data Sources** (embedded and published) | **Data Models** | Tableau data sources are mapped to OpenMetadata Data Model entities. |
+| **Projects** | **Project field** | The Tableau project name is stored in the project field of the Dashboard. |
 ### Example Structure
 **Tableau Structure:**
 ```
@@ -66,15 +66,16 @@ Project: Sales Team
 ```
 **OpenMetadata Structure:**
 ```
-Dashboard: "Revenue Overview" (Project: "Sales Team/Sales Analysis")
+Dashboard: "Sales Analysis" (Project: "Sales Team")
+├── Chart: "Revenue Overview"
 ├── Chart: "Monthly Sales"
 └── Chart: "Sales Story"
 ```
 This mapping ensures that:
-- Tableau dashboards appear as OpenMetadata dashboards (not charts)
-- Workbook context is preserved in the project hierarchy
-- URLs point directly to the specific dashboard views
-- Chrome Extension compatibility is maintained
+- Tableau workbooks appear as OpenMetadata dashboards
+- All views (worksheets, dashboard views, stories) appear as charts under that dashboard
+- Tableau project names are preserved in the project field
+- URLs point directly to the specific views
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"Tableau"} selectServicePath={"/public/images/connectors/tableau/select-service.png"} addNewServicePath={"/public/images/connectors/tableau/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/tableau/service-connection.png"} />
 # Connection Details


### PR DESCRIPTION
## Summary

- Corrects the Tableau entity mapping table across all three versions (v1.12.x, v1.13.x, v2.0.x-SNAPSHOT)
- Previously documented mapping was wrong: it showed Dashboard Views → Dashboard and Workbooks → Project Hierarchy
- Correct mapping (confirmed from source code `yield_dashboard()` docstring): Workbooks → Dashboard, all Views (worksheets, dashboard views, stories) → Chart, Data Sources → Data Models, Projects → Project field
- Updated the example structure to match the correct hierarchy
<img width="2912" height="1684" alt="image" src="https://github.com/user-attachments/assets/2629d3af-bd7d-4668-92ce-91b6aa74d5a7" />

## Test plan
- [ ] Verify entity mapping table is correct in all three versions of `tableau.mdx`
- [ ] Verify the example structure shows Dashboard: "Sales Analysis" with Charts underneath
