### PR TITLE
Docs: Add Entity Mapping section for PowerBI and Looker connectors

### DIFF
--- a/v1.12.x/connectors/dashboard/looker.mdx
+++ b/v1.12.x/connectors/dashboard/looker.mdx
@@ -14,12 +14,13 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
   icon='/public/images/connectors/looker.webp'
 name="Looker"
   stage="PROD"
-availableFeatures={["Dashboards", "Charts", "Owners", "Datamodels", "Lineage", "Usage"]}
-  unavailableFeatures={["Tags", "Projects"]}
+availableFeatures={["Dashboards", "Charts", "Owners", "Datamodels", "Projects", "Lineage", "Usage"]}
+  unavailableFeatures={["Tags"]}
 />
 In this section, we provide guides and references to use the Looker connector.
 Configure and schedule Looker metadata and profiler workflows from the OpenMetadata UI:
 - [Requirements](#requirements)
+- [Entity Mapping](#entity-mapping)
 - [Metadata Ingestion](#metadata-ingestion)
 - [Lineage](#lineage)
 - [Troubleshooting](/v1.12.x/connectors/dashboard/looker/troubleshooting)
@@ -41,6 +42,38 @@ out of LookML Views, including their lineage to the source databases.
 Moreover, Looker lineage only supports LookML views configured with `sql_table_name` and `derived_table` in plain SQL.
 We do not yet support liquid variables.
 </Tip>
+## Entity Mapping
+The Looker connector maps Looker assets to OpenMetadata entities as follows:
+| Looker Asset | OpenMetadata Entity | Description |
+|---|---|---|
+| **Dashboards** | **Dashboard** | Looker dashboards are mapped to OpenMetadata Dashboard entities. |
+| **Dashboard Elements** (tiles) | **Chart** | Visualization tiles within a Looker dashboard are mapped to OpenMetadata Chart entities. |
+| **Explores** and **Views** (LookML) | **Data Models** | LookML Explores and Views are mapped to OpenMetadata Data Model entities. |
+| **Folders** (Dashboards) / **LookML Projects** (Explores & Views) | **Project field** | The project field means something different depending on the entity: for a Dashboard it stores the Looker folder name, while for an Explore or View it stores the LookML project (Git repository) it belongs to. |
+### Example Structure
+**Looker Structure:**
+```
+Folder: Sales Team
+└── Dashboard: Revenue Overview
+    ├── Tile: Monthly Revenue
+    └── Tile: Regional Breakdown
+LookML Project: sales_analytics
+├── Explore: revenue
+└── View: orders
+```
+**OpenMetadata Structure:**
+```
+Dashboard: "Revenue Overview" (Project: "Sales Team")
+├── Chart: "Monthly Revenue"
+└── Chart: "Regional Breakdown"
+Data Model: "revenue" (Project: "sales_analytics")
+Data Model: "orders" (Project: "sales_analytics")
+```
+This mapping ensures that:
+- Looker dashboards appear as OpenMetadata dashboards, organized by their Looker folder
+- Dashboard tiles appear as charts underneath their dashboard
+- LookML Explores and Views appear as data models, organized by their LookML project
+- The project field is sourced differently depending on entity type: a Looker folder for Dashboards, a LookML project for Data Models
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"Looker"} selectServicePath={"/public/images/connectors/looker/select-service.png"} addNewServicePath={"/public/images/connectors/looker/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/looker/service-connection.png"} />
 # Connection Details

--- a/v1.12.x/connectors/dashboard/looker/yaml.mdx
+++ b/v1.12.x/connectors/dashboard/looker/yaml.mdx
@@ -20,8 +20,8 @@ import ExternalIngestionDeployment from '/snippets/v1.12.x/connectors/external-i
   icon='/public/images/connectors/looker.webp'
 name="Looker"
   stage="PROD"
-availableFeatures={["Dashboards", "Charts", "Owners", "Datamodels", "Lineage", "Usage"]}
-  unavailableFeatures={["Tags", "Projects"]}
+availableFeatures={["Dashboards", "Charts", "Owners", "Datamodels", "Projects", "Lineage", "Usage"]}
+  unavailableFeatures={["Tags"]}
 />
 In this section, we provide guides and references to use the Looker connector.
 Configure and schedule Looker metadata and profiler workflows from the OpenMetadata UI:

--- a/v1.12.x/connectors/dashboard/powerbi.mdx
+++ b/v1.12.x/connectors/dashboard/powerbi.mdx
@@ -24,6 +24,7 @@ In this section, we provide guides and references to use the PowerBI connector.
 </Info>
 Configure and schedule PowerBI metadata and profiler workflows from the OpenMetadata UI:
 - [Requirements](#requirements)
+- [Entity Mapping](#entity-mapping)
 - [Metadata Ingestion](#metadata-ingestion)
 - [Lineage](#lineage)
 - [Troubleshooting](/v1.12.x/connectors/dashboard/powerbi/troubleshooting)
@@ -78,6 +79,37 @@ Please refer [here](https://stackoverflow.com/questions/71001110/power-bi-rest-a
 The service principal does not take into account the default user workspaces e.g `My Workspace`.
 Create new workspaces in PowerBI by following the document [here](https://docs.microsoft.com/en-us/power-bi/collaborate-share/service-create-the-new-workspaces)
 For reference here is a [thread](https://community.powerbi.com/t5/Service/Error-while-executing-Get-dataset-call-quot-API-is-not/m-p/912360#M85711) referring to the same
+## Entity Mapping
+The PowerBI connector maps PowerBI assets to OpenMetadata entities as follows:
+| PowerBI Asset | OpenMetadata Entity | Description |
+|---|---|---|
+| **Dashboards** and **Reports** | **Dashboard** | Both PowerBI Dashboards (tile-based) and Reports are mapped to OpenMetadata Dashboard entities. |
+| **Tiles** (within a Dashboard) | **Chart** | Tiles on a PowerBI Dashboard are mapped to OpenMetadata Chart entities. Report pages do not generate separate Chart entities. |
+| **Datasets, Dataflows, Datamarts** | **Data Models** | PowerBI datasets, dataflows, and datamarts are mapped to OpenMetadata Data Model entities. |
+| **Workspaces** | **Project field** | The PowerBI workspace name is stored in the project field of the Dashboard and Data Model entities. |
+### Example Structure
+**PowerBI Structure:**
+```
+Workspace: Sales Team
+├── Dashboard: Revenue Overview
+│   ├── Tile: Monthly Revenue
+│   └── Tile: Regional Breakdown
+├── Report: Sales Trends
+└── Dataset: Sales Data Model
+```
+**OpenMetadata Structure:**
+```
+Dashboard: "Revenue Overview" (Project: "Sales Team")
+├── Chart: "Monthly Revenue"
+└── Chart: "Regional Breakdown"
+Dashboard: "Sales Trends" (Project: "Sales Team")
+Data Model: "Sales Data Model" (Project: "Sales Team")
+```
+This mapping ensures that:
+- PowerBI dashboards and reports both appear as OpenMetadata dashboards
+- Tiles on a dashboard appear as charts underneath it
+- Datasets, dataflows, and datamarts appear as data models
+- PowerBI workspace names are preserved in the project field
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"PowerBI"} selectServicePath={"/public/images/connectors/powerbi/select-service.png"} addNewServicePath={"/public/images/connectors/powerbi/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/powerbi/service-connection.png"} />
 # Connection Details

--- a/v1.13.x/connectors/dashboard/looker.mdx
+++ b/v1.13.x/connectors/dashboard/looker.mdx
@@ -14,12 +14,13 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
   icon='/public/images/connectors/looker.webp'
 name="Looker"
   stage="PROD"
-availableFeatures={["Dashboards", "Charts", "Owners", "Datamodels", "Lineage", "Usage"]}
-  unavailableFeatures={["Tags", "Projects"]}
+availableFeatures={["Dashboards", "Charts", "Owners", "Datamodels", "Projects", "Lineage", "Usage"]}
+  unavailableFeatures={["Tags"]}
 />
 In this section, we provide guides and references to use the Looker connector.
 Configure and schedule Looker metadata and profiler workflows from the OpenMetadata UI:
 - [Requirements](#requirements)
+- [Entity Mapping](#entity-mapping)
 - [Metadata Ingestion](#metadata-ingestion)
 - [Lineage](#lineage)
 - [Troubleshooting](/v1.13.x/connectors/dashboard/looker/troubleshooting)
@@ -41,6 +42,38 @@ out of LookML Views, including their lineage to the source databases.
 Moreover, Looker lineage only supports LookML views configured with `sql_table_name` and `derived_table` in plain SQL.
 We do not yet support liquid variables.
 </Tip>
+## Entity Mapping
+The Looker connector maps Looker assets to OpenMetadata entities as follows:
+| Looker Asset | OpenMetadata Entity | Description |
+|---|---|---|
+| **Dashboards** | **Dashboard** | Looker dashboards are mapped to OpenMetadata Dashboard entities. |
+| **Dashboard Elements** (tiles) | **Chart** | Visualization tiles within a Looker dashboard are mapped to OpenMetadata Chart entities. |
+| **Explores** and **Views** (LookML) | **Data Models** | LookML Explores and Views are mapped to OpenMetadata Data Model entities. |
+| **Folders** (Dashboards) / **LookML Projects** (Explores & Views) | **Project field** | The project field means something different depending on the entity: for a Dashboard it stores the Looker folder name, while for an Explore or View it stores the LookML project (Git repository) it belongs to. |
+### Example Structure
+**Looker Structure:**
+```
+Folder: Sales Team
+└── Dashboard: Revenue Overview
+    ├── Tile: Monthly Revenue
+    └── Tile: Regional Breakdown
+LookML Project: sales_analytics
+├── Explore: revenue
+└── View: orders
+```
+**OpenMetadata Structure:**
+```
+Dashboard: "Revenue Overview" (Project: "Sales Team")
+├── Chart: "Monthly Revenue"
+└── Chart: "Regional Breakdown"
+Data Model: "revenue" (Project: "sales_analytics")
+Data Model: "orders" (Project: "sales_analytics")
+```
+This mapping ensures that:
+- Looker dashboards appear as OpenMetadata dashboards, organized by their Looker folder
+- Dashboard tiles appear as charts underneath their dashboard
+- LookML Explores and Views appear as data models, organized by their LookML project
+- The project field is sourced differently depending on entity type: a Looker folder for Dashboards, a LookML project for Data Models
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"Looker"} selectServicePath={"/public/images/connectors/looker/select-service.png"} addNewServicePath={"/public/images/connectors/looker/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/looker/service-connection.png"} />
 # Connection Details

--- a/v1.13.x/connectors/dashboard/looker/yaml.mdx
+++ b/v1.13.x/connectors/dashboard/looker/yaml.mdx
@@ -20,8 +20,8 @@ import ExternalIngestionDeployment from '/snippets/v1.13.x/connectors/external-i
   icon='/public/images/connectors/looker.webp'
 name="Looker"
   stage="PROD"
-availableFeatures={["Dashboards", "Charts", "Owners", "Datamodels", "Lineage", "Usage"]}
-  unavailableFeatures={["Tags", "Projects"]}
+availableFeatures={["Dashboards", "Charts", "Owners", "Datamodels", "Projects", "Lineage", "Usage"]}
+  unavailableFeatures={["Tags"]}
 />
 In this section, we provide guides and references to use the Looker connector.
 Configure and schedule Looker metadata and profiler workflows from the OpenMetadata UI:

--- a/v1.13.x/connectors/dashboard/powerbi.mdx
+++ b/v1.13.x/connectors/dashboard/powerbi.mdx
@@ -24,6 +24,7 @@ In this section, we provide guides and references to use the PowerBI connector.
 </Info>
 Configure and schedule PowerBI metadata and profiler workflows from the OpenMetadata UI:
 - [Requirements](#requirements)
+- [Entity Mapping](#entity-mapping)
 - [Metadata Ingestion](#metadata-ingestion)
 - [Lineage](#lineage)
 - [Troubleshooting](/v1.13.x/connectors/dashboard/powerbi/troubleshooting)
@@ -78,6 +79,37 @@ Please refer [here](https://stackoverflow.com/questions/71001110/power-bi-rest-a
 The service principal does not take into account the default user workspaces e.g `My Workspace`.
 Create new workspaces in PowerBI by following the document [here](https://docs.microsoft.com/en-us/power-bi/collaborate-share/service-create-the-new-workspaces)
 For reference here is a [thread](https://community.powerbi.com/t5/Service/Error-while-executing-Get-dataset-call-quot-API-is-not/m-p/912360#M85711) referring to the same
+## Entity Mapping
+The PowerBI connector maps PowerBI assets to OpenMetadata entities as follows:
+| PowerBI Asset | OpenMetadata Entity | Description |
+|---|---|---|
+| **Dashboards** and **Reports** | **Dashboard** | Both PowerBI Dashboards (tile-based) and Reports are mapped to OpenMetadata Dashboard entities. |
+| **Tiles** (within a Dashboard) | **Chart** | Tiles on a PowerBI Dashboard are mapped to OpenMetadata Chart entities. Report pages do not generate separate Chart entities. |
+| **Datasets, Dataflows, Datamarts** | **Data Models** | PowerBI datasets, dataflows, and datamarts are mapped to OpenMetadata Data Model entities. |
+| **Workspaces** | **Project field** | The PowerBI workspace name is stored in the project field of the Dashboard and Data Model entities. |
+### Example Structure
+**PowerBI Structure:**
+```
+Workspace: Sales Team
+├── Dashboard: Revenue Overview
+│   ├── Tile: Monthly Revenue
+│   └── Tile: Regional Breakdown
+├── Report: Sales Trends
+└── Dataset: Sales Data Model
+```
+**OpenMetadata Structure:**
+```
+Dashboard: "Revenue Overview" (Project: "Sales Team")
+├── Chart: "Monthly Revenue"
+└── Chart: "Regional Breakdown"
+Dashboard: "Sales Trends" (Project: "Sales Team")
+Data Model: "Sales Data Model" (Project: "Sales Team")
+```
+This mapping ensures that:
+- PowerBI dashboards and reports both appear as OpenMetadata dashboards
+- Tiles on a dashboard appear as charts underneath it
+- Datasets, dataflows, and datamarts appear as data models
+- PowerBI workspace names are preserved in the project field
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"PowerBI"} selectServicePath={"/public/images/connectors/powerbi/select-service.png"} addNewServicePath={"/public/images/connectors/powerbi/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/powerbi/service-connection.png"} />
 # Connection Details

--- a/v2.0.x-SNAPSHOT/connectors/dashboard/looker.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/dashboard/looker.mdx
@@ -14,12 +14,13 @@ import { MetadataIngestionUi } from '/snippets/components/MetadataIngestionUi.js
   icon='/public/images/connectors/looker.webp'
 name="Looker"
   stage="PROD"
-availableFeatures={["Dashboards", "Charts", "Owners", "Datamodels", "Lineage", "Usage"]}
-  unavailableFeatures={["Tags", "Projects"]}
+availableFeatures={["Dashboards", "Charts", "Owners", "Datamodels", "Projects", "Lineage", "Usage"]}
+  unavailableFeatures={["Tags"]}
 />
 In this section, we provide guides and references to use the Looker connector.
 Configure and schedule Looker metadata and profiler workflows from the OpenMetadata UI:
 - [Requirements](#requirements)
+- [Entity Mapping](#entity-mapping)
 - [Metadata Ingestion](#metadata-ingestion)
 - [Lineage](#lineage)
 - [Troubleshooting](/v2.0.x-SNAPSHOT/connectors/dashboard/looker/troubleshooting)
@@ -41,6 +42,38 @@ out of LookML Views, including their lineage to the source databases.
 Moreover, Looker lineage only supports LookML views configured with `sql_table_name` and `derived_table` in plain SQL.
 We do not yet support liquid variables.
 </Tip>
+## Entity Mapping
+The Looker connector maps Looker assets to OpenMetadata entities as follows:
+| Looker Asset | OpenMetadata Entity | Description |
+|---|---|---|
+| **Dashboards** | **Dashboard** | Looker dashboards are mapped to OpenMetadata Dashboard entities. |
+| **Dashboard Elements** (tiles) | **Chart** | Visualization tiles within a Looker dashboard are mapped to OpenMetadata Chart entities. |
+| **Explores** and **Views** (LookML) | **Data Models** | LookML Explores and Views are mapped to OpenMetadata Data Model entities. |
+| **Folders** (Dashboards) / **LookML Projects** (Explores & Views) | **Project field** | The project field means something different depending on the entity: for a Dashboard it stores the Looker folder name, while for an Explore or View it stores the LookML project (Git repository) it belongs to. |
+### Example Structure
+**Looker Structure:**
+```
+Folder: Sales Team
+└── Dashboard: Revenue Overview
+    ├── Tile: Monthly Revenue
+    └── Tile: Regional Breakdown
+LookML Project: sales_analytics
+├── Explore: revenue
+└── View: orders
+```
+**OpenMetadata Structure:**
+```
+Dashboard: "Revenue Overview" (Project: "Sales Team")
+├── Chart: "Monthly Revenue"
+└── Chart: "Regional Breakdown"
+Data Model: "revenue" (Project: "sales_analytics")
+Data Model: "orders" (Project: "sales_analytics")
+```
+This mapping ensures that:
+- Looker dashboards appear as OpenMetadata dashboards, organized by their Looker folder
+- Dashboard tiles appear as charts underneath their dashboard
+- LookML Explores and Views appear as data models, organized by their LookML project
+- The project field is sourced differently depending on entity type: a Looker folder for Dashboards, a LookML project for Data Models
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"Looker"} selectServicePath={"/public/images/connectors/looker/select-service.png"} addNewServicePath={"/public/images/connectors/looker/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/looker/service-connection.png"} />
 # Connection Details

--- a/v2.0.x-SNAPSHOT/connectors/dashboard/looker/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/dashboard/looker/yaml.mdx
@@ -20,8 +20,8 @@ import ExternalIngestionDeployment from '/snippets/v2.0.x-SNAPSHOT/connectors/ex
   icon='/public/images/connectors/looker.webp'
 name="Looker"
   stage="PROD"
-availableFeatures={["Dashboards", "Charts", "Owners", "Datamodels", "Lineage", "Usage"]}
-  unavailableFeatures={["Tags", "Projects"]}
+availableFeatures={["Dashboards", "Charts", "Owners", "Datamodels", "Projects", "Lineage", "Usage"]}
+  unavailableFeatures={["Tags"]}
 />
 In this section, we provide guides and references to use the Looker connector.
 Configure and schedule Looker metadata and profiler workflows from the OpenMetadata UI:

--- a/v2.0.x-SNAPSHOT/connectors/dashboard/powerbi.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/dashboard/powerbi.mdx
@@ -24,6 +24,7 @@ In this section, we provide guides and references to use the PowerBI connector.
 </Info>
 Configure and schedule PowerBI metadata and profiler workflows from the OpenMetadata UI:
 - [Requirements](#requirements)
+- [Entity Mapping](#entity-mapping)
 - [Metadata Ingestion](#metadata-ingestion)
 - [Lineage](#lineage)
 - [Troubleshooting](/v2.0.x-SNAPSHOT/connectors/dashboard/powerbi/troubleshooting)
@@ -78,6 +79,37 @@ Please refer [here](https://stackoverflow.com/questions/71001110/power-bi-rest-a
 The service principal does not take into account the default user workspaces e.g `My Workspace`.
 Create new workspaces in PowerBI by following the document [here](https://docs.microsoft.com/en-us/power-bi/collaborate-share/service-create-the-new-workspaces)
 For reference here is a [thread](https://community.powerbi.com/t5/Service/Error-while-executing-Get-dataset-call-quot-API-is-not/m-p/912360#M85711) referring to the same
+## Entity Mapping
+The PowerBI connector maps PowerBI assets to OpenMetadata entities as follows:
+| PowerBI Asset | OpenMetadata Entity | Description |
+|---|---|---|
+| **Dashboards** and **Reports** | **Dashboard** | Both PowerBI Dashboards (tile-based) and Reports are mapped to OpenMetadata Dashboard entities. |
+| **Tiles** (within a Dashboard) | **Chart** | Tiles on a PowerBI Dashboard are mapped to OpenMetadata Chart entities. Report pages do not generate separate Chart entities. |
+| **Datasets, Dataflows, Datamarts** | **Data Models** | PowerBI datasets, dataflows, and datamarts are mapped to OpenMetadata Data Model entities. |
+| **Workspaces** | **Project field** | The PowerBI workspace name is stored in the project field of the Dashboard and Data Model entities. |
+### Example Structure
+**PowerBI Structure:**
+```
+Workspace: Sales Team
+├── Dashboard: Revenue Overview
+│   ├── Tile: Monthly Revenue
+│   └── Tile: Regional Breakdown
+├── Report: Sales Trends
+└── Dataset: Sales Data Model
+```
+**OpenMetadata Structure:**
+```
+Dashboard: "Revenue Overview" (Project: "Sales Team")
+├── Chart: "Monthly Revenue"
+└── Chart: "Regional Breakdown"
+Dashboard: "Sales Trends" (Project: "Sales Team")
+Data Model: "Sales Data Model" (Project: "Sales Team")
+```
+This mapping ensures that:
+- PowerBI dashboards and reports both appear as OpenMetadata dashboards
+- Tiles on a dashboard appear as charts underneath it
+- Datasets, dataflows, and datamarts appear as data models
+- PowerBI workspace names are preserved in the project field
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"PowerBI"} selectServicePath={"/public/images/connectors/powerbi/select-service.png"} addNewServicePath={"/public/images/connectors/powerbi/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/powerbi/service-connection.png"} />
 # Connection Details


### PR DESCRIPTION
## Summary
- Extends the Tableau Entity Mapping pattern  to PowerBI and Looker.
- Mappings verified against the ingestion source code (`dashboard/powerbi/metadata.py` and `dashboard/looker/metadata.py`) rather than assumed:
  - **PowerBI**: Dashboards and Reports -> Dashboard entity; Tiles -> Chart entity (Report pages generate no charts); Datasets/Dataflows/Datamarts -> Data Model entity; Workspace name -> project field.
<img width="2948" height="1654" alt="image" src="https://github.com/user-attachments/assets/31f39f59-89f6-4436-a5d1-517777e72b11" />

  - **Looker**: Dashboards -> Dashboard entity; Dashboard Elements -> Chart entity; Explores and Views -> Data Model entity; the project field is sourced differently per entity (Looker folder for Dashboards, LookML project for Explores/Views).
  - <img width="2962" height="1596" alt="image" src="https://github.com/user-attachments/assets/330f5f8b-c6ca-4e7a-896f-53bbe503b668" />
 
- Also fixes a related inaccuracy: Looker's `ConnectorDetailsHeader` listed `Projects` as an unavailable feature even though the source code populates the project field — moved to available features on both the main page and `yaml.mdx`.
- Applies to all 3 doc versions: v1.12.x, v1.13.x, v2.0.x-SNAPSHOT.

## Test plan
- [x] Verified entity mappings against the actual ingestion connector source, not guessed.
- [x] Confirmed `availableFeatures`/`unavailableFeatures` stay consistent between Looker's main page and `yaml.mdx` per repo convention.
- [ ] Visual check in `mint dev` that the new Entity Mapping tables and TOC links render correctly.


