### PR TITLE
Docs: Fix Java client Maven dependency and stale pip versions in API Reference

### DIFF
--- a/v1.12.x/api-reference.mdx
+++ b/v1.12.x/api-reference.mdx
@@ -40,8 +40,8 @@ Install an official SDK to interact with the OpenMetadata API in your preferred 
     ```xml
     <dependency>
       <groupId>org.open-metadata</groupId>
-      <artifactId>openmetadata-java-client</artifactId>
-      <version>1.12.1</version>
+      <artifactId>openmetadata-sdk</artifactId>
+      <version>1.12.13</version>
     </dependency>
     ```
 

--- a/v1.12.x/api-reference/getting-started.mdx
+++ b/v1.12.x/api-reference/getting-started.mdx
@@ -58,8 +58,8 @@ pip install "openmetadata-ingestion~=1.12.1"
 ```xml Java (Maven)
 <dependency>
   <groupId>org.open-metadata</groupId>
-  <artifactId>openmetadata-java-client</artifactId>
-  <version>1.12.1</version>
+  <artifactId>openmetadata-sdk</artifactId>
+  <version>1.12.13</version>
 </dependency>
 ```
 

--- a/v1.12.x/api-reference/sdk/java.mdx
+++ b/v1.12.x/api-reference/sdk/java.mdx
@@ -11,15 +11,15 @@ We now present a high-level Java API as a type-safe and gentle wrapper for the O
 The open-source OpenMetadata SDK for Java simplifies provisioning, managing, and using OpenMetadata resources from the Java application code. \
 The OpenMetadata SDK for Java libraries build on top of the underlying OpenMetadata REST API, allows you to use those APIs through familiar Java paradigms. However, you can always use the REST API directly from Java code, if you prefer to do so.
 
-You can find the source code for the OpenMetadata libraries in the [GitHub repository](https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-clients). As an open-source project, contributions are always welcome!
+You can find the source code for the OpenMetadata libraries in the [GitHub repository](https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-sdk). As an open-source project, contributions are always welcome!
 
-You can add the below Maven Dependency for OpenMetadata Java Client.
+You can add the below Maven Dependency for the OpenMetadata Java SDK.
 
 ```xml
 <dependency>
   <groupId>org.open-metadata</groupId>
-  <artifactId>openmetadata-java-client</artifactId>
-  <version>0.11.1</version>
+  <artifactId>openmetadata-sdk</artifactId>
+  <version>1.12.13</version>
 </dependency>
 ```
 
@@ -51,8 +51,8 @@ using the following piece of code.
 OpenMetadata openMetadataGateway = new OpenMetadata(server);
 ```
 
-## Use Java Client without Authentication
-To use Java Client without any authentication, you can use `NoOpAuthenticationProvider.java`. \
+## Use Java SDK without Authentication
+To use the Java SDK without any authentication, you can use `NoOpAuthenticationProvider.java`. \
 
 ```java
 NoOpAuthenticationProvider noOpAuthenticationProvider = new NoOpAuthenticationProvider();
