### PR TITLE
Docs: Document MSSQL Query Store usage/lineage source for v1.13.x and v2.0.x-SNAPSHOT

### DIFF
--- a/v1.13.x/connectors/database/mssql.mdx
+++ b/v1.13.x/connectors/database/mssql.mdx
@@ -52,9 +52,20 @@ GRANT VIEW DEFINITION TO Mary;
 GRANT VIEW ANY DEFINITION TO [login_name];
 ```
 ### Usage & Lineage consideration
-To perform the query analysis for Usage and Lineage computation, we fetch the query logs from `sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` &  `sys.dm_exec_sql_text` system tables. To access these tables your user must have `VIEW SERVER STATE` privilege.
+To perform the query analysis for Usage and Lineage computation, the connector reads query history from SQL Server's [Query Store](https://learn.microsoft.com/en-us/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store) (`sys.query_store_query`, `sys.query_store_query_text`, `sys.query_store_plan` & `sys.query_store_runtime_stats`) when it is enabled on a database. Query Store keeps a durable, on-disk record of executed queries. The plan-cache DMVs (`sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` & `sys.dm_exec_sql_text`) are evicted on server restart, memory pressure, or plan recompilation, and can silently return incomplete history.
+
+Query Store is auto-detected per database. No configuration is needed. When `ingestAllDatabases` is enabled, each database is read from its own best source independently: databases with Query Store use it, and the rest fall back to the plan-cache DMVs, so one database without Query Store never downgrades the others.
+
+**We recommend enabling Query Store** on the databases you ingest, for reliable and durable Usage and Lineage history.
+
+Accessing the plan-cache DMVs requires `VIEW SERVER STATE`:
 ```sql
 GRANT VIEW SERVER STATE TO YourUser;
+```
+Accessing Query Store requires `VIEW DATABASE STATE` (SQL Server 2016-2019 and Azure SQL Database) or `VIEW DATABASE PERFORMANCE STATE` (SQL Server 2022+ and Azure SQL Managed Instance), granted per database:
+```sql
+GRANT VIEW DATABASE STATE TO YourUser;
+-- SQL Server 2022+: GRANT VIEW DATABASE PERFORMANCE STATE TO YourUser;
 ```
 ### For Remote Connection
 #### 1. SQL Server running

--- a/v1.13.x/connectors/database/mssql.mdx
+++ b/v1.13.x/connectors/database/mssql.mdx
@@ -73,17 +73,23 @@ ALTER DATABASE [YourDatabase] SET QUERY_STORE = ON
     CLEANUP_POLICY = ( STALE_QUERY_THRESHOLD_DAYS = 30 )
 );
 ```
-The default `QUERY_CAPTURE_MODE` on SQL Server 2019 and later is `AUTO`, which can skip queries that only run a few times, such as a one-off data migration statement. Setting it to `ALL` ensures every query is captured for lineage. Set `STALE_QUERY_THRESHOLD_DAYS` to cover at least your ingestion lookback window, so queries are not purged before they are read. Query Store's default `SIZE_BASED_CLEANUP_MODE` already purges the oldest queries to stay within `MAX_STORAGE_SIZE_MB` rather than switching to read-only, so no override is needed there.
+The default `QUERY_CAPTURE_MODE` on SQL Server 2019 and later is `AUTO`, which can skip queries that only run a few times, such as a one-off data migration statement. Setting it to `ALL` ensures every query is captured for lineage. Set `STALE_QUERY_THRESHOLD_DAYS` to cover at least your ingestion lookback window, so queries are not purged before they are read. Query Store's default `SIZE_BASED_CLEANUP_MODE` purges the oldest queries to stay within `MAX_STORAGE_SIZE_MB`, which reduces the risk of Query Store switching to read-only. Under heavy write load, cleanup can still fall behind, and Query Store can switch to read-only temporarily until it catches up.
 
-Accessing the plan-cache DMVs requires `VIEW SERVER STATE`:
-```sql
-GRANT VIEW SERVER STATE TO YourUser;
-```
-Accessing Query Store requires `VIEW DATABASE STATE` (SQL Server 2016-2019 and Azure SQL Database) or `VIEW DATABASE PERFORMANCE STATE` (SQL Server 2022+ and Azure SQL Managed Instance), granted per database:
+<Warning>
+Query Store needs two permissions together. The database-level grant below lets `sys.database_query_store_options` and Query Store's other metadata views succeed, but the query text comes from `sys.query_store_query_text`, which needs the server-level grant. Without the server-level grant, usage and lineage queries can run without error while returning no query text.
+</Warning>
+
+Database-level, for Query Store metadata: `VIEW DATABASE STATE` (SQL Server 2016-2019) or `VIEW DATABASE PERFORMANCE STATE` (SQL Server 2022 and later).
 ```sql
 GRANT VIEW DATABASE STATE TO YourUser;
--- SQL Server 2022+: GRANT VIEW DATABASE PERFORMANCE STATE TO YourUser;
+-- SQL Server 2022 and later: GRANT VIEW DATABASE PERFORMANCE STATE TO YourUser;
 ```
+Server-level, for the query text and the plan-cache DMV fallback: `VIEW SERVER STATE` (SQL Server 2019 and earlier) or `VIEW SERVER PERFORMANCE STATE` (SQL Server 2022 and later).
+```sql
+GRANT VIEW SERVER STATE TO YourUser;
+-- SQL Server 2022 and later: GRANT VIEW SERVER PERFORMANCE STATE TO YourUser;
+```
+Exact grant names and tiers can differ on Azure SQL Database and Azure SQL Managed Instance. Check `sys.database_query_store_options` and the [Microsoft documentation](https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-query-store-query-text-transact-sql) for your instance.
 ### For Remote Connection
 #### 1. SQL Server running
 Make sure the SQL server that you are trying to connect is in running state.

