### PR TITLE
Docs: Add Pipeline Observability feature and fix dbt Cloud Lineage/Tags mismatch

### DIFF
--- a/v1.12.x/connectors/pipeline/airflow.mdx
+++ b/v1.12.x/connectors/pipeline/airflow.mdx
@@ -13,7 +13,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 icon='/public/images/connectors/airflow.webp'
 name="Airflow"
 stage="PROD"
-availableFeatures={["Pipelines", "Pipeline Status", "Lineage", "Owners", "Usage"]}
+availableFeatures={["Pipelines", "Pipeline Status", "Pipeline Observability", "Lineage", "Owners", "Usage"]}
 unavailableFeatures={["Tags"]} />
 In this section, we provide guides and references to use the Airflow connector.
 Configure and schedule Airflow metadata workflow from the OpenMetadata UI:

--- a/v1.12.x/connectors/pipeline/airflow/yaml.mdx
+++ b/v1.12.x/connectors/pipeline/airflow/yaml.mdx
@@ -20,7 +20,7 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 icon='/public/images/connectors/airflow.webp'
 name="Airflow"
 stage="PROD"
-availableFeatures={["Pipelines", "Pipeline Status", "Lineage", "Owners"]}
+availableFeatures={["Pipelines", "Pipeline Status", "Pipeline Observability", "Lineage", "Owners"]}
 unavailableFeatures={["Tags"]} />
 In this section, we provide guides and references to use the Airflow connector.
 Configure and schedule Airflow metadata and profiler workflows from the OpenMetadata UI:

--- a/v1.12.x/connectors/pipeline/dbtcloud.mdx
+++ b/v1.12.x/connectors/pipeline/dbtcloud.mdx
@@ -13,7 +13,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 icon='/public/images/connectors/dbtcloud.webp'
 name="dbt Cloud"
 stage="PROD"
-availableFeatures={["Pipelines", "Pipeline Status", "Lineage", "Usage"]}
+availableFeatures={["Pipelines", "Pipeline Status", "Pipeline Observability", "Lineage", "Usage"]}
 unavailableFeatures={["Owners", "Tags"]} />
 In this section, we provide guides and references to use the dbt Cloud connector.
 Configure and schedule dbt Cloud metadata and profiler workflows from the OpenMetadata UI:

--- a/v1.12.x/connectors/pipeline/dbtcloud/yaml.mdx
+++ b/v1.12.x/connectors/pipeline/dbtcloud/yaml.mdx
@@ -20,8 +20,8 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 icon='/public/images/connectors/dbtcloud.webp'
 name="dbt Cloud"
 stage="PROD"
