### PR TITLE
Docs: [Tableau] document Tableau Catalog permissions required for table lineage across all versions

### DIFF
--- a/v1.12.x/connectors/dashboard/tableau.mdx
+++ b/v1.12.x/connectors/dashboard/tableau.mdx
@@ -47,6 +47,14 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 - To connect to a non-default Tableau site, use the `siteName` field instead. The Tableau Python SDK does not require `siteUrl` for authentication.
 - Ensure the `siteName` field is correctly populated (do not use `*`) to enable successful metadata ingestion for multi-site Tableau environments.
 </Tip>
+### Source Tables and Lineage
+
+<Warning>
+**Table lineage requires** the ingestion account to read external assets in Tableau Catalog. Without that access Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+</Warning>
+
+Grant the ingestion account access to external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer role alone is not enough for OpenMetadata to build table lineage.
+
 ## Entity Mapping
 The Tableau connector maps Tableau assets to OpenMetadata entities as follows:
 | Tableau Asset | OpenMetadata Entity | Description |

--- a/v1.12.x/connectors/dashboard/tableau.mdx
+++ b/v1.12.x/connectors/dashboard/tableau.mdx
@@ -50,10 +50,10 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 ### Source Tables and Lineage
 
 <Warning>
-**Table lineage requires** the ingestion account to read external assets in Tableau Catalog. Without that access Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+**Table lineage requires** the ingestion account to have the **View** capability on external assets in Tableau Catalog. Without it Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
 </Warning>
 
-Grant the ingestion account access to external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer role alone is not enough for OpenMetadata to build table lineage.
+Grant the ingestion account the **View** capability on external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
 
 ## Entity Mapping
 The Tableau connector maps Tableau assets to OpenMetadata entities as follows:

--- a/v1.12.x/connectors/dashboard/tableau.mdx
+++ b/v1.12.x/connectors/dashboard/tableau.mdx
@@ -50,10 +50,10 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 ### Source Tables and Lineage
 
 <Warning>
-**Table lineage requires** the ingestion account to have the **View** capability on external assets in Tableau Catalog. Without it Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+**Table lineage requires** the ingestion account to have the **View** capability on the external assets in Tableau Catalog, granted directly or derived. For any asset it cannot view, Tableau returns the source table with its table and database names removed, keeping only internal identifiers, and reports no error. Those tables are skipped without a message, so **no lineage is created between them and the data models that use them**. Assets the account can view are unaffected, and dashboards, charts and data models are still ingested either way.
 </Warning>
 
-Grant the ingestion account the **View** capability on external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
+Grant the ingestion account **View** on the affected external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
 
 ## Entity Mapping
 The Tableau connector maps Tableau assets to OpenMetadata entities as follows:

--- a/v1.12.x/connectors/dashboard/tableau/yaml.mdx
+++ b/v1.12.x/connectors/dashboard/tableau/yaml.mdx
@@ -50,10 +50,10 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 ### Source Tables and Lineage
 
 <Warning>
-**Table lineage requires** the ingestion account to read external assets in Tableau Catalog. Without that access Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+**Table lineage requires** the ingestion account to have the **View** capability on external assets in Tableau Catalog. Without it Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
 </Warning>
 
-Grant the ingestion account access to external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer role alone is not enough for OpenMetadata to build table lineage.
+Grant the ingestion account the **View** capability on external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
 
 ### Python Requirements
 <PythonRequirements />

--- a/v1.12.x/connectors/dashboard/tableau/yaml.mdx
+++ b/v1.12.x/connectors/dashboard/tableau/yaml.mdx
@@ -50,10 +50,10 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 ### Source Tables and Lineage
 
 <Warning>
-**Table lineage requires** the ingestion account to have the **View** capability on external assets in Tableau Catalog. Without it Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+**Table lineage requires** the ingestion account to have the **View** capability on the external assets in Tableau Catalog, granted directly or derived. For any asset it cannot view, Tableau returns the source table with its table and database names removed, keeping only internal identifiers, and reports no error. Those tables are skipped without a message, so **no lineage is created between them and the data models that use them**. Assets the account can view are unaffected, and dashboards, charts and data models are still ingested either way.
 </Warning>
 