--- a/v1.13.x/connectors/database/mssql.mdx
+++ b/v1.13.x/connectors/database/mssql.mdx
@@ -58,6 +58,21 @@ Query Store is auto-detected per database. No configuration is needed. When `ing
 
 **We recommend enabling Query Store** on the databases you ingest, for reliable and durable Usage and Lineage history.
 
+To check whether Query Store is enabled on a database, and how it is currently operating:
+```sql
+SELECT actual_state_desc, query_capture_mode_desc, size_based_cleanup_mode_desc
+FROM sys.database_query_store_options;
+```
+To enable it:
+```sql
+ALTER DATABASE [YourDatabase] SET QUERY_STORE = ON
+(
+    QUERY_CAPTURE_MODE = ALL,
+    CLEANUP_POLICY = ( STALE_QUERY_THRESHOLD_DAYS = 30 )
+);
+```
+The default `QUERY_CAPTURE_MODE` on SQL Server 2019 and later is `AUTO`, which can skip queries that only run a few times, such as a one-off data migration statement. Setting it to `ALL` ensures every query is captured for lineage. Set `STALE_QUERY_THRESHOLD_DAYS` to cover at least your ingestion lookback window, so queries are not purged before they are read. Query Store's default `SIZE_BASED_CLEANUP_MODE` already purges the oldest queries to stay within `MAX_STORAGE_SIZE_MB` rather than switching to read-only, so no override is needed there.
+
 Accessing the plan-cache DMVs requires `VIEW SERVER STATE`:
 ```sql
 GRANT VIEW SERVER STATE TO YourUser;

--- a/v1.13.x/connectors/database/mssql.mdx
+++ b/v1.13.x/connectors/database/mssql.mdx
@@ -52,11 +52,13 @@ GRANT VIEW DEFINITION TO Mary;
 GRANT VIEW ANY DEFINITION TO [login_name];
 ```
 ### Usage & Lineage consideration
-To perform the query analysis for Usage and Lineage computation, the connector reads query history from SQL Server's [Query Store](https://learn.microsoft.com/en-us/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store) (`sys.query_store_query`, `sys.query_store_query_text`, `sys.query_store_plan` & `sys.query_store_runtime_stats`) when it is enabled on a database. Query Store keeps a durable, on-disk record of executed queries. The plan-cache DMVs (`sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` & `sys.dm_exec_sql_text`) are evicted on server restart, memory pressure, or plan recompilation, and can silently return incomplete history.
+To perform the query analysis for Usage and Lineage computation, the connector reads query history from SQL Server's [Query Store](https://learn.microsoft.com/en-us/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store) when it is enabled on a database. Query Store exposes this history through `sys.query_store_query`, `sys.query_store_query_text`, `sys.query_store_plan`, and `sys.query_store_runtime_stats`. Query Store keeps a durable, on-disk record of executed queries. The plan-cache Dynamic Management Views (DMVs) (`sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats`, and `sys.dm_exec_sql_text`) are evicted on server restart, memory pressure, or plan recompilation, and can silently return incomplete history.
 
 Query Store is auto-detected per database. No configuration is needed. When `ingestAllDatabases` is enabled, each database is read from its own best source independently: databases with Query Store use it, and the rest fall back to the plan-cache DMVs, so one database without Query Store never downgrades the others.
 
-**We recommend enabling Query Store** on the databases you ingest, for reliable and durable Usage and Lineage history.
+<Tip>
+**Tip:** Enable Query Store on the databases you ingest, for reliable and durable Usage and Lineage history.
+</Tip>
 
 To check whether Query Store is enabled on a database, and how it is currently operating:
 ```sql

--- a/v1.13.x/connectors/database/mssql/troubleshoot.mdx
+++ b/v1.13.x/connectors/database/mssql/troubleshoot.mdx
@@ -58,3 +58,7 @@ After updating the connection scheme, the connection should succeed. The status 
 ```
 Connection Status: Success
 ```
+
+## Stored Procedure Lineage Across Databases
+
+If the same stored procedure name exists in more than one database or schema, the connector matches each query to its procedure using the database and schema reported by the query source. If the match is still ambiguous, that query is skipped rather than attached to the wrong procedure.

--- a/v1.13.x/connectors/database/mssql/yaml.mdx
+++ b/v1.13.x/connectors/database/mssql/yaml.mdx
@@ -66,6 +66,21 @@ Query Store is auto-detected per database. No configuration is needed. When `ing
 
 **We recommend enabling Query Store** on the databases you ingest, for reliable and durable Usage and Lineage history.
 
+To check whether Query Store is enabled on a database, and how it is currently operating:
+```sql
+SELECT actual_state_desc, query_capture_mode_desc, size_based_cleanup_mode_desc
+FROM sys.database_query_store_options;
+```
+To enable it:
+```sql
+ALTER DATABASE [YourDatabase] SET QUERY_STORE = ON
+(
+    QUERY_CAPTURE_MODE = ALL,
+    CLEANUP_POLICY = ( STALE_QUERY_THRESHOLD_DAYS = 30 )
+);
+```
+The default `QUERY_CAPTURE_MODE` on SQL Server 2019 and later is `AUTO`, which can skip queries that only run a few times, such as a one-off data migration statement. Setting it to `ALL` ensures every query is captured for lineage. Set `STALE_QUERY_THRESHOLD_DAYS` to cover at least your ingestion lookback window, so queries are not purged before they are read. Query Store's default `SIZE_BASED_CLEANUP_MODE` already purges the oldest queries to stay within `MAX_STORAGE_SIZE_MB` rather than switching to read-only, so no override is needed there.
+
 Accessing the plan-cache DMVs requires `VIEW SERVER STATE`:
 ```sql
 GRANT VIEW SERVER STATE TO YourUser;

--- a/v1.13.x/connectors/database/mssql/yaml.mdx
+++ b/v1.13.x/connectors/database/mssql/yaml.mdx
@@ -60,9 +60,20 @@ GRANT VIEW DEFINITION TO Mary;
 GRANT VIEW ANY DEFINITION TO [login_name];
 ```
 ### Usage & Lineage consideration
-To perform the query analysis for Usage and Lineage computation, we fetch the query logs from `sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` &  `sys.dm_exec_sql_text` system tables. To access these tables your user must have `VIEW SERVER STATE` privilege.
+To perform the query analysis for Usage and Lineage computation, the connector reads query history from SQL Server's [Query Store](https://learn.microsoft.com/en-us/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store) (`sys.query_store_query`, `sys.query_store_query_text`, `sys.query_store_plan` & `sys.query_store_runtime_stats`) when it is enabled on a database. Query Store keeps a durable, on-disk record of executed queries. The plan-cache DMVs (`sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` & `sys.dm_exec_sql_text`) are evicted on server restart, memory pressure, or plan recompilation, and can silently return incomplete history.
+
+Query Store is auto-detected per database. No configuration is needed. When `ingestAllDatabases` is enabled, each database is read from its own best source independently: databases with Query Store use it, and the rest fall back to the plan-cache DMVs, so one database without Query Store never downgrades the others.
+
+**We recommend enabling Query Store** on the databases you ingest, for reliable and durable Usage and Lineage history.
+
+Accessing the plan-cache DMVs requires `VIEW SERVER STATE`:
 ```sql
 GRANT VIEW SERVER STATE TO YourUser;
