### PR TITLE
Docs: Add ViewBasic/Document permission prerequisite for Persona feature

### DIFF
--- a/v1.12.x/how-to-guides/admin-guide/persona-landing-page-customization.mdx
+++ b/v1.12.x/how-to-guides/admin-guide/persona-landing-page-customization.mdx
@@ -10,6 +10,10 @@ sidebarTitle: Overview
 ## Overview
 OpenMetadata is designed as a platform for everyone in your organization, catering to the diverse needs of different users. To achieve this, OpenMetadata introduces **Persona and Landing Page Customization**, offering a personalized experience for each user. By defining personas, administrators can customize the application interface and functionality based on the specific requirements of various roles, such as **data engineers, data scientists, data stewards**, etc. This ensures that each user experiences the platform in a way that aligns with their responsibilities, enhancing productivity by providing relevant information and tools tailored to their daily activities.
 
+## Prerequisites
+
+Users must have the **ViewBasic** permission on the **Document** resource for Persona and Landing Page Customization to work correctly. Without this permission, personas and their customized landing pages might not load as expected.
+
 ## Benefits of Persona and Landing Page Customization
 
 - **Persona-Based Personalization**: Users can interact with OpenMetadata based on their selected persona, allowing them to switch between different perspectives to access the most relevant data and tools for their needs. This flexibility helps improve productivity and focus by tailoring the experience to match the user's current tasks and responsibilities.

--- a/v1.13.x/how-to-guides/admin-guide/persona-landing-page-customization.mdx
+++ b/v1.13.x/how-to-guides/admin-guide/persona-landing-page-customization.mdx
@@ -10,6 +10,10 @@ sidebarTitle: Overview
 ## Overview
 OpenMetadata is designed as a platform for everyone in your organization, catering to the diverse needs of different users. To achieve this, OpenMetadata introduces **Persona and Landing Page Customization**, offering a personalized experience for each user. By defining personas, administrators can customize the application interface and functionality based on the specific requirements of various roles, such as **data engineers, data scientists, data stewards**, etc. This ensures that each user experiences the platform in a way that aligns with their responsibilities, enhancing productivity by providing relevant information and tools tailored to their daily activities.
 
+## Prerequisites
+
+Users must have the **ViewBasic** permission on the **Document** resource for Persona and Landing Page Customization to work correctly. Without this permission, personas and their customized landing pages might not load as expected.
+
 ## Benefits of Persona and Landing Page Customization
 
 - **Persona-Based Personalization**: Users can interact with OpenMetadata based on their selected persona, allowing them to switch between different perspectives to access the most relevant data and tools for their needs. This flexibility helps improve productivity and focus by tailoring the experience to match the user's current tasks and responsibilities.

--- a/v2.0.x-SNAPSHOT/how-to-guides/admin-guide/persona-landing-page-customization.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/admin-guide/persona-landing-page-customization.mdx
@@ -10,6 +10,10 @@ sidebarTitle: Overview
 ## Overview
 OpenMetadata is designed as a platform for everyone in your organization, catering to the diverse needs of different users. To achieve this, OpenMetadata introduces **Persona and Landing Page Customization**, offering a personalized experience for each user. By defining personas, administrators can customize the application interface and functionality based on the specific requirements of various roles, such as **data engineers, data scientists, data stewards**, etc. This ensures that each user experiences the platform in a way that aligns with their responsibilities, enhancing productivity by providing relevant information and tools tailored to their daily activities.
 
+## Prerequisites
+
+Users must have the **ViewBasic** permission on the **Document** resource for Persona and Landing Page Customization to work correctly. Without this permission, personas and their customized landing pages might not load as expected.
+
 ## Benefits of Persona and Landing Page Customization
 
 - **Persona-Based Personalization**: Users can interact with OpenMetadata based on their selected persona, allowing them to switch between different perspectives to access the most relevant data and tools for their needs. This flexibility helps improve productivity and focus by tailoring the experience to match the user's current tasks and responsibilities.


### PR DESCRIPTION
## Summary
- Adds a Prerequisites section to the Persona and Landing Page Customization overview page in v1.12.x, v1.13.x, and v2.0.x-SNAPSHOT, noting that users need ViewBasic permission on the Document resource for the feature to work correctly.
<img width="2950" height="1384" alt="image" src="https://github.com/user-attachments/assets/2897c144-34b1-412b-8aa8-6a29af650044" />


## Test plan
- [ ] Verify wording renders correctly for each version on the docs site