### PR TITLE
Docs: Add Bots admin-only note across all JWT token walkthroughs

### DIFF
--- a/snippets/deployment/bots-tile-admin-note.mdx
+++ b/snippets/deployment/bots-tile-admin-note.mdx
@@ -1,0 +1,3 @@
+<Note>
+**Note**: The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
+</Note>

--- a/v1.12.x/api-reference.mdx
+++ b/v1.12.x/api-reference.mdx
@@ -106,9 +106,9 @@ Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
 ```
 </CodeGroup>
 
-You can obtain a token through **Bot Tokens** (for service accounts via **Settings > Bots**) or **Personal Access Tokens** (via your **Profile > Access Tokens**).
-
 <BotsTileAdminNote />
+
+You can obtain a token through **Bot Tokens** (for service accounts via **Settings > Bots**) or **Personal Access Tokens** (via your **Profile > Access Tokens**).
 
 <Card title="Authentication Guide" icon="key" href="/v1.12.x/api-reference/authentication">
   Learn more about authentication methods, token management, and security configuration.

--- a/v1.12.x/api-reference.mdx
+++ b/v1.12.x/api-reference.mdx
@@ -3,6 +3,7 @@ title: OpenMetadata SDKs & APIs
 description: Programmatic access to your OpenMetadata data catalog through REST APIs and native SDKs
 sidebarTitle: Introduction
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # OpenMetadata SDKs & APIs
 
@@ -106,6 +107,8 @@ Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
 </CodeGroup>
 
 You can obtain a token through **Bot Tokens** (for service accounts via **Settings > Bots**) or **Personal Access Tokens** (via your **Profile > Access Tokens**).
+
+<BotsTileAdminNote />
 
 <Card title="Authentication Guide" icon="key" href="/v1.12.x/api-reference/authentication">
   Learn more about authentication methods, token management, and security configuration.

--- a/v1.12.x/api-reference/authentication.mdx
+++ b/v1.12.x/api-reference/authentication.mdx
@@ -3,6 +3,7 @@ title: Authentication
 description: Authenticate your API requests using JWT Bearer tokens
 sidebarTitle: Authentication
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # Authentication
 
@@ -16,9 +17,7 @@ There are two ways to obtain an API token:
 
 Bot tokens are ideal for service accounts, CI/CD pipelines, and automated integrations.
 
-<Note>
-**Note**: The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
-</Note>
+<BotsTileAdminNote />
 
 1. Navigate to **Settings > Bots** in the OpenMetadata UI
 2. Click **Add Bot** or select an existing bot

--- a/v1.12.x/api-reference/authentication.mdx
+++ b/v1.12.x/api-reference/authentication.mdx
@@ -16,6 +16,10 @@ There are two ways to obtain an API token:
 
 Bot tokens are ideal for service accounts, CI/CD pipelines, and automated integrations.
 
+<Note>
+The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
+</Note>
+
 1. Navigate to **Settings > Bots** in the OpenMetadata UI
 2. Click **Add Bot** or select an existing bot
 3. Under **Token**, click **Generate Token**

--- a/v1.12.x/api-reference/authentication.mdx
+++ b/v1.12.x/api-reference/authentication.mdx
@@ -17,7 +17,7 @@ There are two ways to obtain an API token:
 Bot tokens are ideal for service accounts, CI/CD pipelines, and automated integrations.
 
 <Note>
-The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
+**Note**: The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
 </Note>
 
 1. Navigate to **Settings > Bots** in the OpenMetadata UI

--- a/v1.12.x/api-reference/getting-started.mdx
+++ b/v1.12.x/api-reference/getting-started.mdx
@@ -3,6 +3,7 @@ title: Getting Started
 description: Set up your environment and make your first API call in minutes
 sidebarTitle: Getting Started
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # Getting Started
 
@@ -25,6 +26,8 @@ You need a JWT token to authenticate API requests. There are two ways to get one
 1. Navigate to **Settings > Bots** in the OpenMetadata UI
 2. Click on the **ingestion-bot** (or create a new bot for your use case)
 3. Copy the JWT token from the bot details page
+
+<BotsTileAdminNote />
 
 <img src="/public/images/apis/bots/bots.png" alt="Navigate to Settings > Bots to find available bots" />
 

--- a/v1.12.x/api-reference/getting-started.mdx
+++ b/v1.12.x/api-reference/getting-started.mdx
@@ -23,11 +23,11 @@ You need a JWT token to authenticate API requests. There are two ways to get one
 
 **Bot Token** (recommended for automation)
 
+<BotsTileAdminNote />
+
 1. Navigate to **Settings > Bots** in the OpenMetadata UI
 2. Click on the **ingestion-bot** (or create a new bot for your use case)
 3. Copy the JWT token from the bot details page
-
-<BotsTileAdminNote />
 
 <img src="/public/images/apis/bots/bots.png" alt="Navigate to Settings > Bots to find available bots" />
 

--- a/v1.12.x/api-reference/sdk.mdx
+++ b/v1.12.x/api-reference/sdk.mdx
@@ -3,6 +3,7 @@ title: OpenMetadata SDK | OpenMetadata Software Development Kit
 description: Connect Sdk to enable streamlined access, monitoring, or search of enterprise data using secure and scalable integrations.
 sidebarTitle: Overview
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # SDK & API
 
@@ -29,6 +30,8 @@ Access the OpenAPI (Swagger) documentation at [OpenMetadata API](https://docs.op
 ## How to get the JWT Token
 
 ### Bot Token
+
+<BotsTileAdminNote />
 
 1. Go to the settings page from the navbar and then scroll down to the Integrations Section. Click on the Bots and you will see the list of bots, then click on the ingestion-bot. <img src="/public/images/apis/bots/bots.png" alt="bot-list" />
 

--- a/v1.12.x/api-reference/sdk/ai-sdk.mdx
+++ b/v1.12.x/api-reference/sdk/ai-sdk.mdx
@@ -3,6 +3,7 @@ title: AI SDK
 description: Connect any LLM to your metadata catalog with OpenMetadata's MCP tools. Available across Python, TypeScript, and Java.
 sidebarTitle: AI SDK
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # AI SDK
 
@@ -41,6 +42,8 @@ You need:
 2. **A Bot JWT token** for API authentication
 
 To get a JWT token, go to **Settings > Bots** in your OpenMetadata instance, select your bot, and copy the token.
+
+<BotsTileAdminNote />
 
 ## Configuration
 

--- a/v1.12.x/api-reference/sdk/ai-sdk.mdx
+++ b/v1.12.x/api-reference/sdk/ai-sdk.mdx
@@ -41,9 +41,9 @@ You need:
 1. **An OpenMetadata instance** (self-hosted or [Collate](https://www.getcollate.io))
 2. **A Bot JWT token** for API authentication
 
-To get a JWT token, go to **Settings > Bots** in your OpenMetadata instance, select your bot, and copy the token.
-
 <BotsTileAdminNote />
+
+To get a JWT token, go to **Settings > Bots** in your OpenMetadata instance, select your bot, and copy the token.
 
 ## Configuration
 

--- a/v1.12.x/deployment/security/enable-jwt-tokens.mdx
+++ b/v1.12.x/deployment/security/enable-jwt-tokens.mdx
@@ -4,6 +4,7 @@ description: Enable JWT-based security for user authentication, session manageme
 sidebarTitle: Enable jwt tokens
 collate: false
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # Enable JWT Tokens
 
@@ -104,6 +105,8 @@ wget -O - {your domain}/api/v1/system/config/jwks
 ## Generate Token
 
 Once the above configuration is updated, the server is restarted. Admin can go to Settings -> Bots page.
+
+<BotsTileAdminNote />
 
 <img src="/public/images/deployment/security/enable-jwt/settings-bot.png" alt="Settings Page" />
 

--- a/v1.12.x/deployment/security/enable-jwt-tokens.mdx
+++ b/v1.12.x/deployment/security/enable-jwt-tokens.mdx
@@ -104,9 +104,9 @@ wget -O - {your domain}/api/v1/system/config/jwks
 
 ## Generate Token
 
-Once the above configuration is updated, the server is restarted. Admin can go to Settings -> Bots page.
-
 <BotsTileAdminNote />
+
+Once the above configuration is updated, the server is restarted. Admin can go to Settings -> Bots page.
 
 <img src="/public/images/deployment/security/enable-jwt/settings-bot.png" alt="Settings Page" />
 

--- a/v1.12.x/deployment/security/jwt-troubleshooting.mdx
+++ b/v1.12.x/deployment/security/jwt-troubleshooting.mdx
@@ -4,6 +4,8 @@ description: Fix JWT-based authentication issues with deployment and ingestion b
 sidebarTitle: Jwt troubleshooting
 collate: false
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
+
 # JWT Troubleshooting
 
 Add the `{domain}:{port}/api/v1/sytem/config/jwks` in the list of publicKeys
@@ -31,6 +33,8 @@ When the ingestion workflow uses this token, we use `rsapublicKeyPath` to decryp
 ## Get JWT token from UI.
 
 First Open Open-Metadata UI than go to settings > Bots > Ingestion Bot
+
+<BotsTileAdminNote />
 
 <img src="/public/images/deployment/troubleshoot/jwt-token.png" alt="jwt-token" />
 

--- a/v1.12.x/deployment/security/jwt-troubleshooting.mdx
+++ b/v1.12.x/deployment/security/jwt-troubleshooting.mdx
@@ -32,9 +32,9 @@ When the ingestion workflow uses this token, we use `rsapublicKeyPath` to decryp
 
 ## Get JWT token from UI.
 
-First Open Open-Metadata UI than go to settings > Bots > Ingestion Bot
-
 <BotsTileAdminNote />
+
+First Open Open-Metadata UI than go to settings > Bots > Ingestion Bot
 
 <img src="/public/images/deployment/troubleshoot/jwt-token.png" alt="jwt-token" />
 

--- a/v1.12.x/developers/bots.mdx
+++ b/v1.12.x/developers/bots.mdx
@@ -3,14 +3,13 @@ title: How to Set Up Bots | OpenMetadata Developer Guide
 description: Create and manage bots for task automation, data notifications, and metadata workflows.
 sidebarTitle: Bots
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # How to Set Up Bots
 
 The default account for any ingestion pipeline deployed from the UI is `ingestion-bot`. To configure `ingestion-bot` from the UI, go to the settings page and access the `Bots` tile.
 
-<Note>
-**Note**: The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
-</Note>
+<BotsTileAdminNote />
 
 <img src="/public/images/developers/settings-bot.png" alt="settings-bot" />
 

--- a/v1.12.x/developers/bots.mdx
+++ b/v1.12.x/developers/bots.mdx
@@ -7,9 +7,9 @@ import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # How to Set Up Bots
 
-The default account for any ingestion pipeline deployed from the UI is `ingestion-bot`. To configure `ingestion-bot` from the UI, go to the settings page and access the `Bots` tile.
-
 <BotsTileAdminNote />
+
+The default account for any ingestion pipeline deployed from the UI is `ingestion-bot`. To configure `ingestion-bot` from the UI, go to the settings page and access the `Bots` tile.
 
 <img src="/public/images/developers/settings-bot.png" alt="settings-bot" />
 

--- a/v1.12.x/developers/bots.mdx
+++ b/v1.12.x/developers/bots.mdx
@@ -8,6 +8,10 @@ sidebarTitle: Bots
 
 The default account for any ingestion pipeline deployed from the UI is `ingestion-bot`. To configure `ingestion-bot` from the UI, go to the settings page and access the `Bots` tile.
 
+<Note>
+The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
+</Note>
+
 <img src="/public/images/developers/settings-bot.png" alt="settings-bot" />
 
 <img src="/public/images/developers/bot-listing.png" alt="bot-listing" />

--- a/v1.12.x/developers/bots.mdx
+++ b/v1.12.x/developers/bots.mdx
@@ -9,7 +9,7 @@ sidebarTitle: Bots
 The default account for any ingestion pipeline deployed from the UI is `ingestion-bot`. To configure `ingestion-bot` from the UI, go to the settings page and access the `Bots` tile.
 
 <Note>
-The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
+**Note**: The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
 </Note>
 
 <img src="/public/images/developers/settings-bot.png" alt="settings-bot" />

--- a/v1.12.x/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.mdx
+++ b/v1.12.x/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.mdx
@@ -2,6 +2,7 @@
 title: How To Run Ingestion Pipeline Via CLI with Basic Auth
 sidebarTitle: CLI Ingestion with Basic Auth
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # How To Run Ingestion Pipeline Via CLI with Basic Auth
 
@@ -23,6 +24,7 @@ From `0.12.1` OpenMetadata has changed the default `no-auth` to `Basic` auth, So
 
    <img src="/public/images/cli-ingestion-with-basic-auth/bot-list.png" alt="bot-list" />
 
+<BotsTileAdminNote />
 
 **2.** You will be redirected to the `ingestion-bot` details page. there you will get the JWT token, click on the copy button and copy the JWT token.
    <img src="/public/images/cli-ingestion-with-basic-auth/bot-token.png" alt="bot-token" />

--- a/v1.12.x/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.mdx
+++ b/v1.12.x/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.mdx
@@ -18,13 +18,13 @@ From `0.12.1` OpenMetadata has changed the default `no-auth` to `Basic` auth, So
 
 ## How to get the JWT token
 
+<BotsTileAdminNote />
+
 **1.** Go to the `settings` page from the `activity bar` Section. Click on the `Bots` and you will see the list of bots, then click on the `ingestion-bot`.
 
    <img src="/public/images/cli-ingestion-with-basic-auth/settings-bot.png" alt="settings-bot" />
 
    <img src="/public/images/cli-ingestion-with-basic-auth/bot-list.png" alt="bot-list" />
-
-<BotsTileAdminNote />
 
 **2.** You will be redirected to the `ingestion-bot` details page. there you will get the JWT token, click on the copy button and copy the JWT token.
    <img src="/public/images/cli-ingestion-with-basic-auth/bot-token.png" alt="bot-token" />

--- a/v1.12.x/how-to-guides/data-quality-observability/quality/data-quality-as-code/getting-started.mdx
+++ b/v1.12.x/how-to-guides/data-quality-observability/quality/data-quality-as-code/getting-started.mdx
@@ -3,6 +3,7 @@ title: Getting Started with Data Quality as Code
 description: Install the OpenMetadata Python SDK and configure authentication
 sidebarTitle: Getting Started with Data Quality as Code
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # Getting Started with Data Quality as Code
 
@@ -81,6 +82,8 @@ OpenMetadata provides pre-configured bots like the `ingestion-bot`:
 2. Navigate to **Settings > Bots**
 3. Find the **ingestion-bot** (or create a new bot)
 4. Copy the JWT token
+
+<BotsTileAdminNote />
 
 <img src="/public/images/deployment/security/enable-jwt/bot-jwt-token.png" alt="Obtain Bot JWT Token" />
 

--- a/v1.12.x/how-to-guides/data-quality-observability/quality/data-quality-as-code/getting-started.mdx
+++ b/v1.12.x/how-to-guides/data-quality-observability/quality/data-quality-as-code/getting-started.mdx
@@ -74,6 +74,8 @@ Data Quality as Code requires authentication with your OpenMetadata instance. Th
 
 You can obtain a JWT token in two ways:
 
+<BotsTileAdminNote />
+
 #### Option 1: Using an Existing Bot Token
 
 OpenMetadata provides pre-configured bots like the `ingestion-bot`:
@@ -82,8 +84,6 @@ OpenMetadata provides pre-configured bots like the `ingestion-bot`:
 2. Navigate to **Settings > Bots**
 3. Find the **ingestion-bot** (or create a new bot)
 4. Copy the JWT token
-
-<BotsTileAdminNote />
 
 <img src="/public/images/deployment/security/enable-jwt/bot-jwt-token.png" alt="Obtain Bot JWT Token" />
 

--- a/v1.12.x/sdk.mdx
+++ b/v1.12.x/sdk.mdx
@@ -3,6 +3,7 @@ title: OpenMetadata SDK | OpenMetadata Software Development Kit
 description: Connect Sdk to enable streamlined access, monitoring, or search of enterprise data using secure and scalable integrations.
 sidebarTitle: SDK
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # SDK & API
 
@@ -29,6 +30,8 @@ Access the OpenAPI (Swagger) documentation at [OpenMetadata API](https://docs.op
 ## How to get the JWT Token
 
 ### Bot Token
+
+<BotsTileAdminNote />
 
 1. Go to the settings page from the navbar and then scroll down to the Integrations Section. Click on the Bots and you will see the list of bots, then click on the ingestion-bot. <img src="/public/images/apis/bots/bots.png" alt="bot-list" />
 

--- a/v1.12.x/sdk/ai-sdk.mdx
+++ b/v1.12.x/sdk/ai-sdk.mdx
@@ -37,10 +37,10 @@ You need:
 1. **An OpenMetadata instance** with AI Studio Agents enabled
 2. **A Bot JWT token** for API authentication
 
+<BotsTileAdminNote />
+
 To get a JWT token, go to **Settings > Bots** in your OpenMetadata instance, select your bot, and copy the token.
 See [How to get the JWT Token](/v1.12.x/sdk#how-to-get-the-jwt-token) for detailed instructions.
-
-<BotsTileAdminNote />
 
 ## Configuration
 

--- a/v1.12.x/sdk/ai-sdk.mdx
+++ b/v1.12.x/sdk/ai-sdk.mdx
@@ -4,6 +4,7 @@ description: Bring AI to your metadata. Programmatic access to OpenMetadata thro
 slug: /sdk/ai
 sidebarTitle: AI SDK
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # AI SDK
 
@@ -38,6 +39,8 @@ You need:
 
 To get a JWT token, go to **Settings > Bots** in your OpenMetadata instance, select your bot, and copy the token.
 See [How to get the JWT Token](/v1.12.x/sdk#how-to-get-the-jwt-token) for detailed instructions.
+
+<BotsTileAdminNote />
 
 ## Configuration
 

--- a/v1.13.x/api-reference.mdx
+++ b/v1.13.x/api-reference.mdx
@@ -3,6 +3,7 @@ title: OpenMetadata SDKs & APIs
 description: Programmatic access to your OpenMetadata data catalog through REST APIs and native SDKs
 sidebarTitle: Introduction
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # OpenMetadata SDKs & APIs
 
@@ -123,6 +124,8 @@ Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
 </CodeGroup>
 
 You can obtain a token through **Bot Tokens** (for service accounts via **Settings > Bots**) or **Personal Access Tokens** (via your **Profile > Access Tokens**).
+
+<BotsTileAdminNote />
 
 <Card title="Authentication Guide" icon="key" href="/v1.13.x/api-reference/authentication">
   Learn more about authentication methods, token management, and security configuration.

--- a/v1.13.x/api-reference.mdx
+++ b/v1.13.x/api-reference.mdx
@@ -123,9 +123,9 @@ Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
 ```
 </CodeGroup>
 
