### PR TITLE
Docs: Add missing dbt Exposures documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -472,6 +472,7 @@
                           "v1.13.x/connectors/database/dbt/ingest-dbt-domain",
                           "v1.13.x/connectors/database/dbt/ingest-dbt-custom-properties",
                           "v1.13.x/connectors/database/dbt/ingest-dbt-lineage",
+                          "v1.13.x/connectors/database/dbt/ingest-dbt-exposures",
                           "v1.13.x/connectors/database/dbt/setup-multiple-dbt-projects",
                           "v1.13.x/connectors/database/dbt/dbt-troubleshooting"
                         ]
@@ -2774,6 +2775,7 @@
                           "v1.12.x/connectors/database/dbt/ingest-dbt-domain",
                           "v1.12.x/connectors/database/dbt/ingest-dbt-custom-properties",
                           "v1.12.x/connectors/database/dbt/ingest-dbt-lineage",
+                          "v1.12.x/connectors/database/dbt/ingest-dbt-exposures",
                           "v1.12.x/connectors/database/dbt/setup-multiple-dbt-projects",
                           "v1.12.x/connectors/database/dbt/dbt-troubleshooting"
                         ]
@@ -5050,6 +5052,7 @@
                           "v2.0.x-SNAPSHOT/connectors/database/dbt/ingest-dbt-domain",
                           "v2.0.x-SNAPSHOT/connectors/database/dbt/ingest-dbt-custom-properties",
                           "v2.0.x-SNAPSHOT/connectors/database/dbt/ingest-dbt-lineage",
+                          "v2.0.x-SNAPSHOT/connectors/database/dbt/ingest-dbt-exposures",
                           "v2.0.x-SNAPSHOT/connectors/database/dbt/setup-multiple-dbt-projects",
                           "v2.0.x-SNAPSHOT/connectors/database/dbt/dbt-troubleshooting"
                         ]

