### PR TITLE
Docs: Add technical-writing review checklist and on-demand PR review

### DIFF
--- a/.ai/doc-review/instructions.md
+++ b/.ai/doc-review/instructions.md
@@ -1,0 +1,110 @@
+# OpenMetadata content review instructions
+
+Reviews written content against the **OpenMetadata Writing Style Guide** and returns a
+structured table report showing exactly which guideline was violated, the exact line
+or sentence that needs changing, and the suggested replacement.
+
+---
+
+## When to use
+
+Use these instructions when a user asks any AI assistant to review, proofread,
+check, audit, improve, clean up, or validate content for OpenMetadata docs; asks whether
+copy sounds right or on-brand; or asks to check a draft against the style guide.
+
+## How to use
+
+1. Read the content the user wants reviewed.
+2. Read the checklist at `.ai/doc-review/references/checklist.md`.
+3. Run every applicable checklist item against the content.
+4. Return a **Review Report** in the exact format below.
+5. Offer a fully revised version after the report if the user asks.
+
+If no content or file reference is provided, ask the user to provide the content to
+review and stop.
+
+Do not skip applicable categories even if the content is short. Mark checklist
+items as N/A when they do not apply to the content type.
+
+---
+
+## Review Report Format
+
+Output your response in exactly this structure:
+
+---
+
+### OpenMetadata Content Review
+
+**Content type:** [e.g. Email, Documentation, Marketing copy, Release note]
+**Overall verdict:** PASS / NEEDS WORK / FAIL
+*(FAIL = 5 or more Critical issues; NEEDS WORK = any Major issues or 3+ Minor)*
+
+---
+
+#### Issues Found
+
+Present every issue as a row in this table. One row per issue — do not combine multiple issues into one row.
+
+| # | Guideline | Severity | Original text | Suggested change |
+|---|-----------|----------|---------------|-----------------|
+| 1 | [Guideline name + section, e.g. "Active voice — §3.1"] | Critical / Major / Minor | "exact quote from the content" | "replacement text or instruction" |
+| 2 | ... | ... | ... | ... |
+
+**Column definitions:**
+- **#** — Sequential issue number.
+- **Guideline** — The specific rule from the OpenMetadata Writing Style Guide that is violated. Always name the rule and its section number (e.g. "Contractions — §3.3", "Oxford comma — §4.2", "OpenMetadata brand name — §10.1"). Never write a vague label like "tone issue."
+- **Severity** — One of:
+  - **Critical** — Breaks a core rule: wrong brand name, passive voice throughout, title-case documentation headings, gendered pronouns, no Oxford comma throughout.
+  - **Major** — Noticeably degrades quality: jargon, wordiness, redundant phrases used repeatedly, missing contractions throughout.
+  - **Minor** — Single small polish item: one number not spelled out, one missing em dash, one weak word choice.
+- **Original text** — The exact sentence, phrase, or word from the content that needs to change. Always quote verbatim in double quotes. If the issue is structural (e.g. a missing heading), write a short description instead.
+- **Suggested change** — The corrected version in double quotes, or a clear instruction if a full rewrite is needed (e.g. "Split into two sentences" or "Add a heading before this paragraph").
+
+---
+
+#### What's Working Well
+
+List 2–4 specific things the content does correctly. Be concrete — cite actual text or structure from the piece, not generic praise.
+
+---
+
+#### Category Summary
+
+| Category | Status | Issue count |
+|----------|--------|-------------|
+| Voice & Tone | PASS/WARN/FAIL | 0 |
+| Clarity & Conciseness | PASS/WARN/FAIL | 0 |
+| Grammar & Language | PASS/WARN/FAIL | 0 |
+| Punctuation | PASS/WARN/FAIL | 0 |
+| Capitalization | PASS/WARN/FAIL | 0 |
+| Numbers & Dates | PASS/WARN/FAIL | 0 |
+| Formatting & Structure | PASS/WARN/FAIL | 0 |
+| Inclusive Language | PASS/WARN/FAIL | 0 |
+| Accessibility | PASS/WARN/FAIL | 0 |
+| OpenMetadata Branding | PASS/WARN/FAIL | 0 |
+| Global / Localization | PASS/WARN/FAIL/N/A | 0 |
+
+Status key: PASS = no issues, WARN = minor issues only, FAIL = major or critical issues, N/A = category does not apply
+
+---
+
+#### Top 3 Priorities
+
+| Priority | Fix |
+|----------|-----|
+| 1 | [Most impactful single change] |
+| 2 | [Second most impactful change] |
+| 3 | [Third most impactful change] |
+
+---
+
+## Important Behaviour Rules
+
+- **Quote exact text.** The "Original text" column must always contain the verbatim phrase from the content — never a paraphrase. If the passage is long, quote the most relevant fragment (20 words or fewer).
+- **Name the guideline precisely.** Every row must reference a specific rule from the OpenMetadata Writing Style Guide with its section number. "Tone" or "style" alone is not acceptable.
+- **One issue per row.** Do not bundle multiple violations into one row even if they occur in the same sentence. Each violation gets its own row.
+- **Never rewrite the whole document unprompted.** Offer to produce a clean revised version after delivering the report.
+- **Context matters.** Legal disclaimers may use formal language intentionally. Inline code snippets follow code conventions, not prose rules. Use judgment and note exceptions.
+- **If content is under 50 words**, note that the review is limited due to brevity and not all categories can be fully assessed.
+- **For content intended for translation**, treat Global / Localization checklist items as Major severity rather than Minor.