-You can obtain a token through **Bot Tokens** (for service accounts via **Settings > Bots**) or **Personal Access Tokens** (via your **Profile > Access Tokens**).
-
 <BotsTileAdminNote />
+
+You can obtain a token through **Bot Tokens** (for service accounts via **Settings > Bots**) or **Personal Access Tokens** (via your **Profile > Access Tokens**).
 
 <Card title="Authentication Guide" icon="key" href="/v1.13.x/api-reference/authentication">
   Learn more about authentication methods, token management, and security configuration.

--- a/v1.13.x/api-reference/authentication.mdx
+++ b/v1.13.x/api-reference/authentication.mdx
@@ -3,6 +3,7 @@ title: Authentication
 description: Authenticate your API requests using JWT Bearer tokens
 sidebarTitle: Authentication
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # Authentication
 
@@ -16,9 +17,7 @@ There are two ways to obtain an API token:
 
 Bot tokens are ideal for service accounts, CI/CD pipelines, and automated integrations.
 
-<Note>
-**Note**: The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
-</Note>
+<BotsTileAdminNote />
 
 1. Navigate to **Settings > Bots** in the OpenMetadata UI
 2. Click **Add Bot** or select an existing bot

--- a/v1.13.x/api-reference/authentication.mdx
+++ b/v1.13.x/api-reference/authentication.mdx
@@ -16,6 +16,10 @@ There are two ways to obtain an API token:
 
 Bot tokens are ideal for service accounts, CI/CD pipelines, and automated integrations.
 