@@ -64,7 +64,7 @@ Establish the [OpenMetadata Server Connection](#establish-openmetadata-server-co
 server.setAuthProvider(OpenMetadataServerConnection.AuthProvider.NO_AUTH);
 ```
 
-## Use Java Client with Authentication.
+## Use Java SDK with Authentication.
 
 The OpenMetadata Java SDK supports several auth providers:
 * [Google](#google)
@@ -186,7 +186,7 @@ server.setAuthProvider(OpenMetadataServerConnection.AuthProvider.CUSTOM_OIDC);
 server.setSecurityConfig(customOIDCSSOClientConfig);
 ```
 
-## How to Use APIs Using the Java Client
+## How to Use APIs Using the Java SDK
 You can use an API from the [OpenMetadata Gateway](#create-openmetadata-gateway).
 Using OpenMetadata Gateway, you will need to build the client by providing the `class` of the respected API.
 Below are some examples:

--- a/v1.12.x/api-reference/sdk/java/info.mdx
+++ b/v1.12.x/api-reference/sdk/java/info.mdx
@@ -17,8 +17,8 @@ Add the OpenMetadata Java SDK dependency to your `pom.xml`:
 ```xml
 <dependency>
     <groupId>org.open-metadata</groupId>
-    <artifactId>openmetadata-java-client</artifactId>
-    <version>1.9.0</version>
+    <artifactId>openmetadata-sdk</artifactId>
+    <version>1.12.13</version>
 </dependency>
 ```
 
@@ -27,7 +27,7 @@ Add the OpenMetadata Java SDK dependency to your `pom.xml`:
 Add the dependency to your `build.gradle`:
 
 ```gradle
-implementation 'org.open-metadata:openmetadata-java-client:1.9.0'
+implementation 'org.open-metadata:openmetadata-sdk:1.12.13'
 ```
 
 ## Quick Start

--- a/v1.12.x/sdk/java.mdx
+++ b/v1.12.x/sdk/java.mdx
@@ -11,15 +11,15 @@ We now present a high-level Java API as a type-safe and gentle wrapper for the O
 The open-source OpenMetadata SDK for Java simplifies provisioning, managing, and using OpenMetadata resources from the Java application code. \
 The OpenMetadata SDK for Java libraries build on top of the underlying OpenMetadata REST API, allows you to use those APIs through familiar Java paradigms. However, you can always use the REST API directly from Java code, if you prefer to do so.
 
-You can find the source code for the OpenMetadata libraries in the [GitHub repository](https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-clients). As an open-source project, contributions are always welcome!
+You can find the source code for the OpenMetadata libraries in the [GitHub repository](https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-sdk). As an open-source project, contributions are always welcome!
 
-You can add the below Maven Dependency for OpenMetadata Java Client.
+You can add the below Maven Dependency for the OpenMetadata Java SDK.
 
 ```xml
 <dependency>
   <groupId>org.open-metadata</groupId>
-  <artifactId>openmetadata-java-client</artifactId>
-  <version>0.11.1</version>
+  <artifactId>openmetadata-sdk</artifactId>
+  <version>1.12.13</version>
 </dependency>
 ```
 
@@ -51,8 +51,8 @@ using the following piece of code.
 OpenMetadata openMetadataGateway = new OpenMetadata(server);
 ```
 
-## Use Java Client without Authentication
-To use Java Client without any authentication, you can use `NoOpAuthenticationProvider.java`. \
+## Use Java SDK without Authentication
+To use the Java SDK without any authentication, you can use `NoOpAuthenticationProvider.java`. \
 
 ```java
 NoOpAuthenticationProvider noOpAuthenticationProvider = new NoOpAuthenticationProvider();
@@ -64,7 +64,7 @@ Establish the [OpenMetadata Server Connection](#establish-openmetadata-server-co
 server.setAuthProvider(OpenMetadataServerConnection.AuthProvider.NO_AUTH);
 ```
 
-## Use Java Client with Authentication.
+## Use Java SDK with Authentication.
 
 The OpenMetadata Java SDK supports several auth providers:
 * [Google](#google)
@@ -186,7 +186,7 @@ server.setAuthProvider(OpenMetadataServerConnection.AuthProvider.CUSTOM_OIDC);
 server.setSecurityConfig(customOIDCSSOClientConfig);
 ```
 
-## How to Use APIs Using the Java Client
+## How to Use APIs Using the Java SDK
 You can use an API from the [OpenMetadata Gateway](#create-openmetadata-gateway).
 Using OpenMetadata Gateway, you will need to build the client by providing the `class` of the respected API.
 Below are some examples:

--- a/v1.12.x/sdk/java/info.mdx
+++ b/v1.12.x/sdk/java/info.mdx
@@ -17,8 +17,8 @@ Add the OpenMetadata Java SDK dependency to your `pom.xml`:
 ```xml
 <dependency>
     <groupId>org.open-metadata</groupId>
-    <artifactId>openmetadata-java-client</artifactId>
-    <version>1.9.0</version>
+    <artifactId>openmetadata-sdk</artifactId>
+    <version>1.12.13</version>
 </dependency>
 ```
 
@@ -27,7 +27,7 @@ Add the OpenMetadata Java SDK dependency to your `pom.xml`:
 Add the dependency to your `build.gradle`:
 
 ```gradle
-implementation 'org.open-metadata:openmetadata-java-client:1.9.0'
+implementation 'org.open-metadata:openmetadata-sdk:1.12.13'
 ```
 
 ## Quick Start

--- a/v1.13.x/api-reference.mdx
+++ b/v1.13.x/api-reference.mdx
@@ -31,7 +31,7 @@ Install an official SDK to interact with the OpenMetadata API in your preferred 
 <Tabs>
   <Tab title="Python">
     ```bash
-    pip install "openmetadata-ingestion~=1.11.9"
+    pip install "openmetadata-ingestion~=1.13.1"
     ```
 
     The Python SDK provides a high-level, type-safe API with built-in support for ingestion, lineage, and all entity operations.
@@ -40,8 +40,8 @@ Install an official SDK to interact with the OpenMetadata API in your preferred 
     ```xml
     <dependency>
       <groupId>org.open-metadata</groupId>
-      <artifactId>openmetadata-java-client</artifactId>
-      <version>1.11.9</version>
+      <artifactId>openmetadata-sdk</artifactId>
+      <version>1.13.1</version>
     </dependency>
     ```
 

--- a/v1.13.x/api-reference/getting-started.mdx
+++ b/v1.13.x/api-reference/getting-started.mdx
@@ -52,14 +52,14 @@ Choose your preferred language and install the SDK:
 
 <CodeGroup>
 ```bash Python
-pip install "openmetadata-ingestion~=1.11.9"
+pip install "openmetadata-ingestion~=1.13.1"
 ```
 
 ```xml Java (Maven)
 <dependency>
   <groupId>org.open-metadata</groupId>
-  <artifactId>openmetadata-java-client</artifactId>
-  <version>1.11.9</version>
+  <artifactId>openmetadata-sdk</artifactId>
+  <version>1.13.1</version>
 </dependency>
 ```
 

--- a/v1.13.x/api-reference/sdk/java.mdx
+++ b/v1.13.x/api-reference/sdk/java.mdx
@@ -11,15 +11,15 @@ We now present a high-level Java API as a type-safe and gentle wrapper for the O
 The open-source OpenMetadata SDK for Java simplifies provisioning, managing, and using OpenMetadata resources from the Java application code. \
 The OpenMetadata SDK for Java libraries build on top of the underlying OpenMetadata REST API, allows you to use those APIs through familiar Java paradigms. However, you can always use the REST API directly from Java code, if you prefer to do so.
 
-You can find the source code for the OpenMetadata libraries in the [GitHub repository](https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-clients). As an open-source project, contributions are always welcome!
+You can find the source code for the OpenMetadata libraries in the [GitHub repository](https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-sdk). As an open-source project, contributions are always welcome!
 
-You can add the below Maven Dependency for OpenMetadata Java Client.
+You can add the below Maven Dependency for the OpenMetadata Java SDK.
 
 ```xml
 <dependency>
   <groupId>org.open-metadata</groupId>
-  <artifactId>openmetadata-java-client</artifactId>
-  <version>0.11.1</version>
+  <artifactId>openmetadata-sdk</artifactId>
+  <version>1.13.1</version>
 </dependency>
 ```
 
@@ -51,8 +51,8 @@ using the following piece of code.
 OpenMetadata openMetadataGateway = new OpenMetadata(server);
 ```
 
-## Use Java Client without Authentication
-To use Java Client without any authentication, you can use `NoOpAuthenticationProvider.java`. \
+## Use Java SDK without Authentication
+To use the Java SDK without any authentication, you can use `NoOpAuthenticationProvider.java`. \
 
 ```java
 NoOpAuthenticationProvider noOpAuthenticationProvider = new NoOpAuthenticationProvider();
@@ -64,7 +64,7 @@ Establish the [OpenMetadata Server Connection](#establish-openmetadata-server-co
 server.setAuthProvider(OpenMetadataServerConnection.AuthProvider.NO_AUTH);
 ```
 
-## Use Java Client with Authentication.
+## Use Java SDK with Authentication.
 
 The OpenMetadata Java SDK supports several auth providers:
 * [Google](#google)
@@ -186,7 +186,7 @@ server.setAuthProvider(OpenMetadataServerConnection.AuthProvider.CUSTOM_OIDC);
 server.setSecurityConfig(customOIDCSSOClientConfig);
 ```
 
-## How to Use APIs Using the Java Client
+## How to Use APIs Using the Java SDK
 You can use an API from the [OpenMetadata Gateway](#create-openmetadata-gateway).
 Using OpenMetadata Gateway, you will need to build the client by providing the `class` of the respected API.
 Below are some examples:

--- a/v1.13.x/api-reference/sdk/java/info.mdx
+++ b/v1.13.x/api-reference/sdk/java/info.mdx
@@ -17,8 +17,8 @@ Add the OpenMetadata Java SDK dependency to your `pom.xml`:
 ```xml
 <dependency>
     <groupId>org.open-metadata</groupId>
-    <artifactId>openmetadata-java-client</artifactId>
-    <version>1.9.0</version>
+    <artifactId>openmetadata-sdk</artifactId>
+    <version>1.13.1</version>
 </dependency>
 ```
 
@@ -27,7 +27,7 @@ Add the OpenMetadata Java SDK dependency to your `pom.xml`:
 Add the dependency to your `build.gradle`:
 
 ```gradle
-implementation 'org.open-metadata:openmetadata-java-client:1.9.0'
+implementation 'org.open-metadata:openmetadata-sdk:1.13.1'
 ```
 
 ## Quick Start

--- a/v1.13.x/sdk/java.mdx
+++ b/v1.13.x/sdk/java.mdx
@@ -11,15 +11,15 @@ We now present a high-level Java API as a type-safe and gentle wrapper for the O
 The open-source OpenMetadata SDK for Java simplifies provisioning, managing, and using OpenMetadata resources from the Java application code. \
 The OpenMetadata SDK for Java libraries build on top of the underlying OpenMetadata REST API, allows you to use those APIs through familiar Java paradigms. However, you can always use the REST API directly from Java code, if you prefer to do so.
 
-You can find the source code for the OpenMetadata libraries in the [GitHub repository](https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-clients). As an open-source project, contributions are always welcome!
+You can find the source code for the OpenMetadata libraries in the [GitHub repository](https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-sdk). As an open-source project, contributions are always welcome!
 
-You can add the below Maven Dependency for OpenMetadata Java Client.
+You can add the below Maven Dependency for the OpenMetadata Java SDK.
 
 ```xml
 <dependency>
   <groupId>org.open-metadata</groupId>
-  <artifactId>openmetadata-java-client</artifactId>
-  <version>0.11.1</version>
+  <artifactId>openmetadata-sdk</artifactId>
+  <version>1.13.1</version>
 </dependency>
 ```
 
@@ -51,8 +51,8 @@ using the following piece of code.
 OpenMetadata openMetadataGateway = new OpenMetadata(server);
 ```
 
-## Use Java Client without Authentication
-To use Java Client without any authentication, you can use `NoOpAuthenticationProvider.java`. \
+## Use Java SDK without Authentication
+To use the Java SDK without any authentication, you can use `NoOpAuthenticationProvider.java`. \
 
 ```java
 NoOpAuthenticationProvider noOpAuthenticationProvider = new NoOpAuthenticationProvider();
@@ -64,7 +64,7 @@ Establish the [OpenMetadata Server Connection](#establish-openmetadata-server-co
 server.setAuthProvider(OpenMetadataServerConnection.AuthProvider.NO_AUTH);
 ```
 
-## Use Java Client with Authentication.
+## Use Java SDK with Authentication.
 
 The OpenMetadata Java SDK supports several auth providers:
 * [Google](#google)
@@ -186,7 +186,7 @@ server.setAuthProvider(OpenMetadataServerConnection.AuthProvider.CUSTOM_OIDC);
 server.setSecurityConfig(customOIDCSSOClientConfig);
 ```
 
-## How to Use APIs Using the Java Client
+## How to Use APIs Using the Java SDK
 You can use an API from the [OpenMetadata Gateway](#create-openmetadata-gateway).
 Using OpenMetadata Gateway, you will need to build the client by providing the `class` of the respected API.
 Below are some examples:

--- a/v1.13.x/sdk/java/info.mdx
+++ b/v1.13.x/sdk/java/info.mdx
@@ -17,8 +17,8 @@ Add the OpenMetadata Java SDK dependency to your `pom.xml`:
 ```xml
 <dependency>
     <groupId>org.open-metadata</groupId>
-    <artifactId>openmetadata-java-client</artifactId>
-    <version>1.9.0</version>
+    <artifactId>openmetadata-sdk</artifactId>
+    <version>1.13.1</version>
 </dependency>
 ```
 
@@ -27,7 +27,7 @@ Add the OpenMetadata Java SDK dependency to your `pom.xml`:
 Add the dependency to your `build.gradle`:
 
 ```gradle
-implementation 'org.open-metadata:openmetadata-java-client:1.9.0'
+implementation 'org.open-metadata:openmetadata-sdk:1.13.1'
 ```
 
 ## Quick Start

--- a/v2.0.x-SNAPSHOT/api-reference.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference.mdx
@@ -31,7 +31,7 @@ Install an official SDK to interact with the OpenMetadata API in your preferred 
 <Tabs>
   <Tab title="Python">
     ```bash
-    pip install "openmetadata-ingestion~=1.11.9"
+    pip install "openmetadata-ingestion~=1.13.1"
     ```
 
     The Python SDK provides a high-level, type-safe API with built-in support for ingestion, lineage, and all entity operations.
@@ -40,8 +40,8 @@ Install an official SDK to interact with the OpenMetadata API in your preferred 
     ```xml
     <dependency>
       <groupId>org.open-metadata</groupId>
-      <artifactId>openmetadata-java-client</artifactId>
-      <version>1.11.9</version>
+      <artifactId>openmetadata-sdk</artifactId>
+      <version>1.13.1</version>
     </dependency>
     ```
 

--- a/v2.0.x-SNAPSHOT/api-reference/getting-started.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference/getting-started.mdx
@@ -52,14 +52,14 @@ Choose your preferred language and install the SDK:
 
 <CodeGroup>
 ```bash Python
-pip install "openmetadata-ingestion~=1.11.9"
+pip install "openmetadata-ingestion~=1.13.1"
 ```
 
 ```xml Java (Maven)
 <dependency>
   <groupId>org.open-metadata</groupId>
-  <artifactId>openmetadata-java-client</artifactId>
-  <version>1.11.9</version>
+  <artifactId>openmetadata-sdk</artifactId>
+  <version>1.13.1</version>
 </dependency>
 ```
 

--- a/v2.0.x-SNAPSHOT/api-reference/sdk/java.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference/sdk/java.mdx
@@ -11,15 +11,15 @@ We now present a high-level Java API as a type-safe and gentle wrapper for the O
 The open-source OpenMetadata SDK for Java simplifies provisioning, managing, and using OpenMetadata resources from the Java application code. \
 The OpenMetadata SDK for Java libraries build on top of the underlying OpenMetadata REST API, allows you to use those APIs through familiar Java paradigms. However, you can always use the REST API directly from Java code, if you prefer to do so.
 
-You can find the source code for the OpenMetadata libraries in the [GitHub repository](https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-clients). As an open-source project, contributions are always welcome!
+You can find the source code for the OpenMetadata libraries in the [GitHub repository](https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-sdk). As an open-source project, contributions are always welcome!
 
-You can add the below Maven Dependency for OpenMetadata Java Client.
+You can add the below Maven Dependency for the OpenMetadata Java SDK.
 
 ```xml
 <dependency>
   <groupId>org.open-metadata</groupId>
-  <artifactId>openmetadata-java-client</artifactId>
-  <version>0.11.1</version>
+  <artifactId>openmetadata-sdk</artifactId>
+  <version>1.13.1</version>
 </dependency>
 ```
 
@@ -51,8 +51,8 @@ using the following piece of code.
 OpenMetadata openMetadataGateway = new OpenMetadata(server);
 ```
 
-## Use Java Client without Authentication
-To use Java Client without any authentication, you can use `NoOpAuthenticationProvider.java`. \
+## Use Java SDK without Authentication
+To use the Java SDK without any authentication, you can use `NoOpAuthenticationProvider.java`. \
 
 ```java
 NoOpAuthenticationProvider noOpAuthenticationProvider = new NoOpAuthenticationProvider();
@@ -64,7 +64,7 @@ Establish the [OpenMetadata Server Connection](#establish-openmetadata-server-co
 server.setAuthProvider(OpenMetadataServerConnection.AuthProvider.NO_AUTH);
 ```
 
-## Use Java Client with Authentication.
+## Use Java SDK with Authentication.
 
 The OpenMetadata Java SDK supports several auth providers:
 * [Google](#google)
@@ -186,7 +186,7 @@ server.setAuthProvider(OpenMetadataServerConnection.AuthProvider.CUSTOM_OIDC);
 server.setSecurityConfig(customOIDCSSOClientConfig);
 ```
 
-## How to Use APIs Using the Java Client
+## How to Use APIs Using the Java SDK
 You can use an API from the [OpenMetadata Gateway](#create-openmetadata-gateway).
 Using OpenMetadata Gateway, you will need to build the client by providing the `class` of the respected API.
 Below are some examples:

--- a/v2.0.x-SNAPSHOT/api-reference/sdk/java/info.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference/sdk/java/info.mdx
@@ -17,8 +17,8 @@ Add the OpenMetadata Java SDK dependency to your `pom.xml`:
 ```xml
 <dependency>
     <groupId>org.open-metadata</groupId>
-    <artifactId>openmetadata-java-client</artifactId>
-    <version>1.9.0</version>
+    <artifactId>openmetadata-sdk</artifactId>
+    <version>1.13.1</version>
 </dependency>
 ```
 
@@ -27,7 +27,7 @@ Add the OpenMetadata Java SDK dependency to your `pom.xml`:
 Add the dependency to your `build.gradle`:
 
 ```gradle
-implementation 'org.open-metadata:openmetadata-java-client:1.9.0'
+implementation 'org.open-metadata:openmetadata-sdk:1.13.1'
 ```
 
 ## Quick Start

--- a/v2.0.x-SNAPSHOT/sdk/java.mdx
+++ b/v2.0.x-SNAPSHOT/sdk/java.mdx
@@ -11,15 +11,15 @@ We now present a high-level Java API as a type-safe and gentle wrapper for the O
 The open-source OpenMetadata SDK for Java simplifies provisioning, managing, and using OpenMetadata resources from the Java application code. \
 The OpenMetadata SDK for Java libraries build on top of the underlying OpenMetadata REST API, allows you to use those APIs through familiar Java paradigms. However, you can always use the REST API directly from Java code, if you prefer to do so.
 
-You can find the source code for the OpenMetadata libraries in the [GitHub repository](https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-clients). As an open-source project, contributions are always welcome!
+You can find the source code for the OpenMetadata libraries in the [GitHub repository](https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-sdk). As an open-source project, contributions are always welcome!
 
-You can add the below Maven Dependency for OpenMetadata Java Client.
+You can add the below Maven Dependency for the OpenMetadata Java SDK.
 
 ```xml
 <dependency>
   <groupId>org.open-metadata</groupId>
-  <artifactId>openmetadata-java-client</artifactId>
-  <version>0.11.1</version>
+  <artifactId>openmetadata-sdk</artifactId>
+  <version>1.13.1</version>
 </dependency>
 ```
 
@@ -51,8 +51,8 @@ using the following piece of code.
 OpenMetadata openMetadataGateway = new OpenMetadata(server);
 ```
 
-## Use Java Client without Authentication
-To use Java Client without any authentication, you can use `NoOpAuthenticationProvider.java`. \
+## Use Java SDK without Authentication
+To use the Java SDK without any authentication, you can use `NoOpAuthenticationProvider.java`. \
 
 ```java
 NoOpAuthenticationProvider noOpAuthenticationProvider = new NoOpAuthenticationProvider();
@@ -64,7 +64,7 @@ Establish the [OpenMetadata Server Connection](#establish-openmetadata-server-co
 server.setAuthProvider(OpenMetadataServerConnection.AuthProvider.NO_AUTH);
 ```
 
-## Use Java Client with Authentication.
+## Use Java SDK with Authentication.
 
 The OpenMetadata Java SDK supports several auth providers:
 * [Google](#google)
@@ -186,7 +186,7 @@ server.setAuthProvider(OpenMetadataServerConnection.AuthProvider.CUSTOM_OIDC);
 server.setSecurityConfig(customOIDCSSOClientConfig);
 ```
 
-## How to Use APIs Using the Java Client
+## How to Use APIs Using the Java SDK
 You can use an API from the [OpenMetadata Gateway](#create-openmetadata-gateway).
 Using OpenMetadata Gateway, you will need to build the client by providing the `class` of the respected API.
 Below are some examples:

--- a/v2.0.x-SNAPSHOT/sdk/java/info.mdx
+++ b/v2.0.x-SNAPSHOT/sdk/java/info.mdx
@@ -17,8 +17,8 @@ Add the OpenMetadata Java SDK dependency to your `pom.xml`:
 ```xml
 <dependency>
     <groupId>org.open-metadata</groupId>
-    <artifactId>openmetadata-java-client</artifactId>
-    <version>1.9.0</version>
+    <artifactId>openmetadata-sdk</artifactId>
+    <version>1.13.1</version>
 </dependency>
 ```
 
@@ -27,7 +27,7 @@ Add the OpenMetadata Java SDK dependency to your `pom.xml`:
 Add the dependency to your `build.gradle`:
 
 ```gradle
-implementation 'org.open-metadata:openmetadata-java-client:1.9.0'
+implementation 'org.open-metadata:openmetadata-sdk:1.13.1'
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- `openmetadata-java-client` is deprecated ( https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-sdk). Updated the artifact name, wording ("Java Client" -> "Java SDK"), and GitHub source link across all Client Libraries / SDK pages in v1.12.x, v1.13.x, and v2.0.x-SNAPSHOT.
- Version numbers were verified live against Maven Central (`repo1.maven.org`), not guessed: `1.12.13` for v1.12.x, `1.13.1` for v1.13.x/v2.0.x-SNAPSHOT — confirmed with `mvnrepository.com/artifact/org.open-metadata/openmetadata-sdk` (shared by Mohit Yadav) and cross-checked against the raw Maven Central repo listing.
<img width="2904" height="1534" alt="image" src="https://github.com/user-attachments/assets/cf26d57d-c3c6-48b3-95aa-5ab2caf29f7d" />

- Also bumped the stale `pip install "openmetadata-ingestion~=1.11.9"` on v1.13.x/v2.0.x-SNAPSHOT to `~=1.13.1`, verified against PyPI (`pypi.org/pypi/openmetadata-ingestion/json`), matching v1.12.x's already-correct `~=1.12.1` pin.

## Test plan
- [x] Verified every changed version number against its live source (Maven Central raw repo listing, PyPI JSON API) rather than assuming.
- [x] Confirmed no other pages link to the renamed section anchors before rewording headings.
- [ ] Visual check in `mint dev` that the Client Libraries / Java SDK pages render correctly across all 3 versions.