-Grant the ingestion account the **View** capability on external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
+Grant the ingestion account **View** on the affected external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
 
 ### Python Requirements
 <PythonRequirements />

--- a/v1.12.x/connectors/dashboard/tableau/yaml.mdx
+++ b/v1.12.x/connectors/dashboard/tableau/yaml.mdx
@@ -47,6 +47,14 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 - To connect to a non-default Tableau site, use the `siteName` field instead. The Tableau Python SDK does not require `siteUrl` for authentication.
 - Ensure the `siteName` field is correctly populated (do not use `*`) to enable successful metadata ingestion for multi-site Tableau environments.
 </Tip>
+### Source Tables and Lineage
+
+<Warning>
+**Table lineage requires** the ingestion account to read external assets in Tableau Catalog. Without that access Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+</Warning>
+
+Grant the ingestion account access to external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer role alone is not enough for OpenMetadata to build table lineage.
+
 ### Python Requirements
 <PythonRequirements />
 To run the Tableau ingestion, you will need to install:

--- a/v1.13.x/connectors/dashboard/tableau.mdx
+++ b/v1.13.x/connectors/dashboard/tableau.mdx
@@ -47,6 +47,14 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 - To connect to a non-default Tableau site, use the `siteName` field instead. The Tableau Python SDK does not require `siteUrl` for authentication.
 - Ensure the `siteName` field is correctly populated (do not use `*`) to enable successful metadata ingestion for multi-site Tableau environments.
 </Tip>
+### Source Tables and Lineage
+
+<Warning>
+**Table lineage requires** the ingestion account to read external assets in Tableau Catalog. Without that access Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+</Warning>
+
+Grant the ingestion account access to external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer role alone is not enough for OpenMetadata to build table lineage.
+
 ## Entity Mapping
 The Tableau connector maps Tableau assets to OpenMetadata entities as follows:
 | Tableau Asset | OpenMetadata Entity | Description |

--- a/v1.13.x/connectors/dashboard/tableau.mdx
+++ b/v1.13.x/connectors/dashboard/tableau.mdx
@@ -50,10 +50,10 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 ### Source Tables and Lineage
 
 <Warning>
-**Table lineage requires** the ingestion account to read external assets in Tableau Catalog. Without that access Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+**Table lineage requires** the ingestion account to have the **View** capability on external assets in Tableau Catalog. Without it Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
 </Warning>
 
-Grant the ingestion account access to external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer role alone is not enough for OpenMetadata to build table lineage.
+Grant the ingestion account the **View** capability on external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
 
 ## Entity Mapping
 The Tableau connector maps Tableau assets to OpenMetadata entities as follows:

--- a/v1.13.x/connectors/dashboard/tableau.mdx
+++ b/v1.13.x/connectors/dashboard/tableau.mdx
@@ -50,10 +50,10 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 ### Source Tables and Lineage
 
 <Warning>
-**Table lineage requires** the ingestion account to have the **View** capability on external assets in Tableau Catalog. Without it Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+**Table lineage requires** the ingestion account to have the **View** capability on the external assets in Tableau Catalog, granted directly or derived. For any asset it cannot view, Tableau returns the source table with its table and database names removed, keeping only internal identifiers, and reports no error. Those tables are skipped without a message, so **no lineage is created between them and the data models that use them**. Assets the account can view are unaffected, and dashboards, charts and data models are still ingested either way.
 </Warning>
 
-Grant the ingestion account the **View** capability on external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
+Grant the ingestion account **View** on the affected external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
 
 ## Entity Mapping
 The Tableau connector maps Tableau assets to OpenMetadata entities as follows:

--- a/v1.13.x/connectors/dashboard/tableau/yaml.mdx
+++ b/v1.13.x/connectors/dashboard/tableau/yaml.mdx
@@ -50,10 +50,10 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 ### Source Tables and Lineage
 
 <Warning>
-**Table lineage requires** the ingestion account to read external assets in Tableau Catalog. Without that access Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+**Table lineage requires** the ingestion account to have the **View** capability on external assets in Tableau Catalog. Without it Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
 </Warning>
 