--- a/v1.12.x/connectors/database/dbt.mdx
+++ b/v1.12.x/connectors/database/dbt.mdx
@@ -36,7 +36,7 @@ sidebarTitle: Overview
 | [dbt Owner](#4-dbt-owner)                   | <Icon icon="check" />              |
 | [dbt Descriptions](#5-dbt-descriptions)            | <Icon icon="check" />              |
 | [dbt Tests](#6-dbt-tests-and-test-results)                   | <Icon icon="check" />              |
-| dbt Exposures               | <Icon icon="check" />              |
+| [dbt Exposures](#11-dbt-exposures)              | <Icon icon="check" />              |
 | [dbt push metadata](/v1.12.x/connectors/database/dbt/auto-ingest-dbt-core)              | <Icon icon="check" />              |
 | Supported dbt Core Versions | `v1.2` `v1.3` `v1.4` `v1.5` `v1.6` `v1.7` `v1.8` `v1.9`|
 
@@ -323,6 +323,13 @@ Please refer [here](/v1.12.x/connectors/database/dbt/ingest-dbt-domain) for addi
 Custom property values can be imported from dbt to enrich table metadata with organization-specific attributes
 
 Please refer [here](/v1.12.x/connectors/database/dbt/ingest-dbt-custom-properties) for adding dbt custom properties
+
+
+### 11. dbt Exposures
+
+Exposures let you extend lineage from your dbt models to the dashboards, ML models, and API endpoints that consume them.
+
+For more information, see [Ingest Exposures from dbt](/v1.12.x/connectors/database/dbt/ingest-dbt-exposures).
 
 
 ## Troubleshooting

--- a/v1.12.x/connectors/database/dbt/ingest-dbt-exposures.mdx
+++ b/v1.12.x/connectors/database/dbt/ingest-dbt-exposures.mdx
@@ -1,0 +1,84 @@
+---
+title: Ingest Exposures from dbt | OpenMetadata Downstream Lineage Guide
+description: Ingest dbt exposures to extend lineage from your dbt models to the dashboards, ML models, and API endpoints that consume them.
+slug: /connectors/database/dbt/ingest-dbt-exposures
+sidebarTitle: Ingest dbt Exposures
+---
+
+# Ingest Exposures from dbt
+
+Ingest dbt [exposures](https://docs.getdbt.com/docs/build/exposures) from the `manifest.json` file to extend lineage from your dbt models to the dashboards, ML models, and API endpoints that consume them.
+
+## Requirements
+
+<Tip>
+The downstream entity referenced by an exposure must already exist in OpenMetadata before the dbt ingestion runs. OpenMetadata matches it by Fully Qualified Name (FQN). If OpenMetadata can't find a match, it logs a warning and skips the exposure.
+</Tip>
+
+### Supported Exposure Types
+
+OpenMetadata maps a dbt exposure to an OpenMetadata entity based on its `type` field:
+
+| dbt Exposure `type` | OpenMetadata Entity |
+| :------------------- | :--------------- |
+| `dashboard`           | Dashboard        |
+| `ml`                  | ML Model         |
+| `application`         | API Endpoint     |
+
+Any other `type` value is skipped during ingestion.
+
+## Ingesting dbt Exposures
+
+Follow these steps to link a dbt exposure to an existing OpenMetadata entity.
+
+1. **Add exposure information in your dbt project**
+
+    Define the exposure in your dbt project (for example in `models/exposures.yml`), and set `meta.open_metadata_fqn` to the Fully Qualified Name of the corresponding entity already ingested in OpenMetadata.
+
+    For more information, see [Add Exposures to your DAG](https://docs.getdbt.com/docs/build/exposures).
+
+    ```yaml
+    exposures:
+      - name: orders_dashboard
+        label: orders
+        type: dashboard
+        maturity: high
+        url: http://localhost:8080/looker/dashboard/8/
+        description: >
+          Orders dashboard built on top of the orders model.
+        depends_on:
+          - ref('fact_sales')
+        meta:
+          open_metadata_fqn: sample_looker.orders  # OpenMetadata entity Fully Qualified Name
+    ```
+
+    After adding the exposure, run your dbt workflow (`dbt compile` or `dbt run`). The generated `manifest.json` will include the exposure under the `exposures` key, with upstream models listed under `depends_on->nodes`.
+
+    ```json
+    "exposure.jaffle_shop.orders_dashboard": {
+      "name": "orders_dashboard",
+      "resource_type": "exposure",
+      "type": "dashboard",
+      "meta": {
+        "open_metadata_fqn": "sample_looker.orders"
+      },
+      "depends_on": {
+        "nodes": [
+          "model.jaffle_shop.fact_sales"
+        ]
+      }
+    }
+    ```
+
+2. **Viewing the exposure lineage**
+
+    Once ingested, the linked dashboard, ML model, or API endpoint appears as a downstream node in the **Lineage** tab of the upstream dbt table(s) listed under `depends_on`.
+
+## Validation and Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Exposure `type` not one of `dashboard`, `ml`, `application` | Warning logged, exposure skipped |
+| `meta.open_metadata_fqn` missing from exposure spec | Warning logged, exposure skipped |
+| Entity referenced by `open_metadata_fqn` not found in OpenMetadata | Warning logged, exposure skipped |
+| Upstream model not yet ingested as an OpenMetadata table | Upstream node excluded from lineage edge |

--- a/v1.13.x/connectors/database/dbt.mdx
+++ b/v1.13.x/connectors/database/dbt.mdx
@@ -36,7 +36,7 @@ sidebarTitle: Overview
 | [dbt Owner](#4-dbt-owner)                   | <Icon icon="check" />              |
 | [dbt Descriptions](#5-dbt-descriptions)            | <Icon icon="check" />              |
 | [dbt Tests](#6-dbt-tests-and-test-results)                   | <Icon icon="check" />              |
-| dbt Exposures               | <Icon icon="check" />              |
+| [dbt Exposures](#11-dbt-exposures)              | <Icon icon="check" />              |
 | [dbt push metadata](/v1.13.x/connectors/database/dbt/auto-ingest-dbt-core)              | <Icon icon="check" />              |
 | Supported dbt Core Versions | `v1.2` `v1.3` `v1.4` `v1.5` `v1.6` `v1.7` `v1.8` `v1.9`|
 
@@ -323,6 +323,13 @@ Please refer [here](/v1.13.x/connectors/database/dbt/ingest-dbt-domain) for addi
 Custom property values can be imported from dbt to enrich table metadata with organization-specific attributes
 
 Please refer [here](/v1.13.x/connectors/database/dbt/ingest-dbt-custom-properties) for adding dbt custom properties
+
+
+### 11. dbt Exposures
+
+Exposures let you extend lineage from your dbt models to the dashboards, ML models, and API endpoints that consume them.
+
+For more information, see [Ingest Exposures from dbt](/v1.13.x/connectors/database/dbt/ingest-dbt-exposures).
 
 
 ## Troubleshooting

--- a/v1.13.x/connectors/database/dbt/ingest-dbt-exposures.mdx
+++ b/v1.13.x/connectors/database/dbt/ingest-dbt-exposures.mdx
@@ -1,0 +1,84 @@
+---
+title: Ingest Exposures from dbt | OpenMetadata Downstream Lineage Guide
+description: Ingest dbt exposures to extend lineage from your dbt models to the dashboards, ML models, and API endpoints that consume them.
+slug: /connectors/database/dbt/ingest-dbt-exposures
+sidebarTitle: Ingest dbt Exposures
+---
+
+# Ingest Exposures from dbt
+
+Ingest dbt [exposures](https://docs.getdbt.com/docs/build/exposures) from the `manifest.json` file to extend lineage from your dbt models to the dashboards, ML models, and API endpoints that consume them.
+
+## Requirements
+
+<Tip>
+The downstream entity referenced by an exposure must already exist in OpenMetadata before the dbt ingestion runs. OpenMetadata matches it by Fully Qualified Name (FQN). If OpenMetadata can't find a match, it logs a warning and skips the exposure.
+</Tip>
+
+### Supported Exposure Types
+
+OpenMetadata maps a dbt exposure to an OpenMetadata entity based on its `type` field:
+
+| dbt Exposure `type` | OpenMetadata Entity |
+| :------------------- | :--------------- |
+| `dashboard`           | Dashboard        |
+| `ml`                  | ML Model         |
+| `application`         | API Endpoint     |
+
+Any other `type` value is skipped during ingestion.
+
+## Ingesting dbt Exposures
+
+Follow these steps to link a dbt exposure to an existing OpenMetadata entity.
+
+1. **Add exposure information in your dbt project**
+
+    Define the exposure in your dbt project (for example in `models/exposures.yml`), and set `meta.open_metadata_fqn` to the Fully Qualified Name of the corresponding entity already ingested in OpenMetadata.
+
+    For more information, see [Add Exposures to your DAG](https://docs.getdbt.com/docs/build/exposures).
+
+    ```yaml
+    exposures:
+      - name: orders_dashboard
+        label: orders
+        type: dashboard
+        maturity: high
+        url: http://localhost:8080/looker/dashboard/8/
+        description: >
+          Orders dashboard built on top of the orders model.
+        depends_on:
+          - ref('fact_sales')
+        meta:
+          open_metadata_fqn: sample_looker.orders  # OpenMetadata entity Fully Qualified Name
+    ```
+
+    After adding the exposure, run your dbt workflow (`dbt compile` or `dbt run`). The generated `manifest.json` will include the exposure under the `exposures` key, with upstream models listed under `depends_on->nodes`.
+
+    ```json
+    "exposure.jaffle_shop.orders_dashboard": {
+      "name": "orders_dashboard",
+      "resource_type": "exposure",
+      "type": "dashboard",
+      "meta": {
+        "open_metadata_fqn": "sample_looker.orders"
+      },
+      "depends_on": {
+        "nodes": [
+          "model.jaffle_shop.fact_sales"
+        ]
+      }
+    }
+    ```
+
+2. **Viewing the exposure lineage**
+
+    Once ingested, the linked dashboard, ML model, or API endpoint appears as a downstream node in the **Lineage** tab of the upstream dbt table(s) listed under `depends_on`.
+
+## Validation and Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Exposure `type` not one of `dashboard`, `ml`, `application` | Warning logged, exposure skipped |
+| `meta.open_metadata_fqn` missing from exposure spec | Warning logged, exposure skipped |
+| Entity referenced by `open_metadata_fqn` not found in OpenMetadata | Warning logged, exposure skipped |
+| Upstream model not yet ingested as an OpenMetadata table | Upstream node excluded from lineage edge |

--- a/v2.0.x-SNAPSHOT/connectors/database/dbt.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/dbt.mdx
@@ -36,7 +36,7 @@ sidebarTitle: Overview
 | [dbt Owner](#4-dbt-owner)                   | <Icon icon="check" />              |
 | [dbt Descriptions](#5-dbt-descriptions)            | <Icon icon="check" />              |
 | [dbt Tests](#6-dbt-tests-and-test-results)                   | <Icon icon="check" />              |
-| dbt Exposures               | <Icon icon="check" />              |
+| [dbt Exposures](#11-dbt-exposures)              | <Icon icon="check" />              |
 | [dbt push metadata](/v2.0.x-SNAPSHOT/connectors/database/dbt/auto-ingest-dbt-core)              | <Icon icon="check" />              |
 | Supported dbt Core Versions | `v1.2` `v1.3` `v1.4` `v1.5` `v1.6` `v1.7` `v1.8` `v1.9`|
 
@@ -323,6 +323,13 @@ Please refer [here](/v2.0.x-SNAPSHOT/connectors/database/dbt/ingest-dbt-domain) 
 Custom property values can be imported from dbt to enrich table metadata with organization-specific attributes
 
 Please refer [here](/v2.0.x-SNAPSHOT/connectors/database/dbt/ingest-dbt-custom-properties) for adding dbt custom properties
+
+
+### 11. dbt Exposures
+
+Exposures let you extend lineage from your dbt models to the dashboards, ML models, and API endpoints that consume them.
+
+For more information, see [Ingest Exposures from dbt](/v2.0.x-SNAPSHOT/connectors/database/dbt/ingest-dbt-exposures).
 
 
 ## Troubleshooting

--- a/v2.0.x-SNAPSHOT/connectors/database/dbt/ingest-dbt-exposures.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/dbt/ingest-dbt-exposures.mdx
@@ -1,0 +1,84 @@
+---
+title: Ingest Exposures from dbt | OpenMetadata Downstream Lineage Guide
+description: Ingest dbt exposures to extend lineage from your dbt models to the dashboards, ML models, and API endpoints that consume them.
+slug: /connectors/database/dbt/ingest-dbt-exposures
+sidebarTitle: Ingest dbt Exposures
+---
+
+# Ingest Exposures from dbt
+
+Ingest dbt [exposures](https://docs.getdbt.com/docs/build/exposures) from the `manifest.json` file to extend lineage from your dbt models to the dashboards, ML models, and API endpoints that consume them.
+
+## Requirements
+
+<Tip>
+The downstream entity referenced by an exposure must already exist in OpenMetadata before the dbt ingestion runs. OpenMetadata matches it by Fully Qualified Name (FQN). If OpenMetadata can't find a match, it logs a warning and skips the exposure.
+</Tip>
+
+### Supported Exposure Types
+
+OpenMetadata maps a dbt exposure to an OpenMetadata entity based on its `type` field:
+
+| dbt Exposure `type` | OpenMetadata Entity |
+| :------------------- | :--------------- |
+| `dashboard`           | Dashboard        |
+| `ml`                  | ML Model         |
+| `application`         | API Endpoint     |
+
+Any other `type` value is skipped during ingestion.
+
+## Ingesting dbt Exposures
+
+Follow these steps to link a dbt exposure to an existing OpenMetadata entity.
+
+1. **Add exposure information in your dbt project**
+
+    Define the exposure in your dbt project (for example in `models/exposures.yml`), and set `meta.open_metadata_fqn` to the Fully Qualified Name of the corresponding entity already ingested in OpenMetadata.
+
+    For more information, see [Add Exposures to your DAG](https://docs.getdbt.com/docs/build/exposures).
+
+    ```yaml
+    exposures:
+      - name: orders_dashboard
+        label: orders
+        type: dashboard
+        maturity: high
+        url: http://localhost:8080/looker/dashboard/8/
+        description: >
+          Orders dashboard built on top of the orders model.
+        depends_on:
+          - ref('fact_sales')
+        meta:
+          open_metadata_fqn: sample_looker.orders  # OpenMetadata entity Fully Qualified Name
+    ```
+
+    After adding the exposure, run your dbt workflow (`dbt compile` or `dbt run`). The generated `manifest.json` will include the exposure under the `exposures` key, with upstream models listed under `depends_on->nodes`.
+
+    ```json
+    "exposure.jaffle_shop.orders_dashboard": {
+      "name": "orders_dashboard",
+      "resource_type": "exposure",
+      "type": "dashboard",
+      "meta": {
+        "open_metadata_fqn": "sample_looker.orders"
+      },
+      "depends_on": {
+        "nodes": [
+          "model.jaffle_shop.fact_sales"
+        ]
+      }
+    }
+    ```
+
+2. **Viewing the exposure lineage**
+
+    Once ingested, the linked dashboard, ML model, or API endpoint appears as a downstream node in the **Lineage** tab of the upstream dbt table(s) listed under `depends_on`.
+
+## Validation and Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Exposure `type` not one of `dashboard`, `ml`, `application` | Warning logged, exposure skipped |
+| `meta.open_metadata_fqn` missing from exposure spec | Warning logged, exposure skipped |
+| Entity referenced by `open_metadata_fqn` not found in OpenMetadata | Warning logged, exposure skipped |
+| Upstream model not yet ingested as an OpenMetadata table | Upstream node excluded from lineage edge |


### PR DESCRIPTION
## Summary
- Add `connectors/database/dbt/ingest-dbt-exposures.mdx` documenting the dbt Exposures feature — supported types (dashboard, ML model, API endpoint), how to configure `meta.open_metadata_fqn`, and a Validation and Error Handling table — across all three versions (v1.12.x, v1.13.x, v2.0.x-SNAPSHOT)
- Link `dbt Exposures` in the `dbt Integration` table on each version's `dbt.mdx` and add a new `### 11. dbt Exposures` section
- Register the new pages in `docs.json` for all three versions

## Context
Ported from the equivalent fix in `docs-collate` (open-metadata/docs-collate#507), where a customer reported that dbt Exposures was listed as supported in the connector's feature table but had no accompanying documentation or hyperlink, unlike every other row. Verified the feature's actual behavior against the ingestion source in `open-metadata/OpenMetadata`: it reads the `exposures` block from `manifest.json`, supports `dashboard`/`ml`/`application` types, resolves the downstream entity via `meta.open_metadata_fqn`, and builds a lineage edge from upstream dbt tables to that entity. Content adapted for OpenMetadata branding (this repo, unlike docs-collate, correctly uses "OpenMetadata" rather than "Collate" throughout).