+```
+Accessing Query Store requires `VIEW DATABASE STATE` (SQL Server 2016-2019 and Azure SQL Database) or `VIEW DATABASE PERFORMANCE STATE` (SQL Server 2022+ and Azure SQL Managed Instance), granted per database:
+```sql
+GRANT VIEW DATABASE STATE TO YourUser;
+-- SQL Server 2022+: GRANT VIEW DATABASE PERFORMANCE STATE TO YourUser;
 ```
 ### Python Requirements
 <PythonRequirements />

--- a/v1.13.x/connectors/database/mssql/yaml.mdx
+++ b/v1.13.x/connectors/database/mssql/yaml.mdx
@@ -60,11 +60,13 @@ GRANT VIEW DEFINITION TO Mary;
 GRANT VIEW ANY DEFINITION TO [login_name];
 ```
 ### Usage & Lineage consideration
-To perform the query analysis for Usage and Lineage computation, the connector reads query history from SQL Server's [Query Store](https://learn.microsoft.com/en-us/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store) (`sys.query_store_query`, `sys.query_store_query_text`, `sys.query_store_plan` & `sys.query_store_runtime_stats`) when it is enabled on a database. Query Store keeps a durable, on-disk record of executed queries. The plan-cache DMVs (`sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` & `sys.dm_exec_sql_text`) are evicted on server restart, memory pressure, or plan recompilation, and can silently return incomplete history.
+To perform the query analysis for Usage and Lineage computation, the connector reads query history from SQL Server's [Query Store](https://learn.microsoft.com/en-us/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store) when it is enabled on a database. Query Store exposes this history through `sys.query_store_query`, `sys.query_store_query_text`, `sys.query_store_plan`, and `sys.query_store_runtime_stats`. Query Store keeps a durable, on-disk record of executed queries. The plan-cache Dynamic Management Views (DMVs) (`sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats`, and `sys.dm_exec_sql_text`) are evicted on server restart, memory pressure, or plan recompilation, and can silently return incomplete history.
 
 Query Store is auto-detected per database. No configuration is needed. When `ingestAllDatabases` is enabled, each database is read from its own best source independently: databases with Query Store use it, and the rest fall back to the plan-cache DMVs, so one database without Query Store never downgrades the others.
 
-**We recommend enabling Query Store** on the databases you ingest, for reliable and durable Usage and Lineage history.
+<Tip>
+**Tip:** Enable Query Store on the databases you ingest, for reliable and durable Usage and Lineage history.
+</Tip>
 
 To check whether Query Store is enabled on a database, and how it is currently operating:
 ```sql

--- a/v1.13.x/connectors/database/mssql/yaml.mdx
+++ b/v1.13.x/connectors/database/mssql/yaml.mdx
@@ -81,17 +81,23 @@ ALTER DATABASE [YourDatabase] SET QUERY_STORE = ON
     CLEANUP_POLICY = ( STALE_QUERY_THRESHOLD_DAYS = 30 )
 );
 ```
-The default `QUERY_CAPTURE_MODE` on SQL Server 2019 and later is `AUTO`, which can skip queries that only run a few times, such as a one-off data migration statement. Setting it to `ALL` ensures every query is captured for lineage. Set `STALE_QUERY_THRESHOLD_DAYS` to cover at least your ingestion lookback window, so queries are not purged before they are read. Query Store's default `SIZE_BASED_CLEANUP_MODE` already purges the oldest queries to stay within `MAX_STORAGE_SIZE_MB` rather than switching to read-only, so no override is needed there.
+The default `QUERY_CAPTURE_MODE` on SQL Server 2019 and later is `AUTO`, which can skip queries that only run a few times, such as a one-off data migration statement. Setting it to `ALL` ensures every query is captured for lineage. Set `STALE_QUERY_THRESHOLD_DAYS` to cover at least your ingestion lookback window, so queries are not purged before they are read. Query Store's default `SIZE_BASED_CLEANUP_MODE` purges the oldest queries to stay within `MAX_STORAGE_SIZE_MB`, which reduces the risk of Query Store switching to read-only. Under heavy write load, cleanup can still fall behind, and Query Store can switch to read-only temporarily until it catches up.
 
-Accessing the plan-cache DMVs requires `VIEW SERVER STATE`:
-```sql
-GRANT VIEW SERVER STATE TO YourUser;
-```
-Accessing Query Store requires `VIEW DATABASE STATE` (SQL Server 2016-2019 and Azure SQL Database) or `VIEW DATABASE PERFORMANCE STATE` (SQL Server 2022+ and Azure SQL Managed Instance), granted per database:
+<Warning>
+Query Store needs two permissions together. The database-level grant below lets `sys.database_query_store_options` and Query Store's other metadata views succeed, but the query text comes from `sys.query_store_query_text`, which needs the server-level grant. Without the server-level grant, usage and lineage queries can run without error while returning no query text.
+</Warning>
+
+Database-level, for Query Store metadata: `VIEW DATABASE STATE` (SQL Server 2016-2019) or `VIEW DATABASE PERFORMANCE STATE` (SQL Server 2022 and later).
 ```sql
 GRANT VIEW DATABASE STATE TO YourUser;
--- SQL Server 2022+: GRANT VIEW DATABASE PERFORMANCE STATE TO YourUser;
+-- SQL Server 2022 and later: GRANT VIEW DATABASE PERFORMANCE STATE TO YourUser;
 ```
+Server-level, for the query text and the plan-cache DMV fallback: `VIEW SERVER STATE` (SQL Server 2019 and earlier) or `VIEW SERVER PERFORMANCE STATE` (SQL Server 2022 and later).
+```sql
+GRANT VIEW SERVER STATE TO YourUser;
+-- SQL Server 2022 and later: GRANT VIEW SERVER PERFORMANCE STATE TO YourUser;
+```
+Exact grant names and tiers can differ on Azure SQL Database and Azure SQL Managed Instance. Check `sys.database_query_store_options` and the [Microsoft documentation](https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-query-store-query-text-transact-sql) for your instance.
 ### Python Requirements
 <PythonRequirements />
 To run the MSSQL ingestion, you will need to install:

--- a/v1.13.x/connectors/ingestion/workflows/lineage/filter-query-set.mdx
+++ b/v1.13.x/connectors/ingestion/workflows/lineage/filter-query-set.mdx
@@ -81,7 +81,7 @@ For example if you want to add a condition to filter out queries executed by met
 
 MSSQL reads query history from Query Store when it's enabled on a database, otherwise from the plan-cache DMVs. Your filter condition applies to whichever source is active for that database.
 
-When Query Store is enabled, we execute the following query
+When Query Store is enabled, OpenMetadata executes the following query
 
 ```
 SELECT TOP {result_limit}
@@ -120,7 +120,7 @@ WHERE t.text NOT LIKE '/* {{"app": "OpenMetadata", %%}} */%%'
 ORDER BY t.start_time DESC
 ```
 
-When Query Store is not enabled, we fall back to the following query against the plan-cache DMVs
+When Query Store is not enabled, OpenMetadata falls back to the following query against the plan-cache DMVs
 
 ```
 SELECT TOP {result_limit}

--- a/v1.13.x/connectors/ingestion/workflows/lineage/filter-query-set.mdx
+++ b/v1.13.x/connectors/ingestion/workflows/lineage/filter-query-set.mdx
@@ -79,7 +79,48 @@ For example if you want to add a condition to filter out queries executed by met
 
 ## MSSQL Filter Condition
 
-To fetch the query history log from MSSQL we execute the following query
+MSSQL reads query history from Query Store when it's enabled on a database, otherwise from the plan-cache DMVs. Your filter condition applies to whichever source is active for that database.
+
+When Query Store is enabled, we execute the following query
+
+```
+SELECT TOP {result_limit}
+    t.database_name,
+    t.text query_text,
+    t.start_time,
+    t.end_time,
+    t.duration,
+    NULL schema_name,
+    NULL query_type,
+    NULL user_name,
+    NULL aborted
+FROM (
+  SELECT
+    DB_NAME() AS database_name,
+    qt.query_sql_text AS text,
+    MAX(rs.last_execution_time) AS start_time,
+    DATEADD(s, CAST(AVG(rs.avg_duration) / 1000000 AS INT), MAX(rs.last_execution_time)) AS end_time,
+    AVG(rs.avg_duration) / 1000000.0 AS duration
+  FROM sys.query_store_query AS q
+  INNER JOIN sys.query_store_query_text AS qt
+    ON qt.query_text_id = q.query_text_id
+  INNER JOIN sys.query_store_plan AS p
+    ON p.query_id = q.query_id
+  INNER JOIN sys.query_store_runtime_stats AS rs
+    ON rs.plan_id = p.plan_id
+  WHERE ISNULL(q.object_id, 0) = 0
+    AND rs.last_execution_time BETWEEN '{start_time}' AND '{end_time}'
+  GROUP BY q.query_id, qt.query_sql_text
+) AS t
+WHERE t.text NOT LIKE '/* {{"app": "OpenMetadata", %%}} */%%'
+    AND t.text NOT LIKE '/* {{"app": "dbt", %%}} */%%'
+
+    AND {**your filter condition**}
+
+ORDER BY t.start_time DESC
+```
+
+When Query Store is not enabled, we fall back to the following query against the plan-cache DMVs
 
 ```
 SELECT TOP {result_limit}

--- a/v1.13.x/connectors/ingestion/workflows/usage/filter-query-set.mdx
+++ b/v1.13.x/connectors/ingestion/workflows/usage/filter-query-set.mdx
@@ -82,7 +82,7 @@ For example if you want to add a condition to filter out queries executed by met
 
 MSSQL reads query history from Query Store when it's enabled on a database, otherwise from the plan-cache DMVs. Your filter condition applies to whichever source is active for that database.
 
-When Query Store is enabled, we execute the following query
+When Query Store is enabled, OpenMetadata executes the following query
 
 ```
 SELECT TOP {result_limit}
@@ -121,7 +121,7 @@ WHERE t.text NOT LIKE '/* {{"app": "OpenMetadata", %%}} */%%'
 ORDER BY t.start_time DESC
 ```
 
-When Query Store is not enabled, we fall back to the following query against the plan-cache DMVs
+When Query Store is not enabled, OpenMetadata falls back to the following query against the plan-cache DMVs
 
 ```
 SELECT TOP {result_limit}

--- a/v1.13.x/connectors/ingestion/workflows/usage/filter-query-set.mdx
+++ b/v1.13.x/connectors/ingestion/workflows/usage/filter-query-set.mdx
@@ -80,7 +80,48 @@ For example if you want to add a condition to filter out queries executed by met
 
 ## MSSQL Filter Condition
 
-To fetch the query history log from MSSQL we execute the following query
+MSSQL reads query history from Query Store when it's enabled on a database, otherwise from the plan-cache DMVs. Your filter condition applies to whichever source is active for that database.
+
+When Query Store is enabled, we execute the following query
+
+```
+SELECT TOP {result_limit}
+    t.database_name,
+    t.text query_text,
+    t.start_time,
+    t.end_time,
+    t.duration,
+    NULL schema_name,
+    NULL query_type,
+    NULL user_name,
+    NULL aborted
+FROM (
+  SELECT
+    DB_NAME() AS database_name,
+    qt.query_sql_text AS text,
+    MAX(rs.last_execution_time) AS start_time,
+    DATEADD(s, CAST(AVG(rs.avg_duration) / 1000000 AS INT), MAX(rs.last_execution_time)) AS end_time,
+    AVG(rs.avg_duration) / 1000000.0 AS duration
+  FROM sys.query_store_query AS q
+  INNER JOIN sys.query_store_query_text AS qt
+    ON qt.query_text_id = q.query_text_id
+  INNER JOIN sys.query_store_plan AS p
+    ON p.query_id = q.query_id
+  INNER JOIN sys.query_store_runtime_stats AS rs
+    ON rs.plan_id = p.plan_id
+  WHERE ISNULL(q.object_id, 0) = 0
+    AND rs.last_execution_time BETWEEN '{start_time}' AND '{end_time}'
+  GROUP BY q.query_id, qt.query_sql_text
+) AS t
+WHERE t.text NOT LIKE '/* {{"app": "OpenMetadata", %%}} */%%'
+    AND t.text NOT LIKE '/* {{"app": "dbt", %%}} */%%'
+
+    AND {**your filter condition**}
+
+ORDER BY t.start_time DESC
+```
+
+When Query Store is not enabled, we fall back to the following query against the plan-cache DMVs
 
 ```
 SELECT TOP {result_limit}