+<Note>
+The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
+</Note>
+
 1. Navigate to **Settings > Bots** in the OpenMetadata UI
 2. Click **Add Bot** or select an existing bot
 3. Under **Token**, click **Generate Token**

--- a/v1.13.x/api-reference/authentication.mdx
+++ b/v1.13.x/api-reference/authentication.mdx
@@ -17,7 +17,7 @@ There are two ways to obtain an API token:
 Bot tokens are ideal for service accounts, CI/CD pipelines, and automated integrations.
 
 <Note>
-The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
+**Note**: The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
 </Note>
 
 1. Navigate to **Settings > Bots** in the OpenMetadata UI

--- a/v1.13.x/api-reference/getting-started.mdx
+++ b/v1.13.x/api-reference/getting-started.mdx
@@ -3,6 +3,7 @@ title: Getting Started
 description: Set up your environment and make your first API call in minutes
 sidebarTitle: Getting Started
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # Getting Started
 
@@ -25,6 +26,8 @@ You need a JWT token to authenticate API requests. There are two ways to get one
 1. Navigate to **Settings > Bots** in the OpenMetadata UI
 2. Click on the **ingestion-bot** (or create a new bot for your use case)
 3. Copy the JWT token from the bot details page
+
+<BotsTileAdminNote />
 
 <img src="/public/images/apis/bots/bots.png" alt="Navigate to Settings > Bots to find available bots" />
 

