### PR TITLE
chore: add release notes for 1.12.14

### DIFF
--- a/snippets/releases/1.12.14.mdx
+++ b/snippets/releases/1.12.14.mdx
@@ -1,0 +1,39 @@
+<Update label="1.12.14 Release" description="28th July 2026">
+
+View the [OpenMetadata 1.12.14 GitHub release](https://github.com/open-metadata/OpenMetadata/releases/tag/1.12.14-release).
+
+## Changelog
+
+### 🔒 Security
+
+- **Patch MLflow authorization vulnerabilities** [#30046](https://github.com/open-metadata/OpenMetadata/pull/30046): Raised the `mlflow-skinny` requirement to a patched 3.13 or newer release to address CVE-2026-2635 and CVE-2026-8147.
+
+- **Patch PyArrow IPC vulnerabilities** [#30146](https://github.com/open-metadata/OpenMetadata/pull/30146): Raised the PyArrow requirement to `>=23.0.1,<26` to address CVE-2026-25087 and CVE-2024-52338.
+
+- **Patch server dependency vulnerabilities** [bd31ff6](https://github.com/open-metadata/OpenMetadata/commit/bd31ff64405cb01711546bb2eb980787d348dd22) [cd46662](https://github.com/open-metadata/OpenMetadata/commit/cd46662204395f2ca7d449d4ff07ccce7da47a7d) [#30391](https://github.com/open-metadata/OpenMetadata/pull/30391): Updated Jackson, Logback, Apache HttpComponents, Apache Calcite, PostgreSQL JDBC, Netty, and Jetty to patched versions.
+
+- **Harden ingestion container images** [#30024](https://github.com/open-metadata/OpenMetadata/pull/30024) [#30454](https://github.com/open-metadata/OpenMetadata/pull/30454): Removed unused operating-system packages, switched to slimmer runtime components where appropriate, and installed available Debian security updates.
+
+- **Patch UI dependency vulnerabilities** [4ce8b3a](https://github.com/open-metadata/OpenMetadata/commit/4ce8b3a7d97edbe40b616df7c2404adff1d2cb77): Updated Axios, `ws`, `js-yaml`, `brace-expansion`, `fast-uri`, and related packages across both UI workspaces.
+
+### 🔍 Search & Performance
+
+- **Preserve the latest search preview ranking** [#30086](https://github.com/open-metadata/OpenMetadata/pull/30086): Search Settings now discards superseded preview responses, so an older, slower request cannot overwrite the ranking for the latest field-weight changes.
+
+- **Fix Test Suite reindexing failures** [#30220](https://github.com/open-metadata/OpenMetadata/pull/30220): Test Suite keyset reads now bind their pagination parameters correctly, preventing reindexing from failing with a missing named-parameter error.
+
+### 🛡️ Data Governance & Quality
+
+- **Keep Test Suite results aligned with the latest selection** [#29561](https://github.com/open-metadata/OpenMetadata/pull/29561): The Data Quality Test Suites page now ignores stale responses when users switch tabs, pages, searches, or owner filters quickly.
+
+### ⚙️ Apps & Ingestion
+
+- **Fix Data Retention relationship cleanup** [#29981](https://github.com/open-metadata/OpenMetadata/pull/29981): Relationship cleanup now reads `relationType` from the relationship JSON, preventing partial-failure errors on PostgreSQL and MySQL.
+
+- **Fix MySQL ingestion image builds** [#30264](https://github.com/open-metadata/OpenMetadata/pull/30264): Added `pkg-config` to the ingestion base images so `mysqlclient` can build successfully.
+
+### 🧬 Lineage
+
+- **Fix lineage PNG downloads and loading feedback** [#29362](https://github.com/open-metadata/OpenMetadata/pull/29362): PNG exports now use a browser-compatible download flow, display the loading indicator before rendering begins, and allow more time for large lineage graphs.
+
+</Update>

--- a/v1.12.x/releases.mdx
+++ b/v1.12.x/releases.mdx
@@ -4,7 +4,7 @@ description: Discover the latest OpenMetadata releases, new features, bug fixes,
 sidebarTitle: Latest Release
 ---
 
-import ReleaseNotes from '/snippets/releases/1.12.13.mdx';
+import ReleaseNotes from '/snippets/releases/1.12.14.mdx';
 
 # Latest Release 🎉
 

--- a/v1.12.x/releases/all-releases.mdx
+++ b/v1.12.x/releases/all-releases.mdx
@@ -16,6 +16,7 @@ import ReleaseNotes9 from '/snippets/releases/1.12.10.mdx';
 import ReleaseNotes10 from '/snippets/releases/1.12.11.mdx';
 import ReleaseNotes11 from '/snippets/releases/1.12.12.mdx';
 import ReleaseNotes12 from '/snippets/releases/1.12.13.mdx';
+import ReleaseNotes13 from '/snippets/releases/1.12.14.mdx';
 
 # Releases
 
@@ -29,9 +30,11 @@ import ReleaseNotes12 from '/snippets/releases/1.12.13.mdx';
     icon="party-horn"
     title="Upgrade OpenMetadata"
     href="/v1.12.x/deployment/upgrade">
-    Learn how to upgrade your OpenMetadata instance to 1.12.13!
+    Learn how to upgrade your OpenMetadata instance to 1.12.14!
   </Card>
 </CardGroup>
+
+<ReleaseNotes13 />
 
 <ReleaseNotes12 />
 

--- a/v1.13.x/releases/1.12-release.mdx
+++ b/v1.13.x/releases/1.12-release.mdx
@@ -16,8 +16,11 @@ import ReleaseNotes9 from '/snippets/releases/1.12.10.mdx';
 import ReleaseNotes10 from '/snippets/releases/1.12.11.mdx';
 import ReleaseNotes11 from '/snippets/releases/1.12.12.mdx';
 import ReleaseNotes12 from '/snippets/releases/1.12.13.mdx';
+import ReleaseNotes13 from '/snippets/releases/1.12.14.mdx';
 
 # 1.12 Releases
+
+<ReleaseNotes13 />
 
 <ReleaseNotes12 />
 

--- a/v1.13.x/releases/all-releases.mdx
+++ b/v1.13.x/releases/all-releases.mdx
@@ -18,6 +18,7 @@ import ReleaseNotes10 from '/snippets/releases/1.12.11.mdx';
 import ReleaseNotes11 from '/snippets/releases/1.12.12.mdx';
 import ReleaseNotes12 from '/snippets/releases/1.12.13.mdx';
 import ReleaseNotes13 from '/snippets/releases/1.13.0.mdx';
+import ReleaseNotes14 from '/snippets/releases/1.12.14.mdx';
 
 # Releases
 
@@ -38,6 +39,8 @@ import ReleaseNotes13 from '/snippets/releases/1.13.0.mdx';
 <ReleaseNotes />
 
 <ReleaseNotes13 />
+
+<ReleaseNotes14 />
 
 <ReleaseNotes12 />
 

--- a/v2.0.x-SNAPSHOT/releases/1.12-release.mdx
+++ b/v2.0.x-SNAPSHOT/releases/1.12-release.mdx
@@ -16,8 +16,11 @@ import ReleaseNotes9 from '/snippets/releases/1.12.10.mdx';
 import ReleaseNotes10 from '/snippets/releases/1.12.11.mdx';
 import ReleaseNotes11 from '/snippets/releases/1.12.12.mdx';
 import ReleaseNotes12 from '/snippets/releases/1.12.13.mdx';
+import ReleaseNotes13 from '/snippets/releases/1.12.14.mdx';
 
 # 1.12 Releases
+
+<ReleaseNotes13 />
 
 <ReleaseNotes12 />
 

--- a/v2.0.x-SNAPSHOT/releases/all-releases.mdx
+++ b/v2.0.x-SNAPSHOT/releases/all-releases.mdx
@@ -18,6 +18,7 @@ import ReleaseNotes10 from '/snippets/releases/1.12.11.mdx';
 import ReleaseNotes11 from '/snippets/releases/1.12.12.mdx';
 import ReleaseNotes12 from '/snippets/releases/1.12.13.mdx';
 import ReleaseNotes13 from '/snippets/releases/1.13.0.mdx';
+import ReleaseNotes14 from '/snippets/releases/1.12.14.mdx';
 
 # Releases
 
@@ -38,6 +39,8 @@ import ReleaseNotes13 from '/snippets/releases/1.13.0.mdx';
 <ReleaseNotes />
 
 <ReleaseNotes13 />
+
+<ReleaseNotes14 />
 
 <ReleaseNotes12 />
 


### PR DESCRIPTION
## Summary

- add the OpenMetadata 1.12.14 release-note snippet with OM-only changes
- make 1.12.14 the latest 1.12 release
- include it in the 1.12, 1.13, and 2.0 snapshot release archives
- follow the structure used for the 1.12.13 release notes

## Validation

- `npm run broken-links`
- `git diff --check`