--- a/v2.0.x-SNAPSHOT/connectors/database/mssql.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/mssql.mdx
@@ -52,9 +52,20 @@ GRANT VIEW DEFINITION TO Mary;
 GRANT VIEW ANY DEFINITION TO [login_name];
 ```
 ### Usage & Lineage consideration
-To perform the query analysis for Usage and Lineage computation, we fetch the query logs from `sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` &  `sys.dm_exec_sql_text` system tables. To access these tables your user must have `VIEW SERVER STATE` privilege.
+To perform the query analysis for Usage and Lineage computation, the connector reads query history from SQL Server's [Query Store](https://learn.microsoft.com/en-us/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store) (`sys.query_store_query`, `sys.query_store_query_text`, `sys.query_store_plan` & `sys.query_store_runtime_stats`) when it is enabled on a database. Query Store keeps a durable, on-disk record of executed queries. The plan-cache DMVs (`sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` & `sys.dm_exec_sql_text`) are evicted on server restart, memory pressure, or plan recompilation, and can silently return incomplete history.
+
+Query Store is auto-detected per database. No configuration is needed. When `ingestAllDatabases` is enabled, each database is read from its own best source independently: databases with Query Store use it, and the rest fall back to the plan-cache DMVs, so one database without Query Store never downgrades the others.
+
+**We recommend enabling Query Store** on the databases you ingest, for reliable and durable Usage and Lineage history.
+
+Accessing the plan-cache DMVs requires `VIEW SERVER STATE`:
 ```sql
 GRANT VIEW SERVER STATE TO YourUser;
+```
+Accessing Query Store requires `VIEW DATABASE STATE` (SQL Server 2016-2019 and Azure SQL Database) or `VIEW DATABASE PERFORMANCE STATE` (SQL Server 2022+ and Azure SQL Managed Instance), granted per database:
+```sql
+GRANT VIEW DATABASE STATE TO YourUser;
+-- SQL Server 2022+: GRANT VIEW DATABASE PERFORMANCE STATE TO YourUser;
 ```
 ### For Remote Connection
 #### 1. SQL Server running

--- a/v2.0.x-SNAPSHOT/connectors/database/mssql.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/mssql.mdx
@@ -73,17 +73,23 @@ ALTER DATABASE [YourDatabase] SET QUERY_STORE = ON
     CLEANUP_POLICY = ( STALE_QUERY_THRESHOLD_DAYS = 30 )
 );
 ```
-The default `QUERY_CAPTURE_MODE` on SQL Server 2019 and later is `AUTO`, which can skip queries that only run a few times, such as a one-off data migration statement. Setting it to `ALL` ensures every query is captured for lineage. Set `STALE_QUERY_THRESHOLD_DAYS` to cover at least your ingestion lookback window, so queries are not purged before they are read. Query Store's default `SIZE_BASED_CLEANUP_MODE` already purges the oldest queries to stay within `MAX_STORAGE_SIZE_MB` rather than switching to read-only, so no override is needed there.
+The default `QUERY_CAPTURE_MODE` on SQL Server 2019 and later is `AUTO`, which can skip queries that only run a few times, such as a one-off data migration statement. Setting it to `ALL` ensures every query is captured for lineage. Set `STALE_QUERY_THRESHOLD_DAYS` to cover at least your ingestion lookback window, so queries are not purged before they are read. Query Store's default `SIZE_BASED_CLEANUP_MODE` purges the oldest queries to stay within `MAX_STORAGE_SIZE_MB`, which reduces the risk of Query Store switching to read-only. Under heavy write load, cleanup can still fall behind, and Query Store can switch to read-only temporarily until it catches up.
 
-Accessing the plan-cache DMVs requires `VIEW SERVER STATE`:
-```sql
-GRANT VIEW SERVER STATE TO YourUser;
-```
-Accessing Query Store requires `VIEW DATABASE STATE` (SQL Server 2016-2019 and Azure SQL Database) or `VIEW DATABASE PERFORMANCE STATE` (SQL Server 2022+ and Azure SQL Managed Instance), granted per database:
+<Warning>
+Query Store needs two permissions together. The database-level grant below lets `sys.database_query_store_options` and Query Store's other metadata views succeed, but the query text comes from `sys.query_store_query_text`, which needs the server-level grant. Without the server-level grant, usage and lineage queries can run without error while returning no query text.
+</Warning>
+
+Database-level, for Query Store metadata: `VIEW DATABASE STATE` (SQL Server 2016-2019) or `VIEW DATABASE PERFORMANCE STATE` (SQL Server 2022 and later).
 ```sql
 GRANT VIEW DATABASE STATE TO YourUser;
--- SQL Server 2022+: GRANT VIEW DATABASE PERFORMANCE STATE TO YourUser;
+-- SQL Server 2022 and later: GRANT VIEW DATABASE PERFORMANCE STATE TO YourUser;
 ```
+Server-level, for the query text and the plan-cache DMV fallback: `VIEW SERVER STATE` (SQL Server 2019 and earlier) or `VIEW SERVER PERFORMANCE STATE` (SQL Server 2022 and later).
+```sql
+GRANT VIEW SERVER STATE TO YourUser;
+-- SQL Server 2022 and later: GRANT VIEW SERVER PERFORMANCE STATE TO YourUser;
+```
+Exact grant names and tiers can differ on Azure SQL Database and Azure SQL Managed Instance. Check `sys.database_query_store_options` and the [Microsoft documentation](https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-query-store-query-text-transact-sql) for your instance.
 ### For Remote Connection
 #### 1. SQL Server running
 Make sure the SQL server that you are trying to connect is in running state.

--- a/v2.0.x-SNAPSHOT/connectors/database/mssql.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/mssql.mdx
@@ -58,6 +58,21 @@ Query Store is auto-detected per database. No configuration is needed. When `ing
 
 **We recommend enabling Query Store** on the databases you ingest, for reliable and durable Usage and Lineage history.
 
+To check whether Query Store is enabled on a database, and how it is currently operating:
+```sql
+SELECT actual_state_desc, query_capture_mode_desc, size_based_cleanup_mode_desc
+FROM sys.database_query_store_options;
+```
+To enable it:
+```sql
+ALTER DATABASE [YourDatabase] SET QUERY_STORE = ON
+(
+    QUERY_CAPTURE_MODE = ALL,
+    CLEANUP_POLICY = ( STALE_QUERY_THRESHOLD_DAYS = 30 )
+);
+```
+The default `QUERY_CAPTURE_MODE` on SQL Server 2019 and later is `AUTO`, which can skip queries that only run a few times, such as a one-off data migration statement. Setting it to `ALL` ensures every query is captured for lineage. Set `STALE_QUERY_THRESHOLD_DAYS` to cover at least your ingestion lookback window, so queries are not purged before they are read. Query Store's default `SIZE_BASED_CLEANUP_MODE` already purges the oldest queries to stay within `MAX_STORAGE_SIZE_MB` rather than switching to read-only, so no override is needed there.
+
 Accessing the plan-cache DMVs requires `VIEW SERVER STATE`:
 ```sql
 GRANT VIEW SERVER STATE TO YourUser;