--- a/.ai/doc-review/instructions.md
+++ b/.ai/doc-review/instructions.md
@@ -55,7 +55,7 @@ Present every issue as a row in this table. One row per issue — do not combine
 - **#** — Sequential issue number.
 - **Guideline** — The specific rule from the OpenMetadata Writing Style Guide that is violated. Always name the rule and its section number (e.g. "Contractions — §3.3", "Oxford comma — §4.2", "OpenMetadata brand name — §10.1"). Never write a vague label like "tone issue."
 - **Severity** — One of:
-  - **Critical** — Breaks a core rule: wrong brand name, passive voice throughout, title-case documentation headings, gendered pronouns, no Oxford comma throughout.
+  - **Critical** — Breaks a core rule: wrong brand name, passive voice throughout, gendered pronouns, no Oxford comma throughout.
   - **Major** — Noticeably degrades quality: jargon, wordiness, redundant phrases used repeatedly, missing contractions throughout.
   - **Minor** — Single small polish item: one number not spelled out, one missing em dash, one weak word choice.
 - **Original text** — The exact sentence, phrase, or word from the content that needs to change. Always quote verbatim in double quotes. If the issue is structural (e.g. a missing heading), write a short description instead.

--- a/.ai/doc-review/references/checklist.md
+++ b/.ai/doc-review/references/checklist.md
@@ -1,0 +1,296 @@
+# OpenMetadata Content Review Checklist
+
+Full item-by-item checklist derived from the OpenMetadata Writing Style Guide.
+Check every item. Mark each as PASS, FAIL, or N/A.
+
+---
+
+## Category 1: Voice & Tone
+
+### 1.1 Brand Voice
+- [ ] **Warm and clear** — Does the content feel like a knowledgeable colleague rather than a formal institution? Flag overly stiff or robotic phrasing.
+- [ ] **Honest and confident** — Does it say what it means without overselling, hedging excessively, or obscuring issues?
+- [ ] **Human and inclusive** — Is it written for real people, not a faceless audience?
+
+### 1.2 Conversational Naturalness
+- [ ] **Read-aloud test** — Would this sound natural spoken aloud? Flag anything that wouldn't be said in a meeting.
+- [ ] **No corporate filler** — Flag: "synergize," "leverage" (when "use" works), "holistic approach," "move the needle," "circle back," "deep dive," "best-in-class."
+- [ ] **No Latin abbreviations in body text** — Flag "i.e." (use "that is"), "e.g." (use "for example"), "etc." (use "and so on").
+- [ ] **"Please" used sparingly** — Flag "please" outside genuine requests or apologies; don't use it to soften routine instructions.
+- [ ] **No "let's" framing** — Flag "let's configure..." → "Configure..."
+
+### 1.3 Tone Matching
+- [ ] Is the tone appropriate for the content type?
+  - Customer support: empathetic, patient, solution-focused
+  - Technical docs: precise, neutral, instructional
+  - Marketing: energetic, confident, benefit-led
+  - Internal comms: friendly, direct, collegial
+  - Incident/crisis: calm, factual, accountable
+
+---
+
+## Category 2: Clarity & Conciseness
+
+### 2.1 Sentence Length & Complexity
+- [ ] **Short sentences** — Flag sentences with more than two commas plus end punctuation. Suggest breaking them up.
+- [ ] **One idea per sentence** — Flag sentences that try to do too much.
+- [ ] **No modifier stacks** — Flag long chains of nouns used as modifiers (e.g., "extremely well thought-out Windows migration project plan").
+
+### 2.2 Word Economy
+- [ ] **No "you can"** — Flag "you can [verb]" and suggest replacing with the direct imperative or verb alone. E.g., "You can export the report" → "Export the report."
+- [ ] **No "there is/are/were"** — Flag and suggest rewriting. E.g., "There are three options available" → "Three options are available."
+- [ ] **No redundant phrases** — Flag:
+  - "in order to" → "to"
+  - "at this point in time" → "now"
+  - "due to the fact that" → "because"
+  - "prior to" → "before"
+  - "subsequent to" → "after"
+  - "with regard to" → "about"
+  - "in the event that" → "if"
+  - "on a regular basis" → "regularly"
+- [ ] **"Lets you" over "allows you to"** — Flag "allows you to [verb]"; prefer the shorter "lets you [verb]."
+
+### 2.3 Word Choice
+- [ ] **Simple over complex** — Flag:
+  - "utilize" → "use"
+  - "initiate" → "start"
+  - "facilitate" → "help"
+  - "terminate" → "end" or "stop"
+  - "endeavour" → "try"
+  - "ascertain" → "find out"
+  - "commence" → "start" or "begin"
+- [ ] **Jargon check** — Is every technical term necessary and understandable to the target audience? Flag undefined jargon.
+- [ ] **Consistent terminology** — Is the same concept always called the same thing? Flag synonyms used interchangeably for the same concept.
+- [ ] **"Can" vs. "might" vs. "may"** — Use "can" for capability or permission, "might" for uncertain possibility. Flag "may" for either — it's ambiguous between the two.
+- [ ] **"Because" vs. "since"** — Use "because" for causation. Reserve "since" for time-based meaning only ("since version 1.5," not "since it's faster").
+
+### 2.4 Front-Loading
+- [ ] **Key point first** — Does the most important information appear in the first sentence or paragraph?
+- [ ] **Purpose clear early** — In emails and articles, is the purpose stated in the first two sentences?
+
+---
+
+## Category 3: Grammar & Language
+
+### 3.1 Voice
+- [ ] **Active voice preferred** — Flag passive constructions. E.g., "The file was rejected by the system" → "The system rejected the file."
+- [ ] **Passive voice acceptable when** — the actor is unknown, or the action matters more than who did it (e.g., "The database was last updated in March"). Do not flag these.
+- [ ] **No first-person "we/us/our" in reference or technical content** — Flag "we read the query log"; describe what the product does instead ("OpenMetadata reads the query log"). Second person ("you") is fine when addressing the reader directly.
+
+### 3.2 Verbs
+- [ ] **Strong verbs** — Flag verb-to-noun conversions: "make a decision" → "decide," "carry out an implementation" → "implement."
+- [ ] **Imperative mood in instructions** — Instructions should use imperative: "Select the file," not "You should select the file."
+- [ ] **Present tense where possible** — Especially for product descriptions and instructions.
+
+### 3.3 Contractions
+- [ ] **Use contractions in general content** — Flag missing contractions where formal phrasing sounds stiff: "it is" → "it's," "you will" → "you'll," "do not" → "don't."
+- [ ] **No contractions in** legal, compliance, or highly formal documents (these should not be flagged).
+- [ ] **No awkward contractions** — Flag "should've," "there'd," "would've" in professional content.
+
+### 3.4 Sentence Structure
+- [ ] **Standard word order** — Subject + verb + object. Flag inverted or convoluted structures.
+- [ ] **Modifiers close to what they modify** — Flag dangling modifiers and misplaced "only."
+- [ ] **No more than two clauses joined by and/or/but** — Flag run-ons; suggest splitting or using a list.
+
+---
+
+## Category 4: Punctuation
+
+### 4.1 End Punctuation
+- [ ] **Every sentence ends with a period** — Even two-word sentences.
+- [ ] **One space after periods** — Flag double spaces.
+- [ ] **No multiple exclamation marks** — Flag "!!" or "!!!".
+- [ ] **Exclamation marks used sparingly** — Flag if more than one appears in a short document.
+
+### 4.2 Commas
+- [ ] **Oxford (serial) comma used** — "files, folders, and documents" not "files, folders and documents."
+- [ ] **Comma after introductory clause** — Flag missing commas after opening subordinate clauses.
+- [ ] **No comma splice** — Two independent clauses must not be joined by a comma alone without a conjunction.
+- [ ] **No "&" as a stand-in for "and"** — Flag ampersands in prose or headings; reserve "&" for literal UI labels being referenced.
+
+### 4.3 Colons and Semicolons
+- [ ] **Colon before a list** — Used at the end of an introducing phrase, not a complete sentence that already contains a list.
+- [ ] **First word after colon** — Capitalize if it begins an independent clause.
+- [ ] **Avoid semicolons in general content** — Flag; suggest splitting the sentence.
+
+### 4.4 Dashes and Hyphens
+- [ ] **Em dash with no spaces** — "use pipelines—logical groups—to" not "use pipelines — logical groups — to."
+- [ ] **No spaced en dashes used as em dashes** — Flag " – " used mid-sentence.
+- [ ] **En dash for ranges** — "2020–2026," "pages 10–15" (not hyphens).
+- [ ] **Hyphen in compound modifiers before a noun** — "well-known author" but "the author is well known."
+- [ ] **No hyphen after -ly adverbs** — "a highly effective tool" not "a highly-effective tool."
+
+### 4.5 Apostrophes
+- [ ] **No apostrophe in plurals** — "PDFs" not "PDF's," "the 1990s" not "the 1990's."
+- [ ] **Correct possessives** — "the team's results," "OpenMetadata's brand."
+
+### 4.6 Quotation Marks
+- [ ] **Periods and commas inside quotes** — Place commas and periods inside the closing quotation mark, as in "like this."
+- [ ] **Colons and semicolons outside quotes.**
+- [ ] **No scare quotes for emphasis** — Use precise wording instead of ironic quotes.
+
+### 4.7 Parentheses
+- [ ] **No important information in parentheses** — Some readers skip parenthetical content; don't hide anything the reader needs there.
+- [ ] **Keep parenthetical asides brief** — If a parenthetical would run long (e.g., a list of code identifiers), split it into a separate sentence or use a dash instead.
+
+---
+
+## Category 5: Capitalization
+
+### 5.1 Heading Case
+- [ ] **Headings use title case on this site** — Capitalize all major words (e.g., "Bulk Import Test Cases"). This is a deliberate house style across the OpenMetadata docs — do not flag title-case headings as a violation.
+- [ ] **List items start with a capital letter.**
+- [ ] **No all-caps for emphasis** — Flag ANY WORD IN ALL CAPS used for emphasis. Italic is acceptable.
+- [ ] **No all-lowercase as a style choice.**
+
+### 5.2 Proper Nouns
+- [ ] **Product and service names capitalized** — Flag lowercase product names.
+- [ ] **"OpenMetadata" always capitalized** — Flag "openmetadata," "Openmetadata," or "OPENMETADATA."
+- [ ] **Acronyms in full caps** — API, SLA, CRM (no mixed case like "Api").
+
+### 5.3 What Not to Capitalize
+- [ ] **Generic job titles lowercase** — "the engineering manager" (not "Engineering Manager") unless used as a formal title before a name.
+- [ ] **Common tech terms lowercase** — "application," "platform," "database" (not "Platform" or "Database").
+- [ ] **Spelled-out acronyms lowercase** — "application programming interface" not "Application Programming Interface."
+
+---
+
+## Category 6: Numbers & Dates
+
+### 6.1 Numbers
+- [ ] **Spell out zero through nine** — "three options" not "3 options" (unless in a technical/measurement context).
+- [ ] **Numerals for 10 and above** — "15 users" not "fifteen users."
+- [ ] **Numerals always for** measurements, percentages, version numbers, money, technical specs.
+- [ ] **No sentence starting with a numeral** — Rewrite or spell out.
+- [ ] **Commas in 4+ digit numbers** — "1,000" not "1000."
+
+### 6.2 Dates
+- [ ] **Month spelled out** — "May 12, 2026" not "5/12/2026" or "12/5/2026."
+- [ ] **No ordinals in dates** — "June 1" not "June 1st."
+- [ ] **En dash for date ranges** — "May 10–14, 2026."
+
+### 6.3 Time
+- [ ] **12-hour clock with AM/PM in capitals with a space** — "9:00 AM" not "9am" or "9:00am."
+- [ ] **"noon" and "midnight"** — not "12:00 PM" or "12:00 AM."
+
+### 6.4 Percentages & Currency
+- [ ] **% symbol with numerals** — "45%" not "45 percent" (except at the start of a sentence).
+- [ ] **Currency symbol with numeral** — "$500" not "500 dollars."
+
+---
+
+## Category 7: Formatting & Structure
+
+### 7.1 Headings
+- [ ] **Every section has a clear, descriptive heading.**
+- [ ] **Parallel structure in headings** — Same grammatical form within the same section.
+- [ ] **No period at end of headings** — Question marks are acceptable.
+- [ ] **No heading immediately after another heading** with no body text between.
+
+### 7.2 Lists
+- [ ] **At least 2 items** — Single-item lists should be prose.
+- [ ] **No more than 7 items** — Suggest grouping if more.
+- [ ] **Parallel structure** — All items use the same grammatical form.
+- [ ] **Introduced with a complete sentence or colon-ending phrase.**
+- [ ] **No semicolons or commas at end of list items.**
+- [ ] **Period only if items are complete sentences or complete an introductory fragment.**
+
+### 7.3 Bold & Italic
+- [ ] **Bold used only for** key terms on first use, UI element names, or critical warnings. Not for general emphasis.
+- [ ] **No underline** except hyperlinks.
+- [ ] **Italic used for** titles of works or introducing new technical terms.
+
+### 7.4 Instructions
+- [ ] **Numbered list for steps** — Not bullets, not prose.
+- [ ] **One action per step.**
+- [ ] **Imperative verb starts each step** — "Select," "Enter," "Open."
+- [ ] **Location stated first in step** — "On the Settings page, select..."
+- [ ] **Optional steps marked with "Optional:"** — Flag optional steps indicated by parentheses instead; use "Optional: ..." at the start of the step.
+- [ ] **Goal-first phrasing where it reads naturally** — Prefer "To do X, do Y" over burying the goal at the end of the step.
+
+### 7.5 Notices & Callouts
+- [ ] **Used sparingly** — Flag more than one Note/Tip/Warning stacked back-to-back; overuse diminishes their effectiveness.
+- [ ] **Right type for the content** — Note = non-critical, skippable information; Warning = risk of data loss, security issues, or other irreversible harm; Tip = optional helpful suggestion.
+- [ ] **Not used for prerequisites** — Information the reader needs before starting belongs in the main flow, not a callout.
+- [ ] **Not used for essential information** — If the reader can't succeed without it, it isn't a Note — put it in the body text.
+- [ ] **Not used for cross-references** — Link to related content directly in the body text rather than via a callout.
+- [ ] **Not used for procedural steps** — Full steps belong in the numbered instructions, not offset in a box.
+
+---
+
+## Category 8: Inclusive Language
+
+### 8.1 Gender-Neutral Language
+- [ ] **No gendered pronouns in generic references** — Flag "he," "his," "she," "her" when referring to unspecified individuals.
+- [ ] **"You" preferred over third person** — Use direct address, such as "Access your account," not third person, such as "the user can access their account."
+- [ ] **No "he/she" or "s/he" constructions.**
+- [ ] **Singular "they" acceptable** — Flag only if the sentence becomes confusing.
+
+### 8.2 People-First Language
+- [ ] **Person before disability** — "a user who is blind" not "a blind user" (unless the individual/community prefers identity-first).
+- [ ] **No pity language** — Flag "suffering from," "afflicted with," "victim of."
+- [ ] **Disability mentioned only if relevant.**
+
+### 8.3 Culturally Sensitive Language
+- [ ] **No unconscious bias in technical terms** — Flag "master/slave" → "primary/secondary"; "whitelist/blacklist" → "allowlist/blocklist."
+- [ ] **No idioms or colloquialisms** that may not translate or that assume shared cultural background.
+- [ ] **No assumptions about holidays, sports, or political systems** unless directly relevant.
+
+### 8.4 Age & Generational Language
+- [ ] **No age stereotypes** — Do not assume older users cannot use technology or younger users lack professionalism.
+
+---
+
+## Category 9: Accessibility
+
+### 9.1 Structure
+- [ ] **Heading levels reflect hierarchy** — Don't use bold as a substitute for a heading.
+- [ ] **No directional language as sole locator** — "the table on the left" → "the following table."
+- [ ] **Descriptive link text** — Flag "click here," "read more," "learn more" without context. Suggest "Download the Q1 report" or "Learn more about data privacy."
+- [ ] **Link text matches the destination** — Where reasonable, link text should match the title or heading of the page it points to.
+- [ ] **No duplicate links** — Flag the same destination linked more than once on a page, unless linking to distinct sections.
+- [ ] **"For more information, see [X]"** — Use this as the standard phrasing when a full sentence is dedicated to a cross-reference.
+- [ ] **Punctuation outside link text** — Don't include trailing punctuation inside the link. Link text also isn't wrapped in quotation marks.
+
+### 9.2 Images & Media (if described or included)
+- [ ] **Alt text described or present** for all meaningful images.
+- [ ] **No information conveyed only through color.**
+
+### 9.3 Plain Language
+- [ ] **Abbreviations and acronyms spelled out on first use** — "application programming interface (API)" not just "API."
+- [ ] **Consistent terminology throughout** — No synonyms for the same concept.
+
+### 9.4 Interaction Language
+- [ ] **Generic interaction verbs** — "select" not "click," "enter" not "type," "activate" not "tap."
+
+---
+
+## Category 10: OpenMetadata Branding
+
+### 10.1 Project Name
+- [ ] **"OpenMetadata" — correct capitalization** — Flag "openmetadata," "Openmetadata," "OPENMETADATA," "Open Metadata" (as two words), or "OM" as a stand-in.
+- [ ] **First mention in a document uses "OpenMetadata"** — Subsequent uses may also use "OpenMetadata."
+- [ ] **No unofficial abbreviations** — Flag informal shorthand in prose (code identifiers and config keys are exempt).
+
+### 10.2 Product Names
+- [ ] **Exact registered product/feature names used** — No abbreviations, shortened forms, or unofficial variants.
+- [ ] **Product names capitalized as proper nouns.**
+- [ ] **Version numbers formatted correctly** — "OpenMetadata 1.5" not "OpenMetadata v1.5" or "OM 1.5."
+
+### 10.3 Customer-Facing Tone
+- [ ] **Customer addressed as "you"** — Not "the user," "the client," or third person in direct communications.
+- [ ] **Error messages and notifications state result or action first** — "Your file was saved" not "File save operation completed successfully."
+- [ ] **Error messages explain what went wrong + what to do next** — No raw error codes without explanation.
+- [ ] **No unofficial taglines or slogans** — Only approved project language in external content.
+- [ ] **No unapproved product claims** — Performance commitments require maintainer sign-off.
+
+---
+
+## Category 11: Global / Localization (apply when content will be translated)
+
+- [ ] **No idioms or culture-specific expressions.**
+- [ ] **No list items completing an introductory sentence fragment** — These are hard to translate.
+- [ ] **No noun stacks** — Long modifier chains often can't be translated.
+- [ ] **No humor, wordplay, or puns** in content intended for translation.
+- [ ] **UI strings under 80 characters** where possible (translations are often longer).
+- [ ] **Time zones specified** in international scheduling content.

