### PR TITLE
Docs: Add Fivetran connector permissions requirements

### DIFF
--- a/v1.12.x/connectors/pipeline/fivetran.mdx
+++ b/v1.12.x/connectors/pipeline/fivetran.mdx
@@ -25,8 +25,6 @@ To access Fivetran APIs, a Fivetran account on a Standard, Enterprise, or Busine
 
 ### Permissions
 Generate the API key and API secret from a Fivetran user with an account-level role that has read access to all destinations and connections, such as **Account Reviewer**. OpenMetadata needs to discover every destination and connector in the account. A destination-scoped role (for example, View Destination) is not enough, because it only covers destinations the user was explicitly invited to.
-
-For detailed, per-phase Pipeline Status (Extract/Process/Load), OpenMetadata also reads the `fivetran_metadata.log` table that Fivetran automatically publishes in each destination's warehouse, using the Database Service already connected to that warehouse in OpenMetadata. The database user in that connection needs `SELECT` access to the `fivetran_metadata` schema. If this table isn't reachable, OpenMetadata automatically falls back to Fivetran's REST sync-history API for pipeline status.
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"Fivetran"} selectServicePath={"/public/images/connectors/fivetran/select-service.png"} addNewServicePath={"/public/images/connectors/fivetran/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/fivetran/service-connection.png"} />
 # Connection Details

--- a/v1.12.x/connectors/pipeline/fivetran.mdx
+++ b/v1.12.x/connectors/pipeline/fivetran.mdx
@@ -22,6 +22,11 @@ Configure and schedule Fivetran metadata and profiler workflows from the OpenMet
 - [Troubleshooting](/v1.12.x/connectors/pipeline/fivetran/troubleshooting)
 ## Requirements
 To access Fivetran APIs, a Fivetran account on a Standard, Enterprise, or Business Critical plan is required.
+
+### Permissions
+Generate the API key and API secret from a Fivetran user with an account-level role that has read access to all destinations and connections, such as **Account Reviewer**. OpenMetadata needs to discover every destination and connector in the account. A destination-scoped role (for example, View Destination) is not enough, because it only covers destinations the user was explicitly invited to.
+
+For detailed, per-phase Pipeline Status (Extract/Process/Load), OpenMetadata also reads the `fivetran_metadata.log` table that Fivetran automatically publishes in each destination's warehouse, using the Database Service already connected to that warehouse in OpenMetadata. The database user in that connection needs `SELECT` access to the `fivetran_metadata` schema. If this table isn't reachable, OpenMetadata automatically falls back to Fivetran's REST sync-history API for pipeline status.
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"Fivetran"} selectServicePath={"/public/images/connectors/fivetran/select-service.png"} addNewServicePath={"/public/images/connectors/fivetran/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/fivetran/service-connection.png"} />
 # Connection Details

--- a/v1.13.x/connectors/pipeline/fivetran.mdx
+++ b/v1.13.x/connectors/pipeline/fivetran.mdx
@@ -22,6 +22,11 @@ Configure and schedule Fivetran metadata and profiler workflows from the OpenMet
 - [Troubleshooting](/v1.13.x/connectors/pipeline/fivetran/troubleshooting)
 ## Requirements
 To access Fivetran APIs, a Fivetran account on a Standard, Enterprise, or Business Critical plan is required.
+
+### Permissions
+Generate the API key and API secret from a Fivetran user with an account-level role that has read access to all destinations and connections, such as **Account Reviewer**. OpenMetadata needs to discover every destination and connector in the account. A destination-scoped role (for example, View Destination) is not enough, because it only covers destinations the user was explicitly invited to.
+
+For detailed, per-phase Pipeline Status (Extract/Process/Load), OpenMetadata also reads the `fivetran_metadata.log` table that Fivetran automatically publishes in each destination's warehouse, using the Database Service already connected to that warehouse in OpenMetadata. The database user in that connection needs `SELECT` access to the `fivetran_metadata` schema. If this table isn't reachable, OpenMetadata automatically falls back to Fivetran's REST sync-history API for pipeline status.
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"Fivetran"} selectServicePath={"/public/images/connectors/fivetran/select-service.png"} addNewServicePath={"/public/images/connectors/fivetran/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/fivetran/service-connection.png"} />
 # Connection Details

--- a/v2.0.x-SNAPSHOT/connectors/pipeline/fivetran.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/pipeline/fivetran.mdx
@@ -22,6 +22,11 @@ Configure and schedule Fivetran metadata and profiler workflows from the OpenMet
 - [Troubleshooting](/v2.0.x-SNAPSHOT/connectors/pipeline/fivetran/troubleshooting)
 ## Requirements
 To access Fivetran APIs, a Fivetran account on a Standard, Enterprise, or Business Critical plan is required.
+
+### Permissions
+Generate the API key and API secret from a Fivetran user with an account-level role that has read access to all destinations and connections, such as **Account Reviewer**. OpenMetadata needs to discover every destination and connector in the account. A destination-scoped role (for example, View Destination) is not enough, because it only covers destinations the user was explicitly invited to.
+
+For detailed, per-phase Pipeline Status (Extract/Process/Load), OpenMetadata also reads the `fivetran_metadata.log` table that Fivetran automatically publishes in each destination's warehouse, using the Database Service already connected to that warehouse in OpenMetadata. The database user in that connection needs `SELECT` access to the `fivetran_metadata` schema. If this table isn't reachable, OpenMetadata automatically falls back to Fivetran's REST sync-history API for pipeline status.
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"Fivetran"} selectServicePath={"/public/images/connectors/fivetran/select-service.png"} addNewServicePath={"/public/images/connectors/fivetran/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/fivetran/service-connection.png"} />
 # Connection Details


### PR DESCRIPTION
## Summary
- A customer asked for the Fivetran connector docs to call out required Fivetran permissions (originally raised for the Collate docs, cross-applied here since the same connector/gap exists in OpenMetadata OSS docs).
- Adds a **Permissions** subsection under **Requirements** on `connectors/pipeline/fivetran.mdx` for v1.12.x, v1.13.x, and v2.0.x-SNAPSHOT, covering:
  1. The Fivetran account role needed to generate the API key/secret (account-wide read access to all destinations and connections, e.g. Account Reviewer) — the connector discovers every destination/connector in the account, so a destination-scoped role isn't enough.
  2. The optional warehouse `SELECT` permission on `fivetran_metadata.log` needed for detailed per-phase Pipeline Status, with the REST sync-history fallback noted.
<img width="2930" height="1704" alt="image" src="https://github.com/user-attachments/assets/a03cb05e-a592-4c49-8eb2-9db67f329b20" />

## Note for review
The "Account Reviewer" role recommendation is based on Fivetran's public RBAC docs and the connector's read-only, account-wide API calls (confirmed from ingestion source), but hasn't been independently verified against a live Fivetran account. Companion PR in docs-collate: open-metadata/docs-collate#524 (pending the same confirmation).

## Test plan
- [ ] Confirm Account Reviewer (or another role) is the correct minimum permission
- [ ] Docs preview renders correctly (`mint dev`)
- [ ] `mint broken-links` passes