--- a/v2.0.x-SNAPSHOT/connectors/database/mssql.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/mssql.mdx
@@ -52,11 +52,13 @@ GRANT VIEW DEFINITION TO Mary;
 GRANT VIEW ANY DEFINITION TO [login_name];
 ```
 ### Usage & Lineage consideration
-To perform the query analysis for Usage and Lineage computation, the connector reads query history from SQL Server's [Query Store](https://learn.microsoft.com/en-us/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store) (`sys.query_store_query`, `sys.query_store_query_text`, `sys.query_store_plan` & `sys.query_store_runtime_stats`) when it is enabled on a database. Query Store keeps a durable, on-disk record of executed queries. The plan-cache DMVs (`sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` & `sys.dm_exec_sql_text`) are evicted on server restart, memory pressure, or plan recompilation, and can silently return incomplete history.
+To perform the query analysis for Usage and Lineage computation, the connector reads query history from SQL Server's [Query Store](https://learn.microsoft.com/en-us/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store) when it is enabled on a database. Query Store exposes this history through `sys.query_store_query`, `sys.query_store_query_text`, `sys.query_store_plan`, and `sys.query_store_runtime_stats`. Query Store keeps a durable, on-disk record of executed queries. The plan-cache Dynamic Management Views (DMVs) (`sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats`, and `sys.dm_exec_sql_text`) are evicted on server restart, memory pressure, or plan recompilation, and can silently return incomplete history.
 
 Query Store is auto-detected per database. No configuration is needed. When `ingestAllDatabases` is enabled, each database is read from its own best source independently: databases with Query Store use it, and the rest fall back to the plan-cache DMVs, so one database without Query Store never downgrades the others.
 
-**We recommend enabling Query Store** on the databases you ingest, for reliable and durable Usage and Lineage history.
+<Tip>
+**Tip:** Enable Query Store on the databases you ingest, for reliable and durable Usage and Lineage history.
+</Tip>
 
 To check whether Query Store is enabled on a database, and how it is currently operating:
 ```sql

--- a/v2.0.x-SNAPSHOT/connectors/database/mssql/troubleshoot.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/mssql/troubleshoot.mdx
@@ -58,3 +58,7 @@ After updating the connection scheme, the connection should succeed. The status 
 ```
 Connection Status: Success
 ```
+
+## Stored Procedure Lineage Across Databases
+
+If the same stored procedure name exists in more than one database or schema, the connector matches each query to its procedure using the database and schema reported by the query source. If the match is still ambiguous, that query is skipped rather than attached to the wrong procedure.

--- a/v2.0.x-SNAPSHOT/connectors/database/mssql/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/mssql/yaml.mdx
@@ -66,6 +66,21 @@ Query Store is auto-detected per database. No configuration is needed. When `ing
 
 **We recommend enabling Query Store** on the databases you ingest, for reliable and durable Usage and Lineage history.
 
+To check whether Query Store is enabled on a database, and how it is currently operating:
+```sql
+SELECT actual_state_desc, query_capture_mode_desc, size_based_cleanup_mode_desc
+FROM sys.database_query_store_options;
+```
+To enable it:
+```sql
+ALTER DATABASE [YourDatabase] SET QUERY_STORE = ON
+(
+    QUERY_CAPTURE_MODE = ALL,
+    CLEANUP_POLICY = ( STALE_QUERY_THRESHOLD_DAYS = 30 )
+);
+```
+The default `QUERY_CAPTURE_MODE` on SQL Server 2019 and later is `AUTO`, which can skip queries that only run a few times, such as a one-off data migration statement. Setting it to `ALL` ensures every query is captured for lineage. Set `STALE_QUERY_THRESHOLD_DAYS` to cover at least your ingestion lookback window, so queries are not purged before they are read. Query Store's default `SIZE_BASED_CLEANUP_MODE` already purges the oldest queries to stay within `MAX_STORAGE_SIZE_MB` rather than switching to read-only, so no override is needed there.
+
 Accessing the plan-cache DMVs requires `VIEW SERVER STATE`:
 ```sql
 GRANT VIEW SERVER STATE TO YourUser;

--- a/v2.0.x-SNAPSHOT/connectors/database/mssql/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/mssql/yaml.mdx
@@ -60,9 +60,20 @@ GRANT VIEW DEFINITION TO Mary;
 GRANT VIEW ANY DEFINITION TO [login_name];
 ```
 ### Usage & Lineage consideration
-To perform the query analysis for Usage and Lineage computation, we fetch the query logs from `sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` &  `sys.dm_exec_sql_text` system tables. To access these tables your user must have `VIEW SERVER STATE` privilege.
+To perform the query analysis for Usage and Lineage computation, the connector reads query history from SQL Server's [Query Store](https://learn.microsoft.com/en-us/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store) (`sys.query_store_query`, `sys.query_store_query_text`, `sys.query_store_plan` & `sys.query_store_runtime_stats`) when it is enabled on a database. Query Store keeps a durable, on-disk record of executed queries. The plan-cache DMVs (`sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` & `sys.dm_exec_sql_text`) are evicted on server restart, memory pressure, or plan recompilation, and can silently return incomplete history.
+
+Query Store is auto-detected per database. No configuration is needed. When `ingestAllDatabases` is enabled, each database is read from its own best source independently: databases with Query Store use it, and the rest fall back to the plan-cache DMVs, so one database without Query Store never downgrades the others.
+
+**We recommend enabling Query Store** on the databases you ingest, for reliable and durable Usage and Lineage history.
+
+Accessing the plan-cache DMVs requires `VIEW SERVER STATE`:
 ```sql
 GRANT VIEW SERVER STATE TO YourUser;