--- a/.github/workflows/doc-review.yml
+++ b/.github/workflows/doc-review.yml
@@ -1,0 +1,48 @@
+name: AI Documentation Review (on demand)
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  doc-review:
+    if: |
+      github.event.issue.pull_request != null &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+      contains(github.event.comment.body, '/content-review')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trigger_phrase: "/content-review"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.issue.number }}
+
+            Read .ai/doc-review/instructions.md and .ai/doc-review/references/checklist.md
+            in this repo. Run `gh pr diff <PR NUMBER>` to get this PR's changes, and review
+            the changed .mdx content against every applicable checklist item, exactly as
+            instructed.
+
+            Produce the Review Report in the exact format instructions.md specifies,
+            including every finding regardless of severity (Critical, Major, and Minor) —
+            this review was explicitly requested.
+
+            Post it as ONE top-level comment via `gh pr comment <PR NUMBER>`, prefixed with:
+            "**Draft review — not all suggestions may apply. A maintainer will select which
+            findings to act on.**"
+
+            Do not attempt to create inline review comments or submit a formal PR review —
+            only the one summary comment.
+
+          claude_args: |
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr comment:*),Read"

--- a/.github/workflows/doc-review.yml
+++ b/.github/workflows/doc-review.yml
@@ -14,13 +14,14 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: "/content-review"
@@ -37,12 +38,16 @@ jobs:
             including every finding regardless of severity (Critical, Major, and Minor) —
             this review was explicitly requested.
 