-Grant the ingestion account access to external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer role alone is not enough for OpenMetadata to build table lineage.
+Grant the ingestion account the **View** capability on external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
 
 ### Python Requirements
 <PythonRequirements />

--- a/v1.13.x/connectors/dashboard/tableau/yaml.mdx
+++ b/v1.13.x/connectors/dashboard/tableau/yaml.mdx
@@ -50,10 +50,10 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 ### Source Tables and Lineage
 
 <Warning>
-**Table lineage requires** the ingestion account to have the **View** capability on external assets in Tableau Catalog. Without it Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+**Table lineage requires** the ingestion account to have the **View** capability on the external assets in Tableau Catalog, granted directly or derived. For any asset it cannot view, Tableau returns the source table with its table and database names removed, keeping only internal identifiers, and reports no error. Those tables are skipped without a message, so **no lineage is created between them and the data models that use them**. Assets the account can view are unaffected, and dashboards, charts and data models are still ingested either way.
 </Warning>
 
-Grant the ingestion account the **View** capability on external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
+Grant the ingestion account **View** on the affected external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
 
 ### Python Requirements
 <PythonRequirements />

--- a/v1.13.x/connectors/dashboard/tableau/yaml.mdx
+++ b/v1.13.x/connectors/dashboard/tableau/yaml.mdx
@@ -47,6 +47,14 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 - To connect to a non-default Tableau site, use the `siteName` field instead. The Tableau Python SDK does not require `siteUrl` for authentication.
 - Ensure the `siteName` field is correctly populated (do not use `*`) to enable successful metadata ingestion for multi-site Tableau environments.
 </Tip>
+### Source Tables and Lineage
+
+<Warning>
+**Table lineage requires** the ingestion account to read external assets in Tableau Catalog. Without that access Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+</Warning>
+
+Grant the ingestion account access to external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer role alone is not enough for OpenMetadata to build table lineage.
+
 ### Python Requirements
 <PythonRequirements />
 To run the Tableau ingestion, you will need to install:

--- a/v2.0.x-SNAPSHOT/connectors/dashboard/tableau.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/dashboard/tableau.mdx
@@ -50,12 +50,10 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 ### Source Tables and Lineage
 
 <Warning>
-**Table lineage requires** the ingestion account to have the **View** capability on external assets in Tableau Catalog. Without it Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+**Table lineage requires** the ingestion account to have the **View** capability on the external assets in Tableau Catalog, granted directly or derived. For any asset it cannot view, Tableau returns the source table with its table and database names removed, keeping only internal identifiers, and reports no error. Those tables are skipped without a message, so **no lineage is created between them and the data models that use them**. Assets the account can view are unaffected, and dashboards, charts and data models are still ingested either way.
 </Warning>
 
-Grant the ingestion account the **View** capability on external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
-
-The **Get Source Tables** step in Test Connection reports when the names are missing.
+Grant the ingestion account **View** on the affected external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
 
 ## Entity Mapping
 The Tableau connector maps Tableau assets to OpenMetadata entities as follows:

--- a/v2.0.x-SNAPSHOT/connectors/dashboard/tableau.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/dashboard/tableau.mdx
@@ -47,6 +47,16 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 - To connect to a non-default Tableau site, use the `siteName` field instead. The Tableau Python SDK does not require `siteUrl` for authentication.
 - Ensure the `siteName` field is correctly populated (do not use `*`) to enable successful metadata ingestion for multi-site Tableau environments.
 </Tip>
+### Source Tables and Lineage
+
+<Warning>
+**Table lineage requires** the ingestion account to read external assets in Tableau Catalog. Without that access Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+</Warning>
+
+Grant the ingestion account access to external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer role alone is not enough for OpenMetadata to build table lineage.
+
+The **Get Source Tables** step in Test Connection reports when the names are missing.
+
 ## Entity Mapping
 The Tableau connector maps Tableau assets to OpenMetadata entities as follows:
 | Tableau Asset | OpenMetadata Entity | Description |

--- a/v2.0.x-SNAPSHOT/connectors/dashboard/tableau.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/dashboard/tableau.mdx
@@ -50,10 +50,10 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 ### Source Tables and Lineage
 
 <Warning>
