### PR TITLE
Docs: Clarify Pipeline Execution History

### DIFF
--- a/v1.12.x/how-to-guides/data-discovery/details.mdx
+++ b/v1.12.x/how-to-guides/data-discovery/details.mdx
@@ -103,7 +103,7 @@ In case of ML Models, it displays the Hyper Parameters and Model Store details.
 
 ## Executions Tab
 
-The Executions tab is displayed only for Pipelines. It displays the Date, Time, and Status of the pipelines. You can get a quick glance of the status in terms of Success, Failure, Pending, and Aborted. The status can be viewed as a Chronological list or as a tree. You can filter by status as well as by date.
+The **Executions** tab is available only for pipelines. It shows task-level execution history for the pipeline. Each row in **List View** represents a task execution, not a directed acyclic graph (DAG) run or pipeline run. Switch between **List View** and **Tree View**. Filter by status or date. In **List View**, search by task name.
 
 <img src="/public/images/how-to-guides/discovery/exec.png" alt="Pipelines: Executions Tab" />
 

--- a/v1.12.x/how-to-guides/guide-for-data-users/data-asset-tabs.mdx
+++ b/v1.12.x/how-to-guides/guide-for-data-users/data-asset-tabs.mdx
@@ -93,7 +93,7 @@ In case of ML Models, it displays the Hyper Parameters and Model Store details.
 
 ## Executions Tab
 
-The Executions tab is displayed only for Pipelines. It displays the Date, Time, and Status of the pipelines. You can get a quick glance of the status in terms of Success, Failure, Pending, and Aborted. The status can be viewed as a Chronological list or as a tree. You can filter by status as well as by date.
+The **Executions** tab is available only for pipelines. It shows task-level execution history for the pipeline. Each row in **List View** represents a task execution, not a directed acyclic graph (DAG) run or pipeline run. Switch between **List View** and **Tree View**. Filter by status or date. In **List View**, search by task name.
 
 <img src="/public/images/how-to-guides/discovery/exec.png" alt="Pipelines: Executions Tab" />
 

--- a/v1.13.x/how-to-guides/data-discovery/details.mdx
+++ b/v1.13.x/how-to-guides/data-discovery/details.mdx
@@ -103,7 +103,7 @@ In case of ML Models, it displays the Hyper Parameters and Model Store details.
 
 ## Executions Tab
 
-The Executions tab is displayed only for Pipelines. It displays the Date, Time, and Status of the pipelines. You can get a quick glance of the status in terms of Success, Failure, Pending, and Aborted. The status can be viewed as a Chronological list or as a tree. You can filter by status as well as by date.
+The **Executions** tab is available only for pipelines. It shows task-level execution history for the pipeline. Each row in **List View** represents a task execution, not a directed acyclic graph (DAG) run or pipeline run. Switch between **List View** and **Tree View**. Filter by status or date. In **List View**, search by task name.
 
 <img src="/public/images/how-to-guides/discovery/exec.png" alt="Pipelines: Executions Tab" />
 

--- a/v1.13.x/how-to-guides/guide-for-data-users/data-asset-tabs.mdx
+++ b/v1.13.x/how-to-guides/guide-for-data-users/data-asset-tabs.mdx
@@ -93,7 +93,7 @@ In case of ML Models, it displays the Hyper Parameters and Model Store details.
 
 ## Executions Tab
 
-The Executions tab is displayed only for Pipelines. It displays the Date, Time, and Status of the pipelines. You can get a quick glance of the status in terms of Success, Failure, Pending, and Aborted. The status can be viewed as a Chronological list or as a tree. You can filter by status as well as by date.
+The **Executions** tab is available only for pipelines. It shows task-level execution history for the pipeline. Each row in **List View** represents a task execution, not a directed acyclic graph (DAG) run or pipeline run. Switch between **List View** and **Tree View**. Filter by status or date. In **List View**, search by task name.
 
 <img src="/public/images/how-to-guides/discovery/exec.png" alt="Pipelines: Executions Tab" />
 

--- a/v2.0.x-SNAPSHOT/how-to-guides/data-discovery/details.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/data-discovery/details.mdx
@@ -103,7 +103,7 @@ In case of ML Models, it displays the Hyper Parameters and Model Store details.
 
 ## Executions Tab
 
-The Executions tab is displayed only for Pipelines. It displays the Date, Time, and Status of the pipelines. You can get a quick glance of the status in terms of Success, Failure, Pending, and Aborted. The status can be viewed as a Chronological list or as a tree. You can filter by status as well as by date.
+The **Executions** tab is available only for pipelines. It shows task-level execution history for the pipeline. Each row in **List View** represents a task execution, not a directed acyclic graph (DAG) run or pipeline run. Switch between **List View** and **Tree View**. Filter by status or date. In **List View**, search by task name.
 
 <img src="/public/images/how-to-guides/discovery/exec.png" alt="Pipelines: Executions Tab" />
 

--- a/v2.0.x-SNAPSHOT/how-to-guides/guide-for-data-users/data-asset-tabs.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/guide-for-data-users/data-asset-tabs.mdx
@@ -93,7 +93,7 @@ In case of ML Models, it displays the Hyper Parameters and Model Store details.
 
 ## Executions Tab
 
-The Executions tab is displayed only for Pipelines. It displays the Date, Time, and Status of the pipelines. You can get a quick glance of the status in terms of Success, Failure, Pending, and Aborted. The status can be viewed as a Chronological list or as a tree. You can filter by status as well as by date.
+The **Executions** tab is available only for pipelines. It shows task-level execution history for the pipeline. Each row in **List View** represents a task execution, not a directed acyclic graph (DAG) run or pipeline run. Switch between **List View** and **Tree View**. Filter by status or date. In **List View**, search by task name.
 
 <img src="/public/images/how-to-guides/discovery/exec.png" alt="Pipelines: Executions Tab" />
 


### PR DESCRIPTION
## Summary

- Clarify that the pipeline **Executions** tab shows task-level execution history.
- Explain that each **List View** row represents a task execution, not a directed acyclic graph or pipeline run.
- Keep the Data Asset Tabs and Data Discovery guides aligned across maintained versions.

## Affected versions

- `v1.12.x`
- `v1.13.x`
- `v2.0.x-SNAPSHOT`

## Validation

- `mint broken-links` — passed.
- `mint dev --port 3334` — all six affected routes returned HTTP 200 and rendered the updated copy.
- OpenMetadata content review — passed with no findings.

## Related PR

- open-metadata/docs-collate#533