-            Post it as ONE top-level comment via `gh pr comment <PR NUMBER>`, prefixed with:
-            "**Draft review — not all suggestions may apply. A maintainer will select which
-            findings to act on.**"
+            Prefix it with: "**Draft review — not all suggestions may apply. A maintainer
+            will select which findings to act on.**"
+
+            Return the Review Report as your final response — do not call `gh pr comment`
+            or any other command to post it yourself. This action automatically publishes
+            your final response as the PR comment, and calling `gh pr comment` in addition
+            would post a duplicate.
 
             Do not attempt to create inline review comments or submit a formal PR review —
             only the one summary comment.
 
           claude_args: |
-            --allowedTools "Bash(gh pr diff:*),Bash(gh pr comment:*),Read"
+            --allowedTools "Bash(gh pr diff:*),Read"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,14 @@ Connector pages follow a consistent template:
 
 New pages **must** be added to `docs.json` in the appropriate navigation section, or they won't appear in the sidebar.
 
+### AI content review
+
+When reviewing OpenMetadata documentation, release notes, UI copy, or other written content, use the AI-neutral workflow in `.ai/doc-review/instructions.md` and its checklist in `.ai/doc-review/references/checklist.md`. These instructions are shared across AI assistants and are not tied to Claude Code.
+
+### Pre-commit content review (Claude Code)
+
+Before running `git commit` on any change touching `.mdx` files (or `docs.json`), read `.ai/doc-review/instructions.md` and `.ai/doc-review/references/checklist.md`, and review the staged diff against every applicable item — unless the changes were already reviewed against this checklist earlier in the same conversation. Show Critical and Major findings before committing; if Minor findings also exist, mention the count and offer to show them rather than listing them inline by default. Proceed with the commit only after the user has seen this and confirmed.
+
 ---
 
 ## Changing the Site


### PR DESCRIPTION
## Summary
- Ports the docs-collate content-review checklist and instructions to this repo for the first time (`.ai/doc-review/instructions.md`, `.ai/doc-review/references/checklist.md`), branded for OpenMetadata.
- Merges in Technical Documentation Style Guide rules (word choice, parentheses, notices/callouts, cross-references, first-person voice), and codifies this site's title-case heading convention rather than flagging it.
- Adds a `CLAUDE.md` instruction so Claude Code self-checks staged `.mdx`/`docs.json` changes against the checklist before committing, showing Critical/Major findings up front.
- Adds `.github/workflows/doc-review.yml`: an on-demand GitHub Action that runs the same review when a repo collaborator (`OWNER`/`MEMBER`/`COLLABORATOR`) comments `/content-review` on a PR. Posts exactly one draft summary comment — never inline comments or a formal review — so a maintainer always curates before anything becomes actionable feedback.

## Test plan
- [x] Checklist and CLAUDE.md changes work immediately as local files.
- [x] Workflow YAML validated (`ruby -ryaml`).
Note: `issue_comment`-triggered workflows only load from the default branch, so `/content-review` won't be testable until this PR is merged to `main`.