-**Table lineage requires** the ingestion account to read external assets in Tableau Catalog. Without that access Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+**Table lineage requires** the ingestion account to have the **View** capability on external assets in Tableau Catalog. Without it Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
 </Warning>
 
-Grant the ingestion account access to external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer role alone is not enough for OpenMetadata to build table lineage.
+Grant the ingestion account the **View** capability on external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
 
 The **Get Source Tables** step in Test Connection reports when the names are missing.
 

--- a/v2.0.x-SNAPSHOT/connectors/dashboard/tableau/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/dashboard/tableau/yaml.mdx
@@ -47,6 +47,16 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 - To connect to a non-default Tableau site, use the `siteName` field instead. The Tableau Python SDK does not require `siteUrl` for authentication.
 - Ensure the `siteName` field is correctly populated (do not use `*`) to enable successful metadata ingestion for multi-site Tableau environments.
 </Tip>
+### Source Tables and Lineage
+
+<Warning>
+**Table lineage requires** the ingestion account to read external assets in Tableau Catalog. Without that access Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+</Warning>
+
+Grant the ingestion account access to external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer role alone is not enough for OpenMetadata to build table lineage.
+
+The **Get Source Tables** step in Test Connection reports when the names are missing.
+
 ### Python Requirements
 <PythonRequirements />
 To run the Tableau ingestion, you will need to install:

--- a/v2.0.x-SNAPSHOT/connectors/dashboard/tableau/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/dashboard/tableau/yaml.mdx
@@ -50,12 +50,10 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 ### Source Tables and Lineage
 
 <Warning>
-**Table lineage requires** the ingestion account to have the **View** capability on external assets in Tableau Catalog. Without it Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+**Table lineage requires** the ingestion account to have the **View** capability on the external assets in Tableau Catalog, granted directly or derived. For any asset it cannot view, Tableau returns the source table with its table and database names removed, keeping only internal identifiers, and reports no error. Those tables are skipped without a message, so **no lineage is created between them and the data models that use them**. Assets the account can view are unaffected, and dashboards, charts and data models are still ingested either way.
 </Warning>
 
-Grant the ingestion account the **View** capability on external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
-
-The **Get Source Tables** step in Test Connection reports when the names are missing.
+Grant the ingestion account **View** on the affected external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
 
 ### Python Requirements
 <PythonRequirements />

--- a/v2.0.x-SNAPSHOT/connectors/dashboard/tableau/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/dashboard/tableau/yaml.mdx
@@ -50,10 +50,10 @@ For more information on enabling the Tableau Metadata APIs follow the link [here
 ### Source Tables and Lineage
 
 <Warning>
-**Table lineage requires** the ingestion account to read external assets in Tableau Catalog. Without that access Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
+**Table lineage requires** the ingestion account to have the **View** capability on external assets in Tableau Catalog. Without it Tableau returns each source table with its table and database names removed, keeping only internal identifiers, and reports no error. Dashboards, charts and data models are still ingested, and data models are still linked to their dashboards, but **no lineage is created between tables and data models**.
 </Warning>
 
-Grant the ingestion account access to external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer role alone is not enough for OpenMetadata to build table lineage.
+Grant the ingestion account the **View** capability on external assets in Tableau Catalog, or use an account that already holds it. A Viewer or Explorer site role alone is not enough for OpenMetadata to build table lineage. For the steps, see [Manage Permissions for External Assets](https://help.tableau.com/current/server/en-us/dm_perms_assets.htm) in the Tableau documentation.
 
 The **Get Source Tables** step in Test Connection reports when the names are missing.
 


### PR DESCRIPTION
Fixes https://github.com/open-metadata/OpenMetadata/issues/31439

Tableau returns source tables to accounts without Tableau Catalog permissions on external assets with the table and database names removed, keeping only internal identifiers, and reports no error, so table lineage silently fails while dashboards, charts and data models are unaffected. Add a "Source Tables and Lineage" requirements subsection to the Tableau connector page and its YAML page, on v1.12.x, v1.13.x and v2.0.x-SNAPSHOT.