+```
+Accessing Query Store requires `VIEW DATABASE STATE` (SQL Server 2016-2019 and Azure SQL Database) or `VIEW DATABASE PERFORMANCE STATE` (SQL Server 2022+ and Azure SQL Managed Instance), granted per database:
+```sql
+GRANT VIEW DATABASE STATE TO YourUser;
+-- SQL Server 2022+: GRANT VIEW DATABASE PERFORMANCE STATE TO YourUser;
 ```
 ### Python Requirements
 <PythonRequirements />

--- a/v2.0.x-SNAPSHOT/connectors/database/mssql/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/mssql/yaml.mdx
@@ -60,11 +60,13 @@ GRANT VIEW DEFINITION TO Mary;
 GRANT VIEW ANY DEFINITION TO [login_name];
 ```
 ### Usage & Lineage consideration
-To perform the query analysis for Usage and Lineage computation, the connector reads query history from SQL Server's [Query Store](https://learn.microsoft.com/en-us/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store) (`sys.query_store_query`, `sys.query_store_query_text`, `sys.query_store_plan` & `sys.query_store_runtime_stats`) when it is enabled on a database. Query Store keeps a durable, on-disk record of executed queries. The plan-cache DMVs (`sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats` & `sys.dm_exec_sql_text`) are evicted on server restart, memory pressure, or plan recompilation, and can silently return incomplete history.
+To perform the query analysis for Usage and Lineage computation, the connector reads query history from SQL Server's [Query Store](https://learn.microsoft.com/en-us/sql/relational-databases/performance/monitoring-performance-by-using-the-query-store) when it is enabled on a database. Query Store exposes this history through `sys.query_store_query`, `sys.query_store_query_text`, `sys.query_store_plan`, and `sys.query_store_runtime_stats`. Query Store keeps a durable, on-disk record of executed queries. The plan-cache Dynamic Management Views (DMVs) (`sys.dm_exec_cached_plans`, `sys.dm_exec_query_stats`, and `sys.dm_exec_sql_text`) are evicted on server restart, memory pressure, or plan recompilation, and can silently return incomplete history.
 
 Query Store is auto-detected per database. No configuration is needed. When `ingestAllDatabases` is enabled, each database is read from its own best source independently: databases with Query Store use it, and the rest fall back to the plan-cache DMVs, so one database without Query Store never downgrades the others.
 
-**We recommend enabling Query Store** on the databases you ingest, for reliable and durable Usage and Lineage history.
+<Tip>
+**Tip:** Enable Query Store on the databases you ingest, for reliable and durable Usage and Lineage history.
+</Tip>
 
 To check whether Query Store is enabled on a database, and how it is currently operating:
 ```sql

--- a/v2.0.x-SNAPSHOT/connectors/database/mssql/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/mssql/yaml.mdx
@@ -81,17 +81,23 @@ ALTER DATABASE [YourDatabase] SET QUERY_STORE = ON
     CLEANUP_POLICY = ( STALE_QUERY_THRESHOLD_DAYS = 30 )
 );
 ```
-The default `QUERY_CAPTURE_MODE` on SQL Server 2019 and later is `AUTO`, which can skip queries that only run a few times, such as a one-off data migration statement. Setting it to `ALL` ensures every query is captured for lineage. Set `STALE_QUERY_THRESHOLD_DAYS` to cover at least your ingestion lookback window, so queries are not purged before they are read. Query Store's default `SIZE_BASED_CLEANUP_MODE` already purges the oldest queries to stay within `MAX_STORAGE_SIZE_MB` rather than switching to read-only, so no override is needed there.
+The default `QUERY_CAPTURE_MODE` on SQL Server 2019 and later is `AUTO`, which can skip queries that only run a few times, such as a one-off data migration statement. Setting it to `ALL` ensures every query is captured for lineage. Set `STALE_QUERY_THRESHOLD_DAYS` to cover at least your ingestion lookback window, so queries are not purged before they are read. Query Store's default `SIZE_BASED_CLEANUP_MODE` purges the oldest queries to stay within `MAX_STORAGE_SIZE_MB`, which reduces the risk of Query Store switching to read-only. Under heavy write load, cleanup can still fall behind, and Query Store can switch to read-only temporarily until it catches up.
 
-Accessing the plan-cache DMVs requires `VIEW SERVER STATE`:
-```sql
-GRANT VIEW SERVER STATE TO YourUser;
-```
-Accessing Query Store requires `VIEW DATABASE STATE` (SQL Server 2016-2019 and Azure SQL Database) or `VIEW DATABASE PERFORMANCE STATE` (SQL Server 2022+ and Azure SQL Managed Instance), granted per database:
+<Warning>
+Query Store needs two permissions together. The database-level grant below lets `sys.database_query_store_options` and Query Store's other metadata views succeed, but the query text comes from `sys.query_store_query_text`, which needs the server-level grant. Without the server-level grant, usage and lineage queries can run without error while returning no query text.
+</Warning>
+
+Database-level, for Query Store metadata: `VIEW DATABASE STATE` (SQL Server 2016-2019) or `VIEW DATABASE PERFORMANCE STATE` (SQL Server 2022 and later).
 ```sql
 GRANT VIEW DATABASE STATE TO YourUser;
--- SQL Server 2022+: GRANT VIEW DATABASE PERFORMANCE STATE TO YourUser;
+-- SQL Server 2022 and later: GRANT VIEW DATABASE PERFORMANCE STATE TO YourUser;
 ```
+Server-level, for the query text and the plan-cache DMV fallback: `VIEW SERVER STATE` (SQL Server 2019 and earlier) or `VIEW SERVER PERFORMANCE STATE` (SQL Server 2022 and later).
+```sql
+GRANT VIEW SERVER STATE TO YourUser;
+-- SQL Server 2022 and later: GRANT VIEW SERVER PERFORMANCE STATE TO YourUser;
+```
+Exact grant names and tiers can differ on Azure SQL Database and Azure SQL Managed Instance. Check `sys.database_query_store_options` and the [Microsoft documentation](https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-query-store-query-text-transact-sql) for your instance.
 ### Python Requirements
 <PythonRequirements />
 To run the MSSQL ingestion, you will need to install:

--- a/v2.0.x-SNAPSHOT/connectors/ingestion/workflows/lineage/filter-query-set.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/ingestion/workflows/lineage/filter-query-set.mdx
@@ -81,7 +81,7 @@ For example if you want to add a condition to filter out queries executed by met
 
 MSSQL reads query history from Query Store when it's enabled on a database, otherwise from the plan-cache DMVs. Your filter condition applies to whichever source is active for that database.
 