-availableFeatures={["Pipelines", "Pipeline Status", "Tags", "Usage"]}
-unavailableFeatures={["Owners", "Lineage"]} />
+availableFeatures={["Pipelines", "Pipeline Status", "Pipeline Observability", "Lineage", "Usage"]}
+unavailableFeatures={["Owners", "Tags"]} />
 In this section, we provide guides and references to use the dbt Cloud connector.
 Configure and schedule dbt Cloud metadata and profiler workflows from the OpenMetadata UI:
 - [Requirements](#requirements)

--- a/v1.13.x/connectors/pipeline/airflow.mdx
+++ b/v1.13.x/connectors/pipeline/airflow.mdx
@@ -13,7 +13,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 icon='/public/images/connectors/airflow.webp'
 name="Airflow"
 stage="PROD"
-availableFeatures={["Pipelines", "Pipeline Status", "Lineage", "Owners", "Usage"]}
+availableFeatures={["Pipelines", "Pipeline Status", "Pipeline Observability", "Lineage", "Owners", "Usage"]}
 unavailableFeatures={["Tags"]} />
 In this section, we provide guides and references to use the Airflow connector.
 Configure and schedule Airflow metadata workflow from the OpenMetadata UI:

--- a/v1.13.x/connectors/pipeline/airflow/yaml.mdx
+++ b/v1.13.x/connectors/pipeline/airflow/yaml.mdx
@@ -20,7 +20,7 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 icon='/public/images/connectors/airflow.webp'
 name="Airflow"
 stage="PROD"
-availableFeatures={["Pipelines", "Pipeline Status", "Lineage", "Owners"]}
+availableFeatures={["Pipelines", "Pipeline Status", "Pipeline Observability", "Lineage", "Owners"]}
 unavailableFeatures={["Tags"]} />
 In this section, we provide guides and references to use the Airflow connector.
 Configure and schedule Airflow metadata and profiler workflows from the OpenMetadata UI:

--- a/v1.13.x/connectors/pipeline/dbtcloud.mdx
+++ b/v1.13.x/connectors/pipeline/dbtcloud.mdx
@@ -13,7 +13,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 icon='/public/images/connectors/dbtcloud.webp'
 name="dbt Cloud"
 stage="PROD"
-availableFeatures={["Pipelines", "Pipeline Status", "Lineage", "Usage"]}
+availableFeatures={["Pipelines", "Pipeline Status", "Pipeline Observability", "Lineage", "Usage"]}
 unavailableFeatures={["Owners", "Tags"]} />
 In this section, we provide guides and references to use the dbt Cloud connector.
 Configure and schedule dbt Cloud metadata and profiler workflows from the OpenMetadata UI:

--- a/v1.13.x/connectors/pipeline/dbtcloud/yaml.mdx
+++ b/v1.13.x/connectors/pipeline/dbtcloud/yaml.mdx
@@ -20,8 +20,8 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 icon='/public/images/connectors/dbtcloud.webp'
 name="dbt Cloud"
 stage="PROD"
-availableFeatures={["Pipelines", "Pipeline Status", "Tags", "Usage"]}
-unavailableFeatures={["Owners", "Lineage"]} />
+availableFeatures={["Pipelines", "Pipeline Status", "Pipeline Observability", "Lineage", "Usage"]}
+unavailableFeatures={["Owners", "Tags"]} />
 In this section, we provide guides and references to use the dbt Cloud connector.
 Configure and schedule dbt Cloud metadata and profiler workflows from the OpenMetadata UI:
 - [Requirements](#requirements)

--- a/v2.0.x-SNAPSHOT/connectors/pipeline/airflow.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/pipeline/airflow.mdx
@@ -13,7 +13,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 icon='/public/images/connectors/airflow.webp'
 name="Airflow"
 stage="PROD"
-availableFeatures={["Pipelines", "Pipeline Status", "Lineage", "Owners", "Usage"]}
+availableFeatures={["Pipelines", "Pipeline Status", "Pipeline Observability", "Lineage", "Owners", "Usage"]}
 unavailableFeatures={["Tags"]} />
 In this section, we provide guides and references to use the Airflow connector.
 Configure and schedule Airflow metadata workflow from the OpenMetadata UI:

--- a/v2.0.x-SNAPSHOT/connectors/pipeline/airflow/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/pipeline/airflow/yaml.mdx
@@ -20,7 +20,7 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 icon='/public/images/connectors/airflow.webp'
 name="Airflow"
 stage="PROD"
-availableFeatures={["Pipelines", "Pipeline Status", "Lineage", "Owners"]}
+availableFeatures={["Pipelines", "Pipeline Status", "Pipeline Observability", "Lineage", "Owners"]}
 unavailableFeatures={["Tags"]} />
 In this section, we provide guides and references to use the Airflow connector.
 Configure and schedule Airflow metadata and profiler workflows from the OpenMetadata UI:

--- a/v2.0.x-SNAPSHOT/connectors/pipeline/dbtcloud.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/pipeline/dbtcloud.mdx
@@ -13,7 +13,7 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
 icon='/public/images/connectors/dbtcloud.webp'
 name="dbt Cloud"
 stage="PROD"
-availableFeatures={["Pipelines", "Pipeline Status", "Lineage", "Usage"]}
+availableFeatures={["Pipelines", "Pipeline Status", "Pipeline Observability", "Lineage", "Usage"]}
 unavailableFeatures={["Owners", "Tags"]} />
 In this section, we provide guides and references to use the dbt Cloud connector.
 Configure and schedule dbt Cloud metadata and profiler workflows from the OpenMetadata UI:

--- a/v2.0.x-SNAPSHOT/connectors/pipeline/dbtcloud/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/pipeline/dbtcloud/yaml.mdx
@@ -20,8 +20,8 @@ import WorkflowConfig from '/snippets/connectors/yaml/workflow-config.mdx'
 icon='/public/images/connectors/dbtcloud.webp'
 name="dbt Cloud"
 stage="PROD"
-availableFeatures={["Pipelines", "Pipeline Status", "Tags", "Usage"]}
-unavailableFeatures={["Owners", "Lineage"]} />
+availableFeatures={["Pipelines", "Pipeline Status", "Pipeline Observability", "Lineage", "Usage"]}
+unavailableFeatures={["Owners", "Tags"]} />
 In this section, we provide guides and references to use the dbt Cloud connector.
 Configure and schedule dbt Cloud metadata and profiler workflows from the OpenMetadata UI:
 - [Requirements](#requirements)


### PR DESCRIPTION
## Summary
- Add `Pipeline Observability` to the available features list for the Airflow and dbt Cloud connector docs (main page + `yaml.mdx`) across v1.12.x, v1.13.x, and v2.0.x-SNAPSHOT.
- Fix a longstanding bug in dbt Cloud's `yaml.mdx` pages where `Tags` was listed as available and `Lineage` as unavailable — the reverse of what the connector actually supports. Confirmed against the dedicated "Displaying Lineage Information" section (with screenshot) on the main dbt Cloud page, and the absence of any Tags-related content for this connector.
<img width="2994" height="1592" alt="image" src="https://github.com/user-attachments/assets/705995ca-cbcb-4637-b293-2228ce897669" />
<img width="2896" height="1482" alt="image" src="https://github.com/user-attachments/assets/6c600eb3-df8b-40e5-8e71-b0a7a9f0a1fa" />

## Test plan
- [x] Verified `availableFeatures`/`unavailableFeatures` arrays match between each connector's main page and its `yaml.mdx` across all three versions.
- [ ] Visual check in `mint dev` that the feature badges render correctly on the Airflow and dbt Cloud connector pages.