--- a/v1.13.x/api-reference/getting-started.mdx
+++ b/v1.13.x/api-reference/getting-started.mdx
@@ -23,11 +23,11 @@ You need a JWT token to authenticate API requests. There are two ways to get one
 
 **Bot Token** (recommended for automation)
 
+<BotsTileAdminNote />
+
 1. Navigate to **Settings > Bots** in the OpenMetadata UI
 2. Click on the **ingestion-bot** (or create a new bot for your use case)
 3. Copy the JWT token from the bot details page
-
-<BotsTileAdminNote />
 
 <img src="/public/images/apis/bots/bots.png" alt="Navigate to Settings > Bots to find available bots" />
 

--- a/v1.13.x/api-reference/sdk.mdx
+++ b/v1.13.x/api-reference/sdk.mdx
@@ -3,6 +3,7 @@ title: OpenMetadata SDK | OpenMetadata Software Development Kit
 description: Connect Sdk to enable streamlined access, monitoring, or search of enterprise data using secure and scalable integrations.
 sidebarTitle: Overview
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # SDK & API
 
@@ -29,6 +30,8 @@ Access the OpenAPI (Swagger) documentation at [OpenMetadata API](https://docs.op
 ## How to get the JWT Token
 
 ### Bot Token
+
+<BotsTileAdminNote />
 
 1. Go to the settings page from the navbar and then scroll down to the Integrations Section. Click on the Bots and you will see the list of bots, then click on the ingestion-bot. <img src="/public/images/apis/bots/bots.png" alt="bot-list" />
 

--- a/v1.13.x/api-reference/sdk/ai-sdk.mdx
+++ b/v1.13.x/api-reference/sdk/ai-sdk.mdx
@@ -3,6 +3,7 @@ title: AI SDK
 description: Connect any LLM to your metadata catalog with OpenMetadata's MCP tools. Available across Python, TypeScript, and Java.
 sidebarTitle: AI SDK
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # AI SDK
 
@@ -41,6 +42,8 @@ You need:
 2. **A Bot JWT token** for API authentication
 
 To get a JWT token, go to **Settings > Bots** in your OpenMetadata instance, select your bot, and copy the token.
+
+<BotsTileAdminNote />
 
 ## Configuration
 

--- a/v1.13.x/api-reference/sdk/ai-sdk.mdx
+++ b/v1.13.x/api-reference/sdk/ai-sdk.mdx
@@ -41,9 +41,9 @@ You need:
 1. **An OpenMetadata instance** (self-hosted or [Collate](https://www.getcollate.io))
 2. **A Bot JWT token** for API authentication
 
-To get a JWT token, go to **Settings > Bots** in your OpenMetadata instance, select your bot, and copy the token.
-
 <BotsTileAdminNote />
+
+To get a JWT token, go to **Settings > Bots** in your OpenMetadata instance, select your bot, and copy the token.
 
 ## Configuration
 

--- a/v1.13.x/deployment/security/enable-jwt-tokens.mdx
+++ b/v1.13.x/deployment/security/enable-jwt-tokens.mdx
@@ -4,6 +4,7 @@ description: Enable JWT-based security for user authentication, session manageme
 sidebarTitle: Enable jwt tokens
 collate: false
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # Enable JWT Tokens
 
@@ -104,6 +105,8 @@ wget -O - {your domain}/api/v1/system/config/jwks
 ## Generate Token
 
 Once the above configuration is updated, the server is restarted. Admin can go to Settings -> Bots page.
+
+<BotsTileAdminNote />
 
 <img src="/public/images/deployment/security/enable-jwt/settings-bot.png" alt="Settings Page" />
 

--- a/v1.13.x/deployment/security/enable-jwt-tokens.mdx
+++ b/v1.13.x/deployment/security/enable-jwt-tokens.mdx
@@ -104,9 +104,9 @@ wget -O - {your domain}/api/v1/system/config/jwks
 
 ## Generate Token
 
-Once the above configuration is updated, the server is restarted. Admin can go to Settings -> Bots page.
-
 <BotsTileAdminNote />
+
+Once the above configuration is updated, the server is restarted. Admin can go to Settings -> Bots page.
 
 <img src="/public/images/deployment/security/enable-jwt/settings-bot.png" alt="Settings Page" />
 

--- a/v1.13.x/deployment/security/jwt-troubleshooting.mdx
+++ b/v1.13.x/deployment/security/jwt-troubleshooting.mdx
@@ -4,6 +4,8 @@ description: Fix JWT-based authentication issues with deployment and ingestion b
 sidebarTitle: Jwt troubleshooting
 collate: false
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
+
 # JWT Troubleshooting
 
 Add the `{domain}:{port}/api/v1/sytem/config/jwks` in the list of publicKeys
@@ -31,6 +33,8 @@ When the ingestion workflow uses this token, we use `rsapublicKeyPath` to decryp
 ## Get JWT token from UI.
 
 First Open Open-Metadata UI than go to settings > Bots > Ingestion Bot
+
+<BotsTileAdminNote />
 
 <img src="/public/images/deployment/troubleshoot/jwt-token.png" alt="jwt-token" />
 

--- a/v1.13.x/deployment/security/jwt-troubleshooting.mdx
+++ b/v1.13.x/deployment/security/jwt-troubleshooting.mdx
@@ -32,9 +32,9 @@ When the ingestion workflow uses this token, we use `rsapublicKeyPath` to decryp
 
 ## Get JWT token from UI.
 
-First Open Open-Metadata UI than go to settings > Bots > Ingestion Bot
-
 <BotsTileAdminNote />
+
+First Open Open-Metadata UI than go to settings > Bots > Ingestion Bot
 
 <img src="/public/images/deployment/troubleshoot/jwt-token.png" alt="jwt-token" />
 

--- a/v1.13.x/developers/bots.mdx
+++ b/v1.13.x/developers/bots.mdx
@@ -3,14 +3,13 @@ title: How to Set Up Bots | OpenMetadata Developer Guide
 description: Create and manage bots for task automation, data notifications, and metadata workflows.
 sidebarTitle: Bots
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # How to Set Up Bots
 
 The default account for any ingestion pipeline deployed from the UI is `ingestion-bot`. To configure `ingestion-bot` from the UI, go to the settings page and access the `Bots` tile.
 
-<Note>
-**Note**: The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
-</Note>
+<BotsTileAdminNote />
 
 <img src="/public/images/developers/settings-bot.png" alt="settings-bot" />
 

--- a/v1.13.x/developers/bots.mdx
+++ b/v1.13.x/developers/bots.mdx
@@ -7,9 +7,9 @@ import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # How to Set Up Bots
 
-The default account for any ingestion pipeline deployed from the UI is `ingestion-bot`. To configure `ingestion-bot` from the UI, go to the settings page and access the `Bots` tile.
-
 <BotsTileAdminNote />
+
+The default account for any ingestion pipeline deployed from the UI is `ingestion-bot`. To configure `ingestion-bot` from the UI, go to the settings page and access the `Bots` tile.
 
 <img src="/public/images/developers/settings-bot.png" alt="settings-bot" />
 

--- a/v1.13.x/developers/bots.mdx
+++ b/v1.13.x/developers/bots.mdx
@@ -8,6 +8,10 @@ sidebarTitle: Bots
 
 The default account for any ingestion pipeline deployed from the UI is `ingestion-bot`. To configure `ingestion-bot` from the UI, go to the settings page and access the `Bots` tile.
 
+<Note>
+The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
+</Note>
+
 <img src="/public/images/developers/settings-bot.png" alt="settings-bot" />
 
 <img src="/public/images/developers/bot-listing.png" alt="bot-listing" />

--- a/v1.13.x/developers/bots.mdx
+++ b/v1.13.x/developers/bots.mdx
@@ -9,7 +9,7 @@ sidebarTitle: Bots
 The default account for any ingestion pipeline deployed from the UI is `ingestion-bot`. To configure `ingestion-bot` from the UI, go to the settings page and access the `Bots` tile.
 
 <Note>
-The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
+**Note**: The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
 </Note>
 
 <img src="/public/images/developers/settings-bot.png" alt="settings-bot" />

--- a/v1.13.x/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.mdx
+++ b/v1.13.x/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.mdx
@@ -2,6 +2,7 @@
 title: How To Run Ingestion Pipeline Via CLI with Basic Auth
 sidebarTitle: CLI Ingestion with Basic Auth
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # How To Run Ingestion Pipeline Via CLI with Basic Auth
 
@@ -23,6 +24,7 @@ From `0.12.1` OpenMetadata has changed the default `no-auth` to `Basic` auth, So
 
    <img src="/public/images/cli-ingestion-with-basic-auth/bot-list.png" alt="bot-list" />
 
+<BotsTileAdminNote />
 
 **2.** You will be redirected to the `ingestion-bot` details page. there you will get the JWT token, click on the copy button and copy the JWT token.
    <img src="/public/images/cli-ingestion-with-basic-auth/bot-token.png" alt="bot-token" />

--- a/v1.13.x/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.mdx
+++ b/v1.13.x/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.mdx
@@ -18,13 +18,13 @@ From `0.12.1` OpenMetadata has changed the default `no-auth` to `Basic` auth, So
 
 ## How to get the JWT token
 
+<BotsTileAdminNote />
+
 **1.** Go to the `settings` page from the `activity bar` Section. Click on the `Bots` and you will see the list of bots, then click on the `ingestion-bot`.
 
    <img src="/public/images/cli-ingestion-with-basic-auth/settings-bot.png" alt="settings-bot" />
 
    <img src="/public/images/cli-ingestion-with-basic-auth/bot-list.png" alt="bot-list" />
-
-<BotsTileAdminNote />
 
 **2.** You will be redirected to the `ingestion-bot` details page. there you will get the JWT token, click on the copy button and copy the JWT token.
    <img src="/public/images/cli-ingestion-with-basic-auth/bot-token.png" alt="bot-token" />

--- a/v1.13.x/how-to-guides/data-quality-observability/quality/data-quality-as-code/getting-started.mdx
+++ b/v1.13.x/how-to-guides/data-quality-observability/quality/data-quality-as-code/getting-started.mdx
@@ -3,6 +3,7 @@ title: Getting Started with Data Quality as Code
 description: Install the OpenMetadata Python SDK and configure authentication
 sidebarTitle: Getting Started with Data Quality as Code
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # Getting Started with Data Quality as Code
 
@@ -81,6 +82,8 @@ OpenMetadata provides pre-configured bots like the `ingestion-bot`:
 2. Navigate to **Settings > Bots**
 3. Find the **ingestion-bot** (or create a new bot)
 4. Copy the JWT token
+
+<BotsTileAdminNote />
 
 <img src="/public/images/deployment/security/enable-jwt/bot-jwt-token.png" alt="Obtain Bot JWT Token" />
 

--- a/v1.13.x/how-to-guides/data-quality-observability/quality/data-quality-as-code/getting-started.mdx
+++ b/v1.13.x/how-to-guides/data-quality-observability/quality/data-quality-as-code/getting-started.mdx
@@ -74,6 +74,8 @@ Data Quality as Code requires authentication with your OpenMetadata instance. Th
 
 You can obtain a JWT token in two ways:
 
+<BotsTileAdminNote />
+
 #### Option 1: Using an Existing Bot Token
 
 OpenMetadata provides pre-configured bots like the `ingestion-bot`:
@@ -82,8 +84,6 @@ OpenMetadata provides pre-configured bots like the `ingestion-bot`:
 2. Navigate to **Settings > Bots**
 3. Find the **ingestion-bot** (or create a new bot)
 4. Copy the JWT token
-
-<BotsTileAdminNote />
 
 <img src="/public/images/deployment/security/enable-jwt/bot-jwt-token.png" alt="Obtain Bot JWT Token" />
 

--- a/v1.13.x/sdk.mdx
+++ b/v1.13.x/sdk.mdx
@@ -3,6 +3,7 @@ title: OpenMetadata SDK | OpenMetadata Software Development Kit
 description: Connect Sdk to enable streamlined access, monitoring, or search of enterprise data using secure and scalable integrations.
 sidebarTitle: SDK
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # SDK & API
 
@@ -29,6 +30,8 @@ Access the OpenAPI (Swagger) documentation at [OpenMetadata API](https://docs.op
 ## How to get the JWT Token
 
 ### Bot Token
+
+<BotsTileAdminNote />
 
 1. Go to the settings page from the navbar and then scroll down to the Integrations Section. Click on the Bots and you will see the list of bots, then click on the ingestion-bot. <img src="/public/images/apis/bots/bots.png" alt="bot-list" />
 

--- a/v1.13.x/sdk/ai-sdk.mdx
+++ b/v1.13.x/sdk/ai-sdk.mdx
@@ -37,10 +37,10 @@ You need:
 1. **A OpenMetadata instance** with AI Studio Agents enabled
 2. **A Bot JWT token** for API authentication
 
+<BotsTileAdminNote />
+
 To get a JWT token, go to **Settings > Bots** in your OpenMetadata instance, select your bot, and copy the token.
 See [How to get the JWT Token](/v1.13.x/sdk#how-to-get-the-jwt-token) for detailed instructions.
-
-<BotsTileAdminNote />
 
 ## Configuration
 

--- a/v1.13.x/sdk/ai-sdk.mdx
+++ b/v1.13.x/sdk/ai-sdk.mdx
@@ -4,6 +4,7 @@ description: Bring AI to your metadata. Programmatic access to OpenMetadata thro
 slug: /sdk/ai
 sidebarTitle: AI SDK
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # AI SDK
 
@@ -38,6 +39,8 @@ You need:
 
 To get a JWT token, go to **Settings > Bots** in your OpenMetadata instance, select your bot, and copy the token.
 See [How to get the JWT Token](/v1.13.x/sdk#how-to-get-the-jwt-token) for detailed instructions.
+
+<BotsTileAdminNote />
 
 ## Configuration
 

--- a/v2.0.x-SNAPSHOT/api-reference.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference.mdx
@@ -123,9 +123,9 @@ Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
 ```
 </CodeGroup>
 
-You can obtain a token through **Bot Tokens** (for service accounts via **Settings > Bots**) or **Personal Access Tokens** (via your **Profile > Access Tokens**).
-
 <BotsTileAdminNote />
+
+You can obtain a token through **Bot Tokens** (for service accounts via **Settings > Bots**) or **Personal Access Tokens** (via your **Profile > Access Tokens**).
 
 <Card title="Authentication Guide" icon="key" href="/v2.0.x-SNAPSHOT/api-reference/authentication">
   Learn more about authentication methods, token management, and security configuration.

--- a/v2.0.x-SNAPSHOT/api-reference.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference.mdx
@@ -3,6 +3,7 @@ title: OpenMetadata SDKs & APIs
 description: Programmatic access to your OpenMetadata data catalog through REST APIs and native SDKs
 sidebarTitle: Introduction
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # OpenMetadata SDKs & APIs
 
@@ -123,6 +124,8 @@ Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
 </CodeGroup>
 
 You can obtain a token through **Bot Tokens** (for service accounts via **Settings > Bots**) or **Personal Access Tokens** (via your **Profile > Access Tokens**).
+
+<BotsTileAdminNote />
 
 <Card title="Authentication Guide" icon="key" href="/v2.0.x-SNAPSHOT/api-reference/authentication">
   Learn more about authentication methods, token management, and security configuration.

--- a/v2.0.x-SNAPSHOT/api-reference/authentication.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference/authentication.mdx
@@ -3,6 +3,7 @@ title: Authentication
 description: Authenticate your API requests using JWT Bearer tokens
 sidebarTitle: Authentication
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # Authentication
 
@@ -16,9 +17,7 @@ There are two ways to obtain an API token:
 
 Bot tokens are ideal for service accounts, CI/CD pipelines, and automated integrations.
 
-<Note>
-**Note**: The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
-</Note>
+<BotsTileAdminNote />
 
 1. Navigate to **Settings > Bots** in the OpenMetadata UI
 2. Click **Add Bot** or select an existing bot

--- a/v2.0.x-SNAPSHOT/api-reference/authentication.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference/authentication.mdx
@@ -16,6 +16,10 @@ There are two ways to obtain an API token:
 
 Bot tokens are ideal for service accounts, CI/CD pipelines, and automated integrations.
 
+<Note>
+The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
+</Note>
+
 1. Navigate to **Settings > Bots** in the OpenMetadata UI
 2. Click **Add Bot** or select an existing bot
 3. Under **Token**, click **Generate Token**

--- a/v2.0.x-SNAPSHOT/api-reference/authentication.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference/authentication.mdx
@@ -17,7 +17,7 @@ There are two ways to obtain an API token:
 Bot tokens are ideal for service accounts, CI/CD pipelines, and automated integrations.
 
 <Note>
-The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
+**Note**: The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
 </Note>
 
 1. Navigate to **Settings > Bots** in the OpenMetadata UI

--- a/v2.0.x-SNAPSHOT/api-reference/getting-started.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference/getting-started.mdx
@@ -3,6 +3,7 @@ title: Getting Started
 description: Set up your environment and make your first API call in minutes
 sidebarTitle: Getting Started
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # Getting Started
 
@@ -25,6 +26,8 @@ You need a JWT token to authenticate API requests. There are two ways to get one
 1. Navigate to **Settings > Bots** in the OpenMetadata UI
 2. Click on the **ingestion-bot** (or create a new bot for your use case)
 3. Copy the JWT token from the bot details page
+
+<BotsTileAdminNote />
 
 <img src="/public/images/apis/bots/bots.png" alt="Navigate to Settings > Bots to find available bots" />
 

--- a/v2.0.x-SNAPSHOT/api-reference/getting-started.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference/getting-started.mdx
@@ -23,11 +23,11 @@ You need a JWT token to authenticate API requests. There are two ways to get one
 
 **Bot Token** (recommended for automation)
 
+<BotsTileAdminNote />
+
 1. Navigate to **Settings > Bots** in the OpenMetadata UI
 2. Click on the **ingestion-bot** (or create a new bot for your use case)
 3. Copy the JWT token from the bot details page
-
-<BotsTileAdminNote />
 
 <img src="/public/images/apis/bots/bots.png" alt="Navigate to Settings > Bots to find available bots" />
 

--- a/v2.0.x-SNAPSHOT/api-reference/sdk.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference/sdk.mdx
@@ -3,6 +3,7 @@ title: OpenMetadata SDK | OpenMetadata Software Development Kit
 description: Connect Sdk to enable streamlined access, monitoring, or search of enterprise data using secure and scalable integrations.
 sidebarTitle: Overview
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # SDK & API
 
@@ -29,6 +30,8 @@ Access the OpenAPI (Swagger) documentation at [OpenMetadata API](https://docs.op
 ## How to get the JWT Token
 
 ### Bot Token
+
+<BotsTileAdminNote />
 
 1. Go to the settings page from the navbar and then scroll down to the Integrations Section. Click on the Bots and you will see the list of bots, then click on the ingestion-bot. <img src="/public/images/apis/bots/bots.png" alt="bot-list" />
 

--- a/v2.0.x-SNAPSHOT/api-reference/sdk/ai-sdk.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference/sdk/ai-sdk.mdx
@@ -3,6 +3,7 @@ title: AI SDK
 description: Connect any LLM to your metadata catalog with OpenMetadata's MCP tools. Available across Python, TypeScript, and Java.
 sidebarTitle: AI SDK
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # AI SDK
 
@@ -41,6 +42,8 @@ You need:
 2. **A Bot JWT token** for API authentication
 
 To get a JWT token, go to **Settings > Bots** in your OpenMetadata instance, select your bot, and copy the token.
+
+<BotsTileAdminNote />
 
 ## Configuration
 

--- a/v2.0.x-SNAPSHOT/api-reference/sdk/ai-sdk.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference/sdk/ai-sdk.mdx
@@ -41,9 +41,9 @@ You need:
 1. **An OpenMetadata instance** (self-hosted or [Collate](https://www.getcollate.io))
 2. **A Bot JWT token** for API authentication
 
-To get a JWT token, go to **Settings > Bots** in your OpenMetadata instance, select your bot, and copy the token.
-
 <BotsTileAdminNote />
+
+To get a JWT token, go to **Settings > Bots** in your OpenMetadata instance, select your bot, and copy the token.
 
 ## Configuration
 

--- a/v2.0.x-SNAPSHOT/deployment/security/enable-jwt-tokens.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/security/enable-jwt-tokens.mdx
@@ -4,6 +4,7 @@ description: Enable JWT-based security for user authentication, session manageme
 sidebarTitle: Enable jwt tokens
 collate: false
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # Enable JWT Tokens
 
@@ -104,6 +105,8 @@ wget -O - {your domain}/api/v1/system/config/jwks
 ## Generate Token
 
 Once the above configuration is updated, the server is restarted. Admin can go to Settings -> Bots page.
+
+<BotsTileAdminNote />
 
 <img src="/public/images/deployment/security/enable-jwt/settings-bot.png" alt="Settings Page" />
 

--- a/v2.0.x-SNAPSHOT/deployment/security/enable-jwt-tokens.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/security/enable-jwt-tokens.mdx
@@ -104,9 +104,9 @@ wget -O - {your domain}/api/v1/system/config/jwks
 
 ## Generate Token
 
-Once the above configuration is updated, the server is restarted. Admin can go to Settings -> Bots page.
-
 <BotsTileAdminNote />
+
+Once the above configuration is updated, the server is restarted. Admin can go to Settings -> Bots page.
 
 <img src="/public/images/deployment/security/enable-jwt/settings-bot.png" alt="Settings Page" />
 

--- a/v2.0.x-SNAPSHOT/deployment/security/jwt-troubleshooting.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/security/jwt-troubleshooting.mdx
@@ -4,6 +4,8 @@ description: Fix JWT-based authentication issues with deployment and ingestion b
 sidebarTitle: Jwt troubleshooting
 collate: false
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
+
 # JWT Troubleshooting
 
 Add the `{domain}:{port}/api/v1/sytem/config/jwks` in the list of publicKeys
@@ -31,6 +33,8 @@ When the ingestion workflow uses this token, we use `rsapublicKeyPath` to decryp
 ## Get JWT token from UI.
 
 First Open Open-Metadata UI than go to settings > Bots > Ingestion Bot
+
+<BotsTileAdminNote />
 
 <img src="/public/images/deployment/troubleshoot/jwt-token.png" alt="jwt-token" />
 

--- a/v2.0.x-SNAPSHOT/deployment/security/jwt-troubleshooting.mdx
+++ b/v2.0.x-SNAPSHOT/deployment/security/jwt-troubleshooting.mdx
@@ -32,9 +32,9 @@ When the ingestion workflow uses this token, we use `rsapublicKeyPath` to decryp
 
 ## Get JWT token from UI.
 
-First Open Open-Metadata UI than go to settings > Bots > Ingestion Bot
-
 <BotsTileAdminNote />
+
+First Open Open-Metadata UI than go to settings > Bots > Ingestion Bot
 
 <img src="/public/images/deployment/troubleshoot/jwt-token.png" alt="jwt-token" />
 

--- a/v2.0.x-SNAPSHOT/developers/bots.mdx
+++ b/v2.0.x-SNAPSHOT/developers/bots.mdx
@@ -3,14 +3,13 @@ title: How to Set Up Bots | OpenMetadata Developer Guide
 description: Create and manage bots for task automation, data notifications, and metadata workflows.
 sidebarTitle: Bots
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # How to Set Up Bots
 
 The default account for any ingestion pipeline deployed from the UI is `ingestion-bot`. To configure `ingestion-bot` from the UI, go to the settings page and access the `Bots` tile.
 
-<Note>
-**Note**: The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
-</Note>
+<BotsTileAdminNote />
 
 <img src="/public/images/developers/settings-bot.png" alt="settings-bot" />
 

--- a/v2.0.x-SNAPSHOT/developers/bots.mdx
+++ b/v2.0.x-SNAPSHOT/developers/bots.mdx
@@ -7,9 +7,9 @@ import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # How to Set Up Bots
 
-The default account for any ingestion pipeline deployed from the UI is `ingestion-bot`. To configure `ingestion-bot` from the UI, go to the settings page and access the `Bots` tile.
-
 <BotsTileAdminNote />
+
+The default account for any ingestion pipeline deployed from the UI is `ingestion-bot`. To configure `ingestion-bot` from the UI, go to the settings page and access the `Bots` tile.
 
 <img src="/public/images/developers/settings-bot.png" alt="settings-bot" />
 

--- a/v2.0.x-SNAPSHOT/developers/bots.mdx
+++ b/v2.0.x-SNAPSHOT/developers/bots.mdx
@@ -8,6 +8,10 @@ sidebarTitle: Bots
 
 The default account for any ingestion pipeline deployed from the UI is `ingestion-bot`. To configure `ingestion-bot` from the UI, go to the settings page and access the `Bots` tile.
 
+<Note>
+The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
+</Note>
+
 <img src="/public/images/developers/settings-bot.png" alt="settings-bot" />
 
 <img src="/public/images/developers/bot-listing.png" alt="bot-listing" />

--- a/v2.0.x-SNAPSHOT/developers/bots.mdx
+++ b/v2.0.x-SNAPSHOT/developers/bots.mdx
@@ -9,7 +9,7 @@ sidebarTitle: Bots
 The default account for any ingestion pipeline deployed from the UI is `ingestion-bot`. To configure `ingestion-bot` from the UI, go to the settings page and access the `Bots` tile.
 
 <Note>
-The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
+**Note**: The **Bots** tile under **Settings** is only visible to users with Admin privileges. If you don't see it, ask your organization's OpenMetadata Admin to generate a bot token for you or grant you Admin access.
 </Note>
 
 <img src="/public/images/developers/settings-bot.png" alt="settings-bot" />

--- a/v2.0.x-SNAPSHOT/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.mdx
@@ -2,6 +2,7 @@
 title: How To Run Ingestion Pipeline Via CLI with Basic Auth
 sidebarTitle: CLI Ingestion with Basic Auth
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # How To Run Ingestion Pipeline Via CLI with Basic Auth
 
@@ -23,6 +24,7 @@ From `0.12.1` OpenMetadata has changed the default `no-auth` to `Basic` auth, So
 
    <img src="/public/images/cli-ingestion-with-basic-auth/bot-list.png" alt="bot-list" />
 
+<BotsTileAdminNote />
 
 **2.** You will be redirected to the `ingestion-bot` details page. there you will get the JWT token, click on the copy button and copy the JWT token.
    <img src="/public/images/cli-ingestion-with-basic-auth/bot-token.png" alt="bot-token" />

--- a/v2.0.x-SNAPSHOT/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.mdx
@@ -18,13 +18,13 @@ From `0.12.1` OpenMetadata has changed the default `no-auth` to `Basic` auth, So
 
 ## How to get the JWT token
 
+<BotsTileAdminNote />
+
 **1.** Go to the `settings` page from the `activity bar` Section. Click on the `Bots` and you will see the list of bots, then click on the `ingestion-bot`.
 
    <img src="/public/images/cli-ingestion-with-basic-auth/settings-bot.png" alt="settings-bot" />
 
    <img src="/public/images/cli-ingestion-with-basic-auth/bot-list.png" alt="bot-list" />
-
-<BotsTileAdminNote />
 
 **2.** You will be redirected to the `ingestion-bot` details page. there you will get the JWT token, click on the copy button and copy the JWT token.
    <img src="/public/images/cli-ingestion-with-basic-auth/bot-token.png" alt="bot-token" />

--- a/v2.0.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/data-quality-as-code/getting-started.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/data-quality-as-code/getting-started.mdx
@@ -3,6 +3,7 @@ title: Getting Started with Data Quality as Code
 description: Install the OpenMetadata Python SDK and configure authentication
 sidebarTitle: Getting Started with Data Quality as Code
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # Getting Started with Data Quality as Code
 
@@ -81,6 +82,8 @@ OpenMetadata provides pre-configured bots like the `ingestion-bot`:
 2. Navigate to **Settings > Bots**
 3. Find the **ingestion-bot** (or create a new bot)
 4. Copy the JWT token
+
+<BotsTileAdminNote />
 
 <img src="/public/images/deployment/security/enable-jwt/bot-jwt-token.png" alt="Obtain Bot JWT Token" />
 

--- a/v2.0.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/data-quality-as-code/getting-started.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/data-quality-as-code/getting-started.mdx
@@ -74,6 +74,8 @@ Data Quality as Code requires authentication with your OpenMetadata instance. Th
 
 You can obtain a JWT token in two ways:
 
+<BotsTileAdminNote />
+
 #### Option 1: Using an Existing Bot Token
 
 OpenMetadata provides pre-configured bots like the `ingestion-bot`:
@@ -82,8 +84,6 @@ OpenMetadata provides pre-configured bots like the `ingestion-bot`:
 2. Navigate to **Settings > Bots**
 3. Find the **ingestion-bot** (or create a new bot)
 4. Copy the JWT token
-
-<BotsTileAdminNote />
 
 <img src="/public/images/deployment/security/enable-jwt/bot-jwt-token.png" alt="Obtain Bot JWT Token" />
 

--- a/v2.0.x-SNAPSHOT/sdk.mdx
+++ b/v2.0.x-SNAPSHOT/sdk.mdx
@@ -3,6 +3,7 @@ title: OpenMetadata SDK | OpenMetadata Software Development Kit
 description: Connect Sdk to enable streamlined access, monitoring, or search of enterprise data using secure and scalable integrations.
 sidebarTitle: SDK
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # SDK & API
 
@@ -29,6 +30,8 @@ Access the OpenAPI (Swagger) documentation at [OpenMetadata API](https://docs.op
 ## How to get the JWT Token
 
 ### Bot Token
+
+<BotsTileAdminNote />
 
 1. Go to the settings page from the navbar and then scroll down to the Integrations Section. Click on the Bots and you will see the list of bots, then click on the ingestion-bot. <img src="/public/images/apis/bots/bots.png" alt="bot-list" />
 

--- a/v2.0.x-SNAPSHOT/sdk/ai-sdk.mdx
+++ b/v2.0.x-SNAPSHOT/sdk/ai-sdk.mdx
@@ -37,10 +37,10 @@ You need:
 1. **A OpenMetadata instance** with AI Studio Agents enabled
 2. **A Bot JWT token** for API authentication
 
+<BotsTileAdminNote />
+
 To get a JWT token, go to **Settings > Bots** in your OpenMetadata instance, select your bot, and copy the token.
 See [How to get the JWT Token](/v2.0.x-SNAPSHOT/sdk#how-to-get-the-jwt-token) for detailed instructions.
-
-<BotsTileAdminNote />
 
 ## Configuration
 

--- a/v2.0.x-SNAPSHOT/sdk/ai-sdk.mdx
+++ b/v2.0.x-SNAPSHOT/sdk/ai-sdk.mdx
@@ -4,6 +4,7 @@ description: Bring AI to your metadata. Programmatic access to OpenMetadata thro
 slug: /sdk/ai
 sidebarTitle: AI SDK
 ---
+import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'
 
 # AI SDK
 
@@ -38,6 +39,8 @@ You need:
 
 To get a JWT token, go to **Settings > Bots** in your OpenMetadata instance, select your bot, and copy the token.
 See [How to get the JWT Token](/v2.0.x-SNAPSHOT/sdk#how-to-get-the-jwt-token) for detailed instructions.
+
+<BotsTileAdminNote />
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- Adds a note clarifying that the **Bots** tile under **Settings** is only visible to users with Admin privileges, wherever a page walks the reader through generating a bot JWT token via Settings > Bots.
- Originally added to just `developers/bots.mdx` and `api-reference/authentication.mdx`. 
<img width="2934" height="1586" alt="image" src="https://github.com/user-attachments/assets/1f4515d9-7157-4f5c-8be4-9f432194b8f2" />

Extended to 8 more pages that give the identical instruction and would confuse non-admin readers the same way:
  - `api-reference.mdx`
  - `api-reference/getting-started.mdx`
  - `api-reference/sdk.mdx`
  - `api-reference/sdk/ai-sdk.mdx`
  - `deployment/security/enable-jwt-tokens.mdx`
  - `deployment/security/jwt-troubleshooting.mdx`
  - `how-to-guides/admin-guide/cli-ingestion-with-basic-auth.mdx`
  - `how-to-guides/data-quality-observability/quality/data-quality-as-code/getting-started.mdx`
  - `sdk.mdx`
  - `sdk/ai-sdk.mdx`

  (all x `v1.12.x`, `v1.13.x`, `v2.0.x-SNAPSHOT` = 30 files)

- Converted the note to a shared snippet (`snippets/deployment/bots-tile-admin-note.mdx`), imported via `import BotsTileAdminNote from '/snippets/deployment/bots-tile-admin-note.mdx'` + `<BotsTileAdminNote />`, instead of duplicating the same 3-line block across 30+ files. Future wording or permission-rule changes are now a single edit.

## Why

A non-admin user following any of these walkthroughs would get stuck at "go to Settings > Bots" with no indication of why the tile isn't there. Fixing it in the two original pages but not the others that give the same instruction would leave the same confusion everywhere else.

Two pages that mention bots/tokens in passing but don't actually walk the reader through the Settings > Bots UI (`connectors/pipeline/airflow/gcp-composer.mdx`, `deployment/ingestion/openmetadata/troubleshooting.mdx`) were deliberately left out as weak fits.

## Test plan

- [ ] `mint dev` and spot-check a few of the updated pages to confirm the snippet renders correctly
- [ ] `mint broken-links` passes (new snippet import paths)