-When Query Store is enabled, we execute the following query
+When Query Store is enabled, OpenMetadata executes the following query
 
 ```
 SELECT TOP {result_limit}
@@ -120,7 +120,7 @@ WHERE t.text NOT LIKE '/* {{"app": "OpenMetadata", %%}} */%%'
 ORDER BY t.start_time DESC
 ```
 
-When Query Store is not enabled, we fall back to the following query against the plan-cache DMVs
+When Query Store is not enabled, OpenMetadata falls back to the following query against the plan-cache DMVs
 
 ```
 SELECT TOP {result_limit}

--- a/v2.0.x-SNAPSHOT/connectors/ingestion/workflows/lineage/filter-query-set.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/ingestion/workflows/lineage/filter-query-set.mdx
@@ -79,7 +79,48 @@ For example if you want to add a condition to filter out queries executed by met
 
 ## MSSQL Filter Condition
 
-To fetch the query history log from MSSQL we execute the following query
+MSSQL reads query history from Query Store when it's enabled on a database, otherwise from the plan-cache DMVs. Your filter condition applies to whichever source is active for that database.
+
+When Query Store is enabled, we execute the following query
+
+```
+SELECT TOP {result_limit}
+    t.database_name,
+    t.text query_text,
+    t.start_time,
+    t.end_time,
+    t.duration,
+    NULL schema_name,
+    NULL query_type,
+    NULL user_name,
+    NULL aborted
+FROM (
+  SELECT
+    DB_NAME() AS database_name,
+    qt.query_sql_text AS text,
+    MAX(rs.last_execution_time) AS start_time,
+    DATEADD(s, CAST(AVG(rs.avg_duration) / 1000000 AS INT), MAX(rs.last_execution_time)) AS end_time,
+    AVG(rs.avg_duration) / 1000000.0 AS duration
+  FROM sys.query_store_query AS q
+  INNER JOIN sys.query_store_query_text AS qt
+    ON qt.query_text_id = q.query_text_id
+  INNER JOIN sys.query_store_plan AS p
+    ON p.query_id = q.query_id
+  INNER JOIN sys.query_store_runtime_stats AS rs
+    ON rs.plan_id = p.plan_id
+  WHERE ISNULL(q.object_id, 0) = 0
+    AND rs.last_execution_time BETWEEN '{start_time}' AND '{end_time}'
+  GROUP BY q.query_id, qt.query_sql_text
+) AS t
+WHERE t.text NOT LIKE '/* {{"app": "OpenMetadata", %%}} */%%'
+    AND t.text NOT LIKE '/* {{"app": "dbt", %%}} */%%'
+
+    AND {**your filter condition**}
+
+ORDER BY t.start_time DESC
+```
+
+When Query Store is not enabled, we fall back to the following query against the plan-cache DMVs
 
 ```
 SELECT TOP {result_limit}

--- a/v2.0.x-SNAPSHOT/connectors/ingestion/workflows/usage/filter-query-set.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/ingestion/workflows/usage/filter-query-set.mdx
@@ -82,7 +82,7 @@ For example if you want to add a condition to filter out queries executed by met
 
 MSSQL reads query history from Query Store when it's enabled on a database, otherwise from the plan-cache DMVs. Your filter condition applies to whichever source is active for that database.
 
-When Query Store is enabled, we execute the following query
+When Query Store is enabled, OpenMetadata executes the following query
 
 ```
 SELECT TOP {result_limit}
@@ -121,7 +121,7 @@ WHERE t.text NOT LIKE '/* {{"app": "OpenMetadata", %%}} */%%'
 ORDER BY t.start_time DESC
 ```
 
-When Query Store is not enabled, we fall back to the following query against the plan-cache DMVs
+When Query Store is not enabled, OpenMetadata falls back to the following query against the plan-cache DMVs
 
 ```
 SELECT TOP {result_limit}

--- a/v2.0.x-SNAPSHOT/connectors/ingestion/workflows/usage/filter-query-set.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/ingestion/workflows/usage/filter-query-set.mdx
@@ -80,7 +80,48 @@ For example if you want to add a condition to filter out queries executed by met
 
 ## MSSQL Filter Condition
 
-To fetch the query history log from MSSQL we execute the following query
+MSSQL reads query history from Query Store when it's enabled on a database, otherwise from the plan-cache DMVs. Your filter condition applies to whichever source is active for that database.
+
+When Query Store is enabled, we execute the following query
+
+```
+SELECT TOP {result_limit}
+    t.database_name,
+    t.text query_text,
+    t.start_time,
+    t.end_time,
+    t.duration,
+    NULL schema_name,
+    NULL query_type,
+    NULL user_name,
+    NULL aborted
+FROM (
+  SELECT
+    DB_NAME() AS database_name,
+    qt.query_sql_text AS text,
+    MAX(rs.last_execution_time) AS start_time,
+    DATEADD(s, CAST(AVG(rs.avg_duration) / 1000000 AS INT), MAX(rs.last_execution_time)) AS end_time,
+    AVG(rs.avg_duration) / 1000000.0 AS duration
+  FROM sys.query_store_query AS q
+  INNER JOIN sys.query_store_query_text AS qt
+    ON qt.query_text_id = q.query_text_id
+  INNER JOIN sys.query_store_plan AS p
+    ON p.query_id = q.query_id
+  INNER JOIN sys.query_store_runtime_stats AS rs
+    ON rs.plan_id = p.plan_id
+  WHERE ISNULL(q.object_id, 0) = 0
+    AND rs.last_execution_time BETWEEN '{start_time}' AND '{end_time}'
+  GROUP BY q.query_id, qt.query_sql_text
+) AS t
+WHERE t.text NOT LIKE '/* {{"app": "OpenMetadata", %%}} */%%'
+    AND t.text NOT LIKE '/* {{"app": "dbt", %%}} */%%'
+
+    AND {**your filter condition**}
+
+ORDER BY t.start_time DESC
+```
+
+When Query Store is not enabled, we fall back to the following query against the plan-cache DMVs
 
 ```
 SELECT TOP {result_limit}


### PR DESCRIPTION
Followed by the changes from https://github.com/open-metadata/OpenMetadata/pull/29719

Documents the MSSQL Query Store based usage/lineage source, per-database ingestAllDatabases routing, cross-database stored procedure lineage matching, and how to check/enable Query Store.