### PR TITLE
Docs: Document the GX 1.x action and the profileSampleConfig sampling shape

### DIFF
--- a/snippets/v1.13.x/connectors/yaml/data-profiler.mdx
+++ b/snippets/v1.13.x/connectors/yaml/data-profiler.mdx
@@ -25,43 +25,46 @@ Configure the source type and service name for your profiler workflow.
 
 </ContentSection>
 
-<ContentSection id={3} title="Profile Sample" lines="7">
+<ContentSection id={3} title="Profile Sample Config" lines="7-10">
 
-**profileSample**: Percentage of data or no. of rows we want to execute the profiler and tests on.
+**profileSampleConfig**: How much data the profiler and tests run on.
+
+- **sampleConfigType**: `DYNAMIC` (default) resolves the sample size at runtime from the table's row count. `STATIC` uses a fixed size you set yourself.
+- **config**: the settings for the chosen type. With `DYNAMIC`, `smartSampling: true` applies the built-in tiers; set it to `false` and provide `thresholds` to define your own. With `STATIC`, set `profileSample`, and optionally `profileSampleType` and `samplingMethodType`.
 
 </ContentSection>
 
-<ContentSection id={4} title="Thread Count" lines="8">
+<ContentSection id={4} title="Thread Count" lines="11">
 
 **threadCount**: Number of threads to use during metric computations.
 
 </ContentSection>
 
-<ContentSection id={5} title="Timeout Seconds" lines="9">
+<ContentSection id={5} title="Timeout Seconds" lines="12">
 
 **timeoutSeconds**: Profiler Timeout in Seconds.
 
 </ContentSection>
 
-<ContentSection id={6} title="Database Filter Pattern" lines="10-15">
+<ContentSection id={6} title="Database Filter Pattern" lines="13-18">
 
 **databaseFilterPattern**: Regex to only fetch databases that matches the pattern.
 
 </ContentSection>
 
-<ContentSection id={7} title="Schema Filter Pattern" lines="16-21">
+<ContentSection id={7} title="Schema Filter Pattern" lines="19-24">
 
 **schemaFilterPattern**: Regex to only fetch tables or databases that matches the pattern.
 
 </ContentSection>
 
-<ContentSection id={8} title="Table Filter Pattern" lines="22-27">
+<ContentSection id={8} title="Table Filter Pattern" lines="25-30">
 
 **tableFilterPattern**: Regex to only fetch tables or databases that matches the pattern.
 
 </ContentSection>
 
-<ContentSection id={9} title="Processor Configuration" lines="28-58">
+<ContentSection id={9} title="Processor Configuration" lines="31-64">
 
 Choose the `orm-profiler`. Its config can also be updated to define tests from the YAML itself instead of the UI.
 
@@ -73,7 +76,7 @@ Choose the `orm-profiler`. Its config can also be updated to define tests from t
 
 </ContentSection>
 
-<ContentSection id={10} title="Sink Configuration" lines="59-61">
+<ContentSection id={10} title="Sink Configuration" lines="65-67">
 
 To send the metadata to OpenMetadata, it needs to be specified as `type: metadata-rest`.
 
@@ -90,7 +93,10 @@ source:
   sourceConfig:
     config:
       type: Profiler
-      # profileSample: 85
+      # profileSampleConfig:
+      #   sampleConfigType: DYNAMIC  # DYNAMIC (default) or STATIC
+      #   config:
+      #     smartSampling: true
       # threadCount: 5
       # timeoutSeconds: 43200
       # databaseFilterPattern:
@@ -116,7 +122,10 @@ processor:
   config: {}  # Remove braces if adding properties
     # tableConfig:
     #   - fullyQualifiedName: <table fqn>
-    #     profileSample: <number between 0 and 99> # default will be 100 if omitted
+    #     profileSampleConfig:
+    #       sampleConfigType: STATIC  # omit entirely to inherit dynamic sampling
+    #       config:
+    #         profileSample: <number between 0 and 99>
     #     profileQuery: <query to use for sampling data for the profiler>
     #     columnConfig:
     #       excludeColumns:

--- a/snippets/v1.13.x/connectors/yaml/data-profiler.mdx
+++ b/snippets/v1.13.x/connectors/yaml/data-profiler.mdx
@@ -30,7 +30,7 @@ Configure the source type and service name for your profiler workflow.
 **profileSampleConfig**: How much data the profiler and tests run on.
 
 - **sampleConfigType**: `DYNAMIC` (default) resolves the sample size at runtime from the table's row count. `STATIC` uses a fixed size you set yourself.
-- **config**: the settings for the chosen type. With `DYNAMIC`, `smartSampling: true` applies the built-in tiers; set it to `false` and provide `thresholds` to define your own. With `STATIC`, set `profileSample`, and optionally `profileSampleType` and `samplingMethodType`.
+- **config**: the settings for the chosen type. With `DYNAMIC`, `smartSampling: true` applies the built-in tiers. Set it to `false` and provide `thresholds` to define your own. With `STATIC`, set `profileSample`, and optionally `profileSampleType` and `samplingMethodType`.
 
 </ContentSection>
 

--- a/snippets/v2.0.x-SNAPSHOT/connectors/yaml/data-profiler.mdx
+++ b/snippets/v2.0.x-SNAPSHOT/connectors/yaml/data-profiler.mdx
@@ -25,43 +25,46 @@ Configure the source type and service name for your profiler workflow.
 
 </ContentSection>
 
-<ContentSection id={3} title="Profile Sample" lines="7">
+<ContentSection id={3} title="Profile Sample Config" lines="7-10">
 
-**profileSample**: Percentage of data or no. of rows we want to execute the profiler and tests on.
+**profileSampleConfig**: How much data the profiler and tests run on.
+
+- **sampleConfigType**: `DYNAMIC` (default) resolves the sample size at runtime from the table's row count. `STATIC` uses a fixed size you set yourself.
+- **config**: the settings for the chosen type. With `DYNAMIC`, `smartSampling: true` applies the built-in tiers; set it to `false` and provide `thresholds` to define your own. With `STATIC`, set `profileSample`, and optionally `profileSampleType` and `samplingMethodType`.
 
 </ContentSection>
 
-<ContentSection id={4} title="Thread Count" lines="8">
+<ContentSection id={4} title="Thread Count" lines="11">
 
 **threadCount**: Number of threads to use during metric computations.
 
 </ContentSection>
 
-<ContentSection id={5} title="Timeout Seconds" lines="9">
+<ContentSection id={5} title="Timeout Seconds" lines="12">
 
 **timeoutSeconds**: Profiler Timeout in Seconds.
 
 </ContentSection>
 
-<ContentSection id={6} title="Database Filter Pattern" lines="10-15">
+<ContentSection id={6} title="Database Filter Pattern" lines="13-18">
 
 **databaseFilterPattern**: Regex to only fetch databases that matches the pattern.
 
 </ContentSection>
 
-<ContentSection id={7} title="Schema Filter Pattern" lines="16-21">
+<ContentSection id={7} title="Schema Filter Pattern" lines="19-24">
 
 **schemaFilterPattern**: Regex to only fetch tables or databases that matches the pattern.
 
 </ContentSection>
 
-<ContentSection id={8} title="Table Filter Pattern" lines="22-27">
+<ContentSection id={8} title="Table Filter Pattern" lines="25-30">
 
 **tableFilterPattern**: Regex to only fetch tables or databases that matches the pattern.
 
 </ContentSection>
 
-<ContentSection id={9} title="Processor Configuration" lines="28-58">
+<ContentSection id={9} title="Processor Configuration" lines="31-64">
 
 Choose the `orm-profiler`. Its config can also be updated to define tests from the YAML itself instead of the UI.
 
@@ -73,7 +76,7 @@ Choose the `orm-profiler`. Its config can also be updated to define tests from t
 
 </ContentSection>
 
-<ContentSection id={10} title="Sink Configuration" lines="59-61">
+<ContentSection id={10} title="Sink Configuration" lines="65-67">
 
 To send the metadata to OpenMetadata, it needs to be specified as `type: metadata-rest`.
 
@@ -90,7 +93,10 @@ source:
   sourceConfig:
     config:
       type: Profiler
-      # profileSample: 85
+      # profileSampleConfig:
+      #   sampleConfigType: DYNAMIC  # DYNAMIC (default) or STATIC
+      #   config:
+      #     smartSampling: true
       # threadCount: 5
       # timeoutSeconds: 43200
       # databaseFilterPattern:
@@ -116,7 +122,10 @@ processor:
   config: {}  # Remove braces if adding properties
     # tableConfig:
     #   - fullyQualifiedName: <table fqn>
-    #     profileSample: <number between 0 and 99> # default will be 100 if omitted
+    #     profileSampleConfig:
+    #       sampleConfigType: STATIC  # omit entirely to inherit dynamic sampling
+    #       config:
+    #         profileSample: <number between 0 and 99>
     #     profileQuery: <query to use for sampling data for the profiler>
     #     columnConfig:
     #       excludeColumns:

--- a/snippets/v2.0.x-SNAPSHOT/connectors/yaml/data-profiler.mdx
+++ b/snippets/v2.0.x-SNAPSHOT/connectors/yaml/data-profiler.mdx
@@ -30,7 +30,7 @@ Configure the source type and service name for your profiler workflow.
 **profileSampleConfig**: How much data the profiler and tests run on.
 
 - **sampleConfigType**: `DYNAMIC` (default) resolves the sample size at runtime from the table's row count. `STATIC` uses a fixed size you set yourself.
-- **config**: the settings for the chosen type. With `DYNAMIC`, `smartSampling: true` applies the built-in tiers; set it to `false` and provide `thresholds` to define your own. With `STATIC`, set `profileSample`, and optionally `profileSampleType` and `samplingMethodType`.
+- **config**: the settings for the chosen type. With `DYNAMIC`, `smartSampling: true` applies the built-in tiers. Set it to `false` and provide `thresholds` to define your own. With `STATIC`, set `profileSample`, and optionally `profileSampleType` and `samplingMethodType`.
 
 </ContentSection>
 

--- a/snippets/v2.0.x-SNAPSHOT/deployment/upgrade/upgrade-prerequisites.mdx
+++ b/snippets/v2.0.x-SNAPSHOT/deployment/upgrade/upgrade-prerequisites.mdx
@@ -18,6 +18,22 @@ import { VERSION_MATRIX_DATA_WITH_UPDATES } from '/snippets/components/VersionMa
 
 - Changed field from **status** to **entityStatus** for **glossaryTerm** and **dataContract**, as we introduce it for different data assets.
 - For Data Contracts, the value also changed from **Active** to **Approved**.
+
+- **Great Expectations:** the validation action now requires **Great Expectations 1.3 or later**. Support for the 0.18 line has been removed, and `openmetadata-ingestion[great-expectations]` now installs `great-expectations~=1.3`. The separate `great-expectations-1xx` extra no longer exists.
+
+  If you adopted the interim GX 1.x module during 1.13, rename it in your checkpoint. `metadata.great_expectations.action1xx` and `OpenMetadataValidationAction1xx` have been removed:
+
+  ```python
+  # Before
+  from metadata.great_expectations.action1xx import OpenMetadataValidationAction1xx
+
+  # After
+  from metadata.great_expectations.action import OpenMetadataValidationAction
+  ```
+
+  Checkpoints that already reference `metadata.great_expectations.action` and `OpenMetadataValidationAction` keep those names, but the surrounding checkpoint definition has to move to the GX 1.x API: actions are passed as objects to `Checkpoint(actions=[...])` rather than as an `action_list` of dictionaries, and `great_expectations checkpoint run` is replaced by `checkpoint.run()`. See the [Great Expectations](/v2.0.x-SNAPSHOT/connectors/ingestion/great-expectations) guide for the updated configuration.
+
+  Test case results now report row counts only — `unexpected_count`, `missing_count`, `element_count` and `observed_value`. The percentage values (`unexpected_percent`, `unexpected_percent_total`, `missing_percent`, `success_rate`) are no longer sent, because OpenMetadata charts every result value of a test case on a single axis and percentages plotted next to row counts were unreadable. Percentages remain derivable as `unexpected_count / element_count`.
 </BreakingChanges>
 
 ## Prerequisites

--- a/snippets/v2.0.x-SNAPSHOT/deployment/upgrade/upgrade-prerequisites.mdx
+++ b/snippets/v2.0.x-SNAPSHOT/deployment/upgrade/upgrade-prerequisites.mdx
@@ -19,7 +19,7 @@ import { VERSION_MATRIX_DATA_WITH_UPDATES } from '/snippets/components/VersionMa
 - Changed field from **status** to **entityStatus** for **glossaryTerm** and **dataContract**, as we introduce it for different data assets.
 - For Data Contracts, the value also changed from **Active** to **Approved**.
 
-- **Great Expectations:** the validation action now requires **Great Expectations 1.3 or later**. Support for the 0.18 line has been removed, and `openmetadata-ingestion[great-expectations]` now installs `great-expectations~=1.3`. The separate `great-expectations-1xx` extra no longer exists.
+- **Great Expectations:** the validation action now requires **Great Expectations 1.3 or later**. OpenMetadata 2.0 drops support for the 0.18 line, and `openmetadata-ingestion[great-expectations]` now installs `great-expectations~=1.3`. The separate `great-expectations-1xx` extra no longer exists.
 
   If you adopted the interim GX 1.x module during 1.13, rename it in your checkpoint. `metadata.great_expectations.action1xx` and `OpenMetadataValidationAction1xx` have been removed:
 
@@ -31,9 +31,9 @@ import { VERSION_MATRIX_DATA_WITH_UPDATES } from '/snippets/components/VersionMa
   from metadata.great_expectations.action import OpenMetadataValidationAction
   ```
 
-  Checkpoints that already reference `metadata.great_expectations.action` and `OpenMetadataValidationAction` keep those names, but the surrounding checkpoint definition has to move to the GX 1.x API: actions are passed as objects to `Checkpoint(actions=[...])` rather than as an `action_list` of dictionaries, and `great_expectations checkpoint run` is replaced by `checkpoint.run()`. See the [Great Expectations](/v2.0.x-SNAPSHOT/connectors/ingestion/great-expectations) guide for the updated configuration.
+  Checkpoints that already reference `metadata.great_expectations.action` and `OpenMetadataValidationAction` keep those names. The surrounding checkpoint definition still has to move to the GX 1.x API. Pass actions as objects to `Checkpoint(actions=[...])` rather than as an `action_list` of dictionaries, and call `checkpoint.run()` instead of `great_expectations checkpoint run`. See the [Great Expectations](/v2.0.x-SNAPSHOT/connectors/ingestion/great-expectations) guide for the updated configuration.
 
-  Test case results now report row counts only — `unexpected_count`, `missing_count`, `element_count` and `observed_value`. The percentage values (`unexpected_percent`, `unexpected_percent_total`, `missing_percent`, `success_rate`) are no longer sent, because OpenMetadata charts every result value of a test case on a single axis and percentages plotted next to row counts were unreadable. Percentages remain derivable as `unexpected_count / element_count`.
+  Test case results now report row counts only — `unexpected_count`, `missing_count`, `element_count`, and `observed_value`. The percentage values (`unexpected_percent`, `unexpected_percent_total`, `missing_percent`, and `success_rate`) are no longer sent, because OpenMetadata charts every result value of a test case on a single axis and percentages plotted next to row counts were unreadable. Percentages remain derivable as `unexpected_count / element_count`.
 </BreakingChanges>
 
 ## Prerequisites

--- a/v1.13.x/api-reference/data-assets/database-schemas/advanced.mdx
+++ b/v1.13.x/api-reference/data-assets/database-schemas/advanced.mdx
@@ -94,8 +94,13 @@ config = DatabaseSchemas.get_profiler_config(schema_id)
 
 # Set profiler config
 DatabaseSchemas.set_profiler_config(schema_id, {
-    "profileSample": 50,
-    "profileSampleType": "PERCENTAGE",
+    "profileSampleConfig": {
+      "sampleConfigType": "STATIC",
+      "config": {
+        "profileSample": 50,
+        "profileSampleType": "PERCENTAGE"
+      }
+    },
     "sampleDataCount": 200
 })
 
@@ -145,8 +150,13 @@ curl -X PUT "{base_url}/api/v1/databaseSchemas/f681432b-e66c-4096-a1cd-7771358c5
   -H "Authorization: Bearer {access_token}" \
   -H "Content-Type: application/json" \
   -d '{
-    "profileSample": 50,
-    "profileSampleType": "PERCENTAGE",
+    "profileSampleConfig": {
+      "sampleConfigType": "STATIC",
+      "config": {
+        "profileSample": 50,
+        "profileSampleType": "PERCENTAGE"
+      }
+    },
     "sampleDataCount": 200
   }'
 

--- a/v1.13.x/api-reference/data-assets/databases/advanced.mdx
+++ b/v1.13.x/api-reference/data-assets/databases/advanced.mdx
@@ -94,8 +94,13 @@ config = Databases.get_profiler_config(database_id)
 
 # Set profiler config
 Databases.set_profiler_config(database_id, {
-    "profileSample": 50,
-    "profileSampleType": "PERCENTAGE",
+    "profileSampleConfig": {
+      "sampleConfigType": "STATIC",
+      "config": {
+        "profileSample": 50,
+        "profileSampleType": "PERCENTAGE"
+      }
+    },
     "sampleDataCount": 200
 })
 
@@ -145,8 +150,13 @@ curl -X PUT "{base_url}/api/v1/databases/1d08c2c6-cea7-4adf-9043-0f6a6aaf9721/pr
   -H "Authorization: Bearer {access_token}" \
   -H "Content-Type: application/json" \
   -d '{
-    "profileSample": 50,
-    "profileSampleType": "PERCENTAGE",
+    "profileSampleConfig": {
+      "sampleConfigType": "STATIC",
+      "config": {
+        "profileSample": 50,
+        "profileSampleType": "PERCENTAGE"
+      }
+    },
     "sampleDataCount": 200
   }'
 

--- a/v1.13.x/api-reference/data-assets/tables/profiler.mdx
+++ b/v1.13.x/api-reference/data-assets/tables/profiler.mdx
@@ -25,12 +25,12 @@ Manage the profiler configuration for a table and retrieve profiling results inc
   UUID of the table.
 </ParamField>
 
-<ParamField body="profileSample" type="number">
-  Sample size for profiling (percentage or row count depending on `profileSampleType`).
-</ParamField>
+<ParamField body="profileSampleConfig" type="object">
+  How much data to profile. Contains `sampleConfigType` (`STATIC` or `DYNAMIC`, defaults to `DYNAMIC`) and a `config` object holding the settings for that type.
 
-<ParamField body="profileSampleType" type="string">
-  Type of sample: `PERCENTAGE` or `ROWS`.
+  For `STATIC`, `config` takes `profileSample` (number), `profileSampleType` (`PERCENTAGE` or `ROWS`) and optionally `samplingMethodType` (`BERNOULLI` or `SYSTEM`).
+
+  For `DYNAMIC`, `config` takes `smartSampling` (boolean, defaults to `true`) and optionally `thresholds`, a list of `{rowCountThreshold, profileSample}` tiers.
 </ParamField>
 
 <ParamField body="sampleDataCount" type="integer">
@@ -111,20 +111,25 @@ table_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
 # Get profiler config
 config = Tables.get_profiler_config(table_id)
-print(f"Sample: {config.get('profileSample')}%")
+sample_config = config.get("profileSampleConfig", {}).get("config", {})
+print(f"Sample: {sample_config.get('profileSample')}%")
 
 # Set profiler config - profile 50% of rows
 Tables.set_profiler_config(table_id, {
-    "profileSample": 50,
-    "profileSampleType": "PERCENTAGE",
+    "profileSampleConfig": {
+        "sampleConfigType": "STATIC",
+        "config": {"profileSample": 50, "profileSampleType": "PERCENTAGE"}
+    },
     "sampleDataCount": 200,
     "excludeColumns": ["created_at"]
 })
 
 # Set profiler config with specific column metrics
 Tables.set_profiler_config(table_id, {
-    "profileSample": 100,
-    "profileSampleType": "PERCENTAGE",
+    "profileSampleConfig": {
+        "sampleConfigType": "STATIC",
+        "config": {"profileSample": 100, "profileSampleType": "PERCENTAGE"}
+    },
     "includeColumns": [
         {"columnName": "email", "metrics": ["distinctCount", "nullCount"]},
         {"columnName": "name", "metrics": ["distinctCount", "maxLength", "minLength"]}
@@ -145,8 +150,10 @@ var config = Tables.getProfilerConfig(tableId);
 
 // Set profiler config
 Tables.setProfilerConfig(tableId, Map.of(
-    "profileSample", 50,
-    "profileSampleType", "PERCENTAGE",
+    "profileSampleConfig", Map.of(
+        "sampleConfigType", "STATIC",
+        "config", Map.of("profileSample", 50, "profileSampleType", "PERCENTAGE")
+    ),
     "sampleDataCount", 200,
     "excludeColumns", List.of("created_at")
 ));
@@ -165,8 +172,10 @@ curl -X PUT "{base_url}/api/v1/tables/455e3d9d-dbbf-455e-b3be-7191daa825f3/profi
   -H "Authorization: Bearer {access_token}" \
   -H "Content-Type: application/json" \
   -d '{
-    "profileSample": 50,
-    "profileSampleType": "PERCENTAGE",
+    "profileSampleConfig": {
+      "sampleConfigType": "STATIC",
+      "config": {"profileSample": 50, "profileSampleType": "PERCENTAGE"}
+    },
     "sampleDataCount": 200,
     "excludeColumns": ["performance_score"]
   }'
@@ -192,8 +201,10 @@ curl "{base_url}/api/v1/tables/455e3d9d-dbbf-455e-b3be-7191daa825f3/systemProfil
 <ResponseExample>
 ```json Response (Profiler Config)
 {
-  "profileSample": 50,
-  "profileSampleType": "PERCENTAGE",
+  "profileSampleConfig": {
+    "sampleConfigType": "STATIC",
+    "config": {"profileSample": 50, "profileSampleType": "PERCENTAGE"}
+  },
   "sampleDataCount": 200,
   "excludeColumns": ["created_at"]
 }
@@ -218,12 +229,8 @@ curl "{base_url}/api/v1/tables/455e3d9d-dbbf-455e-b3be-7191daa825f3/systemProfil
 
 ## Response (Profiler Config)
 
-<ResponseField name="profileSample" type="number">
-  Sample size for profiling.
-</ResponseField>
-
-<ResponseField name="profileSampleType" type="string">
-  Type of sample: `PERCENTAGE` or `ROWS`.
+<ResponseField name="profileSampleConfig" type="object">
+  How much data is profiled. Contains `sampleConfigType` (`STATIC` or `DYNAMIC`) and a `config` object holding the settings for that type.
 </ResponseField>
 
 <ResponseField name="sampleDataCount" type="integer">

--- a/v1.13.x/api-reference/sdk/python/api-reference/table-mixin.mdx
+++ b/v1.13.x/api-reference/sdk/python/api-reference/table-mixin.mdx
@@ -63,13 +63,14 @@ create_or_update_table_profiler_config(
 ) → Optional[Table]
 ```
 
-Update the profileSample property of a Table, given its FQN.
+Update the profiler configuration of a Table, given its FQN.
 
 **Args:**
 
 `fqn`: Table FQN
 
-`profile_sample`: new profile sample to set
+`table_profiler_config`: the `TableProfilerConfig` to set. Sampling lives under its
+`profileSampleConfig` field
 
 **Returns:**
 

--- a/v1.13.x/developers/contribute/codebase-deep-dives/sampler.mdx
+++ b/v1.13.x/developers/contribute/codebase-deep-dives/sampler.mdx
@@ -106,14 +106,17 @@ Defined in `models.py`:
 
 ```
 SampleConfig
-  ├── profileSample: float         # Percentage (e.g., 50.0) or row count
-  ├── profileSampleType: PERCENTAGE | ROWS
-  ├── samplingMethodType: BERNOULLI | SYSTEM   # Database-specific method
+  ├── profileSampleConfig: ProfileSampleConfig | None
+  │     ├── sampleConfigType: STATIC | DYNAMIC
+  │     └── config: StaticSamplingConfig | DynamicSamplingConfig
+  │           ├── (static)  profileSample / profileSampleType / samplingMethodType
+  │           └── (dynamic) smartSampling: bool / thresholds: list
   └── randomizedSample: bool       # Whether to randomize row selection
 
-TableConfig
+TableConfig                        # extends BaseProfileConfig
   ├── fullyQualifiedName: str
-  ├── profileSample / profileSampleType / samplingMethodType
+  ├── profileSampleConfig: ProfileSampleConfig | None
+  ├── profileSample / profileSampleType / samplingMethodType   # resolved values
   ├── profileQuery: str            # Custom SQL for sampling
   ├── partitionConfig: ...         # Partition filtering
   └── columnConfig: ColumnConfig   # Include/exclude columns
@@ -277,7 +280,7 @@ Supports:
 For NoSQL databases (MongoDB, DynamoDB), `NoSQLSampler`:
 
 - Uses `NoSQLAdaptor` to abstract database-specific operations
-- Converts percentage to row count: `num_rows * (profileSample / 100)`
+- Converts percentage to row count: `num_rows * (profileSample / 100)`, using the sample resolved from `profileSampleConfig`
 - Calls `client.scan(limit=N)` for sampling
 - Transposes list-of-dicts format into columnar `TableData`
 
@@ -293,10 +296,13 @@ For NoSQL databases (MongoDB, DynamoDB), `NoSQLSampler`:
     from metadata.sampler.sqlalchemy.sampler import SQASampler
 
     class MyDBSampler(SQASampler):
-        def set_tablesample(self, selectable):
-            # Add your database's TABLESAMPLE clause
+        def set_tablesample(self, static: StaticSamplingConfig | None, selectable):
+            # Add your database's TABLESAMPLE clause. The static config is resolved
+            # by the caller, so dynamic sampling is already collapsed to a number.
+            if not static:
+                return selectable
             return selectable.tablesample(
-                func.bernoulli(self.sample_config.profileSample)
+                func.bernoulli(static.profileSample)
             )
     ```
   </Step>

--- a/v1.13.x/how-to-guides/data-quality-observability/profiler/external-workflow.mdx
+++ b/v1.13.x/how-to-guides/data-quality-observability/profiler/external-workflow.mdx
@@ -87,8 +87,11 @@ processor:
     # schemaConfig:
     # - fullyQualifiedName: demo_snowflake.new_database.new_dschema
     #   sampleDataCount: 50
-    #   profileSample: 1
-    #   profileSampleType: ROWS
+    #   profileSampleConfig:
+    #     sampleConfigType: STATIC
+    #     config:
+    #       profileSample: 1
+    #       profileSampleType: ROWS
     #   sampleDataStorageConfig:
     #     config:
     #       bucketName: awsdatalake-testing
@@ -105,8 +108,11 @@ processor:
     # databaseConfig:
     # - fullyQualifiedName: snowflake_prod.prod_db
     #   sampleDataCount: 50
-    #   profileSample: 1
-    #   profileSampleType: ROWS
+    #   profileSampleConfig:
+    #     sampleConfigType: STATIC
+    #     config:
+    #       profileSample: 1
+    #       profileSampleType: ROWS
     #   sampleDataStorageConfig:
     #     config:
     #       bucketName: awsdatalake-testing

--- a/v1.13.x/how-to-guides/data-quality-observability/profiler/profiler-workflow.mdx
+++ b/v1.13.x/how-to-guides/data-quality-observability/profiler/profiler-workflow.mdx
@@ -154,11 +154,16 @@ This is a good option if you which to execute your workflow via the Airflow SDK 
 This is a sample config for the profiler:
 
 <Steps>
-<Step title="computeMetrics">
-**computeMetrics**: Option to turn on/off computing profiler metrics. This flag is useful when you want to only ingest the sample data with the profiler workflow and not any other information.
+<Step title="computeTableMetrics">
+**computeTableMetrics**: Option to turn on/off computing table level metrics. Turn both this and `computeColumnMetrics` off when you only want to ingest sample data with the profiler workflow and not any other information.
 </Step>
-<Step title="profileSample">
-**profileSample**: Percentage of data or no. of rows we want to execute the profiler and tests on.
+<Step title="computeColumnMetrics">
+**computeColumnMetrics**: Option to turn on/off computing column level metrics.
+</Step>
+<Step title="profileSampleConfig">
+**profileSampleConfig**: How much data the profiler and tests run on.
+
+`sampleConfigType` is either `DYNAMIC` (the default), which resolves the sample size at runtime from the table's row count, or `STATIC`, which uses a fixed size you set yourself. `config` holds the settings for the type you chose.
 </Step>
 <Step title="threadCount">
 **threadCount**: Number of threads to use during metric computations.
@@ -203,8 +208,12 @@ source:
   sourceConfig:
     config:
       type: Profiler
-computeMetrics: true
-# profileSample: 85
+computeTableMetrics: true
+computeColumnMetrics: true
+# profileSampleConfig:
+#   sampleConfigType: DYNAMIC
+#   config:
+#     smartSampling: true
 # threadCount: 5
 # timeoutSeconds: 43200
 # databaseFilterPattern:
@@ -233,9 +242,10 @@ processor:
   config: {}  # Remove braces if adding properties
     # tableConfig:
     #   - fullyQualifiedName: <table fqn>
-    #     profileSample: <number between 0 and 99> # default
-
-    #     profileSample: <number between 0 and 99> # default will be 100 if omitted
+    #     profileSampleConfig:
+    #       sampleConfigType: STATIC  # omit entirely to inherit dynamic sampling
+    #       config:
+    #         profileSample: <number between 0 and 99>
     #     columnConfig:
     #       excludeColumns:
     #         - <column name>

--- a/v1.13.x/how-to-guides/data-quality-observability/profiler/profiler-workflow.mdx
+++ b/v1.13.x/how-to-guides/data-quality-observability/profiler/profiler-workflow.mdx
@@ -155,10 +155,10 @@ This is a sample config for the profiler:
 
 <Steps>
 <Step title="computeTableMetrics">
-**computeTableMetrics**: Option to turn on/off computing table level metrics. Turn both this and `computeColumnMetrics` off when you only want to ingest sample data with the profiler workflow and not any other information.
+**computeTableMetrics**: Option to turn on/off computing table-level metrics. Turn both this and `computeColumnMetrics` off when you only want to ingest sample data with the profiler workflow and not any other information.
 </Step>
 <Step title="computeColumnMetrics">
-**computeColumnMetrics**: Option to turn on/off computing column level metrics.
+**computeColumnMetrics**: Option to turn on/off computing column-level metrics.
 </Step>
 <Step title="profileSampleConfig">
 **profileSampleConfig**: How much data the profiler and tests run on.

--- a/v1.13.x/sdk/python/api-reference/table-mixin.mdx
+++ b/v1.13.x/sdk/python/api-reference/table-mixin.mdx
@@ -63,13 +63,14 @@ create_or_update_table_profiler_config(
 ) → Optional[Table]
 ```
 
-Update the profileSample property of a Table, given its FQN.
+Update the profiler configuration of a Table, given its FQN.
 
 **Args:**
 
 `fqn`: Table FQN
 
-`profile_sample`: new profile sample to set
+`table_profiler_config`: the `TableProfilerConfig` to set. Sampling lives under its
+`profileSampleConfig` field
 
 **Returns:**
 

--- a/v2.0.x-SNAPSHOT/api-reference/data-assets/database-schemas/advanced.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference/data-assets/database-schemas/advanced.mdx
@@ -94,8 +94,13 @@ config = DatabaseSchemas.get_profiler_config(schema_id)
 
 # Set profiler config
 DatabaseSchemas.set_profiler_config(schema_id, {
-    "profileSample": 50,
-    "profileSampleType": "PERCENTAGE",
+    "profileSampleConfig": {
+      "sampleConfigType": "STATIC",
+      "config": {
+        "profileSample": 50,
+        "profileSampleType": "PERCENTAGE"
+      }
+    },
     "sampleDataCount": 200
 })
 
@@ -145,8 +150,13 @@ curl -X PUT "{base_url}/api/v1/databaseSchemas/f681432b-e66c-4096-a1cd-7771358c5
   -H "Authorization: Bearer {access_token}" \
   -H "Content-Type: application/json" \
   -d '{
-    "profileSample": 50,
-    "profileSampleType": "PERCENTAGE",
+    "profileSampleConfig": {
+      "sampleConfigType": "STATIC",
+      "config": {
+        "profileSample": 50,
+        "profileSampleType": "PERCENTAGE"
+      }
+    },
     "sampleDataCount": 200
   }'
 

--- a/v2.0.x-SNAPSHOT/api-reference/data-assets/databases/advanced.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference/data-assets/databases/advanced.mdx
@@ -94,8 +94,13 @@ config = Databases.get_profiler_config(database_id)
 
 # Set profiler config
 Databases.set_profiler_config(database_id, {
-    "profileSample": 50,
-    "profileSampleType": "PERCENTAGE",
+    "profileSampleConfig": {
+      "sampleConfigType": "STATIC",
+      "config": {
+        "profileSample": 50,
+        "profileSampleType": "PERCENTAGE"
+      }
+    },
     "sampleDataCount": 200
 })
 
@@ -145,8 +150,13 @@ curl -X PUT "{base_url}/api/v1/databases/1d08c2c6-cea7-4adf-9043-0f6a6aaf9721/pr
   -H "Authorization: Bearer {access_token}" \
   -H "Content-Type: application/json" \
   -d '{
-    "profileSample": 50,
-    "profileSampleType": "PERCENTAGE",
+    "profileSampleConfig": {
+      "sampleConfigType": "STATIC",
+      "config": {
+        "profileSample": 50,
+        "profileSampleType": "PERCENTAGE"
+      }
+    },
     "sampleDataCount": 200
   }'
 

--- a/v2.0.x-SNAPSHOT/api-reference/data-assets/tables/profiler.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference/data-assets/tables/profiler.mdx
@@ -25,12 +25,12 @@ Manage the profiler configuration for a table and retrieve profiling results inc
   UUID of the table.
 </ParamField>
 
-<ParamField body="profileSample" type="number">
-  Sample size for profiling (percentage or row count depending on `profileSampleType`).
-</ParamField>
+<ParamField body="profileSampleConfig" type="object">
+  How much data to profile. Contains `sampleConfigType` (`STATIC` or `DYNAMIC`, defaults to `DYNAMIC`) and a `config` object holding the settings for that type.
 
-<ParamField body="profileSampleType" type="string">
-  Type of sample: `PERCENTAGE` or `ROWS`.
+  For `STATIC`, `config` takes `profileSample` (number), `profileSampleType` (`PERCENTAGE` or `ROWS`) and optionally `samplingMethodType` (`BERNOULLI` or `SYSTEM`).
+
+  For `DYNAMIC`, `config` takes `smartSampling` (boolean, defaults to `true`) and optionally `thresholds`, a list of `{rowCountThreshold, profileSample}` tiers.
 </ParamField>
 
 <ParamField body="sampleDataCount" type="integer">
@@ -111,20 +111,25 @@ table_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
 # Get profiler config
 config = Tables.get_profiler_config(table_id)
-print(f"Sample: {config.get('profileSample')}%")
+sample_config = config.get("profileSampleConfig", {}).get("config", {})
+print(f"Sample: {sample_config.get('profileSample')}%")
 
 # Set profiler config - profile 50% of rows
 Tables.set_profiler_config(table_id, {
-    "profileSample": 50,
-    "profileSampleType": "PERCENTAGE",
+    "profileSampleConfig": {
+        "sampleConfigType": "STATIC",
+        "config": {"profileSample": 50, "profileSampleType": "PERCENTAGE"}
+    },
     "sampleDataCount": 200,
     "excludeColumns": ["created_at"]
 })
 
 # Set profiler config with specific column metrics
 Tables.set_profiler_config(table_id, {
-    "profileSample": 100,
-    "profileSampleType": "PERCENTAGE",
+    "profileSampleConfig": {
+        "sampleConfigType": "STATIC",
+        "config": {"profileSample": 100, "profileSampleType": "PERCENTAGE"}
+    },
     "includeColumns": [
         {"columnName": "email", "metrics": ["distinctCount", "nullCount"]},
         {"columnName": "name", "metrics": ["distinctCount", "maxLength", "minLength"]}
@@ -145,8 +150,10 @@ var config = Tables.getProfilerConfig(tableId);
 
 // Set profiler config
 Tables.setProfilerConfig(tableId, Map.of(
-    "profileSample", 50,
-    "profileSampleType", "PERCENTAGE",
+    "profileSampleConfig", Map.of(
+        "sampleConfigType", "STATIC",
+        "config", Map.of("profileSample", 50, "profileSampleType", "PERCENTAGE")
+    ),
     "sampleDataCount", 200,
     "excludeColumns", List.of("created_at")
 ));
@@ -165,8 +172,10 @@ curl -X PUT "{base_url}/api/v1/tables/455e3d9d-dbbf-455e-b3be-7191daa825f3/profi
   -H "Authorization: Bearer {access_token}" \
   -H "Content-Type: application/json" \
   -d '{
-    "profileSample": 50,
-    "profileSampleType": "PERCENTAGE",
+    "profileSampleConfig": {
+      "sampleConfigType": "STATIC",
+      "config": {"profileSample": 50, "profileSampleType": "PERCENTAGE"}
+    },
     "sampleDataCount": 200,
     "excludeColumns": ["performance_score"]
   }'
@@ -192,8 +201,10 @@ curl "{base_url}/api/v1/tables/455e3d9d-dbbf-455e-b3be-7191daa825f3/systemProfil
 <ResponseExample>
 ```json Response (Profiler Config)
 {
-  "profileSample": 50,
-  "profileSampleType": "PERCENTAGE",
+  "profileSampleConfig": {
+    "sampleConfigType": "STATIC",
+    "config": {"profileSample": 50, "profileSampleType": "PERCENTAGE"}
+  },
   "sampleDataCount": 200,
   "excludeColumns": ["created_at"]
 }
@@ -218,12 +229,8 @@ curl "{base_url}/api/v1/tables/455e3d9d-dbbf-455e-b3be-7191daa825f3/systemProfil
 
 ## Response (Profiler Config)
 
-<ResponseField name="profileSample" type="number">
-  Sample size for profiling.
-</ResponseField>
-
-<ResponseField name="profileSampleType" type="string">
-  Type of sample: `PERCENTAGE` or `ROWS`.
+<ResponseField name="profileSampleConfig" type="object">
+  How much data is profiled. Contains `sampleConfigType` (`STATIC` or `DYNAMIC`) and a `config` object holding the settings for that type.
 </ResponseField>
 
 <ResponseField name="sampleDataCount" type="integer">

--- a/v2.0.x-SNAPSHOT/api-reference/sdk/python/api-reference/table-mixin.mdx
+++ b/v2.0.x-SNAPSHOT/api-reference/sdk/python/api-reference/table-mixin.mdx
@@ -63,13 +63,14 @@ create_or_update_table_profiler_config(
 ) → Optional[Table]
 ```
 
-Update the profileSample property of a Table, given its FQN.
+Update the profiler configuration of a Table, given its FQN.
 
 **Args:**
 
 `fqn`: Table FQN
 
-`profile_sample`: new profile sample to set
+`table_profiler_config`: the `TableProfilerConfig` to set. Sampling lives under its
+`profileSampleConfig` field
 
 **Returns:**
 

--- a/v2.0.x-SNAPSHOT/connectors/ingestion/great-expectations.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/ingestion/great-expectations.mdx
@@ -7,10 +7,18 @@ sidebarTitle: Great Expectations
 # Great Expectations
 For Data Quality tests the open source python package Great Expectations stands out from the crowd. For those of you who don't know, [Great Expectations](https://greatexpectations.io/) is a shared, open standard for data quality. It helps data teams eliminate pipeline debt, through data testing, documentation, and profiling. Learn more about the product in [their documentation](https://docs.greatexpectations.io/docs/).  With this tutorial, we show you how to configure Great Expectations to integrate with OpenMetadata and ingest your test results to your table service page.
 
+<Warning>
+**Great Expectations 1.3 or later is required.**
+
+Support for the Great Expectations 0.18 line was removed in OpenMetadata 2.0. The `OpenMetadataValidationAction1xx` class and the `metadata.great_expectations.action1xx` module that shipped alongside it during the transition have also been removed — use `OpenMetadataValidationAction` from `metadata.great_expectations.action` instead.
+
+Great Expectations 1.x removed the `great_expectations` CLI and the YAML checkpoint file. Checkpoints are now defined in Python, and the OpenMetadata action is passed as an object rather than an `action_list` entry. See [Upgrade Prerequisites](/v2.0.x-SNAPSHOT/deployment/upgrade) for the full list of breaking changes.
+</Warning>
+
 ## Requirements
 
 ### OpenMetadata Requirements
-You will to have OpenMetadata version 0.12 or later.
+You will need to have OpenMetadata version 1.13 or later.
 
 To deploy OpenMetadata, follow the procedure to [Try OpenMetadata in Docker](/v2.0.x-SNAPSHOT/quick-start/local-docker-deployment).
 
@@ -20,88 +28,16 @@ Before ingesting your tests results from Great Expectations you will need to hav
 
 <PythonRequirements />
 
-You will need to install our Great Expectations submodule
+Install the OpenMetadata Great Expectations submodule, which brings in `great-expectations~=1.3`:
 
 ```shell
 pip3 install 'openmetadata-ingestion[great-expectations]'
 ```
 
 ## Great Expectations Setup
-### Configure your checkpoint file
-Great Expectations integration leverage custom actions. To be able to execute custom actions you will need to run a checkpoint file.
-
-```yaml
-[...]
-action:
-  module_name: metadata.great_expectations.action
-  class_name: OpenMetadataValidationAction
-  config_file_path: path/to/ometa/config/file/
-  database_service_name: <serviceName in OM>
-  database_name: <databaseName in OM>
-  schema_name: <schemaName in OM>
-  table_name: <tableName in OM>
-  expectation_suite_table_config_map:
-    my_first_suite_name:
-        database_name: <databaseName in OM>
-        schema_name: <schemaName in OM>
-        table_name: <tableName in OM>
-    my_other_suite_name:
-        database_name: <databaseName in OM>
-        schema_name: <schemaName in OM>
-        table_name: <tableName in OM>
-[...]
-```
-
-In your checkpoint yaml file, you will need to add the above code block in `action_list` section.
-
-**Properties**:
-
-- `module_name`: this is OpenMetadata  submodule name
-- `class_name`: this is the name of the class that will be used to execute the custom action
-- `config_file_path`: this is the path to your `config.yaml` file that holds the configuration of your OpenMetadata server
-- `database_service_name`: [Optional] this is an optional parameter. If not specified and 2 tables have the same name in 2 different OpenMetadata services, the custom action will fail
-- `database_name`: [Optional] The database name as it appears in OpenMetadata. For table-based validations (`SqlAlchemyDatasourceBatchSpec`), this is inferred from the batch spec. **Required** for query-based or dataframe validations (`RuntimeQueryBatchSpec`, `RuntimeDataBatchSpec`) where the table context must be explicitly specified.
-- `schema_name`: [Optional] The schema name as it appears in OpenMetadata. For table-based validations, this is inferred from the batch spec. **Required** for query-based or dataframe validations. Defaults to *default* if not specified.
-- `table_name`: [Optional] The table name as it appears in OpenMetadata. For table-based validations, this is inferred from the batch spec. **Required** for query-based or dataframe validations where the table cannot be automatically determined.
-- `expectation_suite_table_config_map`: [Optional] A dictionary mapping expectation suite names to their target OpenMetadata tables. Required when running multi-table checkpoints, where different expectation suites should send results to different tables. Each entry specifies the `database_name`, `schema_name` and `table_name` for routing validation results.
-
-
-<Info>
-**Multi-Table Checkpoints**
-
-When validating **multiple tables in a single checkpoint**, use the `expectation_suite_table_config_map` parameter to route validation results to the correct OpenMetadata tables. This is necessary because:
-- Each expectation suite may target a different table
-- The checkpoint action needs to know where to send each suite's results
-- Without the mapping, all results would attempt to go to the same default table
-
-**Example scenario:** You have a checkpoint validating both `users` and `orders` tables with separate expectation suites (`users_suite` and `orders_suite`). The `expectation_suite_table_config_map` ensures `users_suite` results go to the `users` table and the `orders_suite` go to the `orders` table.
-
-For single-table checkpoints, this parameter is not needed - the table information is provided directly or inferred from the batch spec.
-</Info>
-
-**Note**
-
-If you are using Great Expectation `DataContext` instance in Python to run your tests, you can use the `run_checkpoint` method as follows:
-
-```python
-data_context.run_checkpoint(
-    checkpoint_name="my_checkpoint",
-    batch_request=None,
-    run_name=None,
-    list_action={
-        "name": "my_action_name",
-        "action": {
-          "module_name": "metadata.great_expectations.action",
-          "class_name": "OpenMetadataValidationAction",
-          "config_file_path": "path/to/ometa/config/file/",
-          "database_service_name": "my_service_name",
-        },
-    ,}
-)
-```
 
 ### Create your `config.yaml` file
-To ingest Great Expectations results in OpenMetadata, you will need to specify your OpenMetadata security configuration for the REST endpoint. This configuration file needs to be located inside the `config_file_path` referenced in step 2 and named `config.yaml`.
+To ingest Great Expectations results in OpenMetadata, you will need to specify your OpenMetadata security configuration for the REST endpoint. This configuration file needs to be located inside the directory you pass as `config_file_path` and named `config.yaml`.
 
 ```yaml
 hostPort: http://localhost:8585/api
@@ -120,239 +56,215 @@ You can use environment variables in your configuration file by simply using `{{
 
 ![Great Expectations config file](/public/images/features/integrations/ge-config-yaml.gif)
 
-### Run your Great Expectations Checkpoint File
-With everything set up, it is now time to run your checkpoint file.
+### Add the action to your checkpoint
 
-```shell
-great_expectations checkpoint run <my_checkpoint>
-```
-
-![Run Great Expectations checkpoint](/public/images/features/integrations/ge-run-checkpoint.gif)
-
-### Running GX using the Python SDK?
-If you are running GX using their Python SDK below is a full example of how to add the action to your code
-
-```python
- import great_expectations as gx
-
-from great_expectations.checkpoint import Checkpoint
-
-context = gx.get_context()
-conn_string = f"postgresql+psycopg2://user:pw@host:port/db"
-
-data_source = context.sources.add_postgres(
-    name="source_name",
-    connection_string=conn_string,
-)
-
-data_asset = data_source.add_table_asset(
-    name="name",
-    table_name="table_name",
-    schema_name="schema_name",
-)
-
-batch_request = data_source.get_asset("name").build_batch_request()
-
-expectation_suite_name = "expectation_suite_name"
-context.add_or_update_expectation_suite(expectation_suite_name=expectation_suite_name)
-validator = context.get_validator(
-    batch_request=batch_request,
-    expectation_suite_name=expectation_suite_name,
-)
-
-validator.expect_column_values_to_not_be_null(column="column_name")
-
-validator.expect_column_values_to_be_between(
-    column="column_name", min_value=min_value, max_value=max_value
-)
-
-validator.save_expectation_suite(discard_failed_expectations=False)
-
-my_checkpoint_name = "my_sql_checkpoint"
-
-checkpoint = Checkpoint(
-    name=my_checkpoint_name,
-    run_name_template="%Y%m%d-%H%M%S-my-run-name-template",
-    data_context=context,
-    batch_request=batch_request,
-    expectation_suite_name=expectation_suite_name,
-    action_list=[
-        {
-            "name": "store results in OpenMetadata",
-            "action": {
-                "module_name": "metadata.great_expectations.action",
-                "class_name": "OpenMetadataValidationAction",
-                "config_file_path": "path/to/config/file",
-                "database_service_name": "openmetadata_service_name",
-                "database_name": "database_name",
-                "table_name": "table_name",
-                "schema_name": "schema_name",
-            }
-        },
-    ],
-)
-
-context.add_or_update_checkpoint(checkpoint=checkpoint)
-checkpoint_result = checkpoint.run()
-```
-
-#### Multi-Table Checkpoint Example
-
-Validate multiple tables in a single checkpoint run:
-
-```python
-import great_expectations as gx
-from great_expectations.checkpoint import Checkpoint
-
-context = gx.get_context()
-conn_string = "postgresql+psycopg2://user:pw@host:port/db"
-
-data_source = context.sources.add_postgres(
-  name="my_datasource",
-  connection_string=conn_string,
-)
-
-# Set up users table validation
-users_asset = data_source.add_table_asset(
-  name="users_asset",
-  table_name="users",
-  schema_name="public",
-)
-users_suite = "users_suite"
-context.add_or_update_expectation_suite(expectation_suite_name=users_suite)
-users_validator = context.get_validator(
-  batch_request=users_asset.build_batch_request(),
-  expectation_suite_name=users_suite,
-)
-users_validator.expect_column_values_to_not_be_null(column="email")
-users_validator.save_expectation_suite(discard_failed_expectations=False)
-
-# Set up orders table validation
-orders_asset = data_source.add_table_asset(
-  name="orders_asset",
-  table_name="orders",
-  schema_name="public",
-)
-orders_suite = "orders_suite"
-context.add_or_update_expectation_suite(expectation_suite_name=orders_suite)
-orders_validator = context.get_validator(
-  batch_request=orders_asset.build_batch_request(),
-  expectation_suite_name=orders_suite,
-)
-orders_validator.expect_column_values_to_be_between(column="amount", min_value=0, max_value=1000000)
-orders_validator.save_expectation_suite(discard_failed_expectations=False)
-
-# Create multi-table checkpoint
-checkpoint = Checkpoint(
-  name="multi_table_checkpoint",
-  run_name_template="%Y%m%d-%H%M%S-multi-table",
-  data_context=context,
-  validations=[
-      {
-          "batch_request": users_asset.build_batch_request(),
-          "expectation_suite_name": users_suite,
-      },
-      {
-          "batch_request": orders_asset.build_batch_request(),
-          "expectation_suite_name": orders_suite,
-      },
-  ],
-  action_list=[
-      {
-          "name": "openmetadata_action",
-          "action": {
-              "module_name": "metadata.great_expectations.action",
-              "class_name": "OpenMetadataValidationAction",
-              "config_file_path": "/path/to/config/",
-              "database_service_name": "my_postgres_service",
-              "expectation_suite_table_config_map": {
-                  "users_suite": {
-                      "database_name": "production",
-                      "schema_name": "public",
-                      "table_name": "users",
-                  },
-                  "orders_suite": {
-                      "database_name": "production",
-                      "schema_name": "public",
-                      "table_name": "orders",
-                  },
-              },
-          }
-      },
-  ],
-)
-
-context.add_or_update_checkpoint(checkpoint=checkpoint)
-checkpoint_result = checkpoint.run()
-```
-
-### Working with GX 1.x.x?
-In v1.x.x GX introduced significant changes to their SDK. One notable change was the removal of the `great_expectations` CLI. OpenMetadata introduced support for 1.x.x version through its `OpenMetadataValidationAction1xx` class. You will need to first `pip install 'open-metadata[great-expectations-1xx]'. Below is a complete example
+Instantiate `OpenMetadataValidationAction` and pass it to the `actions` list of your checkpoint:
 
 ```python
 import great_expectations as gx
 
-from metadata.great_expectations.action1xx import OpenMetadataValidationAction1xx # OpenMetadata Validation Action for GX 1.x.x
-
+from metadata.great_expectations.action import OpenMetadataValidationAction
 
 context = gx.get_context()
-conn_string = f"redshift+psycopg2://user:pw@host:port/db"
+conn_string = "redshift+psycopg2://user:pw@host:port/db"
 
 data_source = context.data_sources.add_redshift(
-    name="name",
+    name="my_datasource",
     connection_string=conn_string,
 )
 
 data_asset = data_source.add_table_asset(
-    name="name",
-    table_name="table_name",
-    schema_name="schema_name",
+    name="customers_asset",
+    table_name="customers",
+    schema_name="public",
 )
 
-batch_definition = data_asset.add_batch_definition_whole_table("batch definition")
-batch = batch_definition.get_batch()
+batch_definition = data_asset.add_batch_definition_whole_table("customers_batch")
 
 suite = context.suites.add(
-    gx.core.expectation_suite.ExpectationSuite(name="name")
+    gx.core.expectation_suite.ExpectationSuite(name="customers_suite")
 )
 suite.add_expectation(
-    gx.expectations.ExpectColumnValuesToNotBeNull(
-        column="column_name"
+    gx.expectations.ExpectColumnValuesToNotBeNull(column="customer_id")
+)
+suite.add_expectation(
+    gx.expectations.ExpectColumnValuesToBeBetween(
+        column="lifetime_value", min_value=0, max_value=1000000
     )
-)
-suite.add_expectation(
-    gx.expectations.ExpectColumnValuesToBeBetween(column="column_name", min_value=50, max_value=1000000)
 )
 
 validation_definition = context.validation_definitions.add(
     gx.core.validation_definition.ValidationDefinition(
-        name="validation definition",
+        name="customers_validation",
         data=batch_definition,
         suite=suite,
     )
 )
 
-action_list = [
-    OpenMetadataValidationAction1xx(
-        database_service_name="openmetadata_service_name",
-        database_name="openmetadata_database_name",
-        table_name="openmetadata_table_name",
-        schema_name="openmetadata_schema_name",
-        config_file_path="path/to/config/file",
-    )
-]
+action = OpenMetadataValidationAction(
+    config_file_path="path/to/ometa/config/file/",
+    database_service_name="<serviceName in OM>",
+    database_name="<databaseName in OM>",
+    schema_name="<schemaName in OM>",
+    table_name="<tableName in OM>",
+)
 
 checkpoint = context.checkpoints.add(
     gx.checkpoint.checkpoint.Checkpoint(
-        name="checkpoint", validation_definitions=[validation_definition], actions=action_list
+        name="customers_checkpoint",
+        validation_definitions=[validation_definition],
+        actions=[action],
     )
 )
 
 checkpoint_result = checkpoint.run()
 ```
 
+**Properties**:
+
+- `config_file_path`: the path to the **directory** holding the `config.yaml` file that describes your OpenMetadata server connection
+- `database_service_name`: [Optional] the name of the service in OpenMetadata. If not specified and 2 tables have the same name in 2 different OpenMetadata services, the action will fail
+- `database_name`: [Optional] The database name as it appears in OpenMetadata. When omitted, the database of the execution engine the expectations ran against is used
+- `schema_name`: [Optional] The schema name as it appears in OpenMetadata. For table assets the action reads this from the batch spec when present. Defaults to *default* if not specified
+- `table_name`: [Optional] The table name as it appears in OpenMetadata. For table assets the action reads this from the batch spec when present. **Required** for query assets, where the table cannot be determined automatically
+- `expectation_suite_table_config_map`: [Optional] A dictionary mapping expectation suite names to their target OpenMetadata tables. Required when running multi-table checkpoints, where different expectation suites should send results to different tables. Each entry specifies the `database_name`, `schema_name` and `table_name` for routing validation results
+
+<Info>
+Every part of the table name has to resolve before the action writes anything. The action looks in three places: its own configuration, the suite mapping, and the batch spec. If it can't determine the database, schema, or table, the run fails with an error naming the missing parts instead of writing to the wrong table.
+</Info>
+
+### Adding a description to your test cases
+
+The action copies the `description` set in an expectation's `meta` to the OpenMetadata test case:
+
+```python
+suite.add_expectation(
+    gx.expectations.ExpectColumnValuesToNotBeNull(
+        column="customer_id",
+        meta={"description": "Every customer must have an id"},
+    )
+)
+```
+
+Expectations without a `meta` description are still ingested; they simply produce a test case with no description.
+
+### Run your checkpoint
+
+Great Expectations 1.x removed the CLI, so checkpoints are run from Python:
+
+```python
+checkpoint_result = checkpoint.run()
+```
+
+Once the run completes, the test cases and their results appear on the table's Data Quality tab in OpenMetadata.
+
+## Multi-Table Checkpoints
+
+When validating **multiple tables in a single checkpoint**, use the `expectation_suite_table_config_map` parameter to route validation results to the correct OpenMetadata tables. This is necessary because:
+- Each expectation suite might target a different table
+- The checkpoint action needs to know where to send each suite's results
+- Without the mapping, all results would attempt to go to the same default table
+
+This matters most for **query assets**: a query asset's batch spec carries the query, not the table it reads from, so the mapping is the only way the action can tell where the results belong.
+
+```python
+import great_expectations as gx
+
+from metadata.great_expectations.action import OpenMetadataValidationAction
+
+context = gx.get_context()
+
+data_source = context.data_sources.add_postgres(
+    name="my_datasource",
+    connection_string="postgresql+psycopg2://user:pw@host:port/db",
+)
+
+validation_definitions = []
+
+# users table
+users_asset = data_source.add_table_asset(
+    name="users_asset", table_name="users", schema_name="public"
+)
+users_suite = context.suites.add(
+    gx.core.expectation_suite.ExpectationSuite(name="users_suite")
+)
+users_suite.add_expectation(gx.expectations.ExpectColumnValuesToNotBeNull(column="email"))
+validation_definitions.append(
+    context.validation_definitions.add(
+        gx.core.validation_definition.ValidationDefinition(
+            name="users_validation",
+            data=users_asset.add_batch_definition_whole_table("users_batch"),
+            suite=users_suite,
+        )
+    )
+)
+
+# orders table
+orders_asset = data_source.add_table_asset(
+    name="orders_asset", table_name="orders", schema_name="public"
+)
+orders_suite = context.suites.add(
+    gx.core.expectation_suite.ExpectationSuite(name="orders_suite")
+)
+orders_suite.add_expectation(
+    gx.expectations.ExpectColumnValuesToBeBetween(
+        column="amount", min_value=0, max_value=1000000
+    )
+)
+validation_definitions.append(
+    context.validation_definitions.add(
+        gx.core.validation_definition.ValidationDefinition(
+            name="orders_validation",
+            data=orders_asset.add_batch_definition_whole_table("orders_batch"),
+            suite=orders_suite,
+        )
+    )
+)
+
+action = OpenMetadataValidationAction(
+    config_file_path="/path/to/config/",
+    database_service_name="my_postgres_service",
+    expectation_suite_table_config_map={
+        "users_suite": {
+            "database_name": "production",
+            "schema_name": "public",
+            "table_name": "users",
+        },
+        "orders_suite": {
+            "database_name": "production",
+            "schema_name": "public",
+            "table_name": "orders",
+        },
+    },
+)
+
+checkpoint = context.checkpoints.add(
+    gx.checkpoint.checkpoint.Checkpoint(
+        name="multi_table_checkpoint",
+        validation_definitions=validation_definitions,
+        actions=[action],
+    )
+)
+
+checkpoint_result = checkpoint.run()
+```
+
+Any suite not present in the map falls back to the `database_name` / `schema_name` / `table_name` set on the action.
+
+## Test Results
+
+Each expectation becomes a test case in OpenMetadata, and each run adds a result to it. Results report row counts:
+
+| Value | Meaning |
+|---|---|
+| `unexpected_count` | Rows that failed the expectation |
+| `missing_count` | Rows with a null value for the column under test |
+| `element_count` | Rows evaluated |
+| `observed_value` | The value the expectation measured, for expectations that report one (for example `expect_column_mean_to_be_between`) |
+
+<Info>
+The action doesn't report percentages such as `unexpected_percent` and `missing_percent`. OpenMetadata charts every result value of a test case on a single axis, so a percentage plotted next to a row count is flattened into the baseline and unreadable. Divide `unexpected_count` by `element_count` if you need the percentage.
+</Info>
 
 ### List of Great Expectations Supported Test
 We currently only support a certain number of Great Expectations tests. The full list can be found in the [Tests](/v2.0.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/tests-yaml) section.
-
-If a test is not supported, there is no need to worry about the execution of your Great Expectations test. We will simply skip the tests that are not supported and continue the execution of your test suite.

--- a/v2.0.x-SNAPSHOT/connectors/ingestion/great-expectations.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/ingestion/great-expectations.mdx
@@ -10,15 +10,15 @@ For Data Quality tests the open source python package Great Expectations stands 
 <Warning>
 **Great Expectations 1.3 or later is required.**
 
-Support for the Great Expectations 0.18 line was removed in OpenMetadata 2.0. The `OpenMetadataValidationAction1xx` class and the `metadata.great_expectations.action1xx` module that shipped alongside it during the transition have also been removed — use `OpenMetadataValidationAction` from `metadata.great_expectations.action` instead.
+OpenMetadata 2.0 removes support for the Great Expectations 0.18 line. It also removes the `OpenMetadataValidationAction1xx` class and the `metadata.great_expectations.action1xx` module that shipped alongside it during the transition — use `OpenMetadataValidationAction` from `metadata.great_expectations.action` instead.
 
-Great Expectations 1.x removed the `great_expectations` CLI and the YAML checkpoint file. Checkpoints are now defined in Python, and the OpenMetadata action is passed as an object rather than an `action_list` entry. See [Upgrade Prerequisites](/v2.0.x-SNAPSHOT/deployment/upgrade) for the full list of breaking changes.
+Great Expectations 1.x removed the `great_expectations` CLI and the YAML checkpoint file. You now define checkpoints in Python and pass the OpenMetadata action as an object rather than as an `action_list` entry. See [Upgrade Prerequisites](/v2.0.x-SNAPSHOT/deployment/upgrade) for the full list of breaking changes.
 </Warning>
 
 ## Requirements
 
 ### OpenMetadata Requirements
-You will need to have OpenMetadata version 1.13 or later.
+You'll need OpenMetadata version 1.13 or later.
 
 To deploy OpenMetadata, follow the procedure to [Try OpenMetadata in Docker](/v2.0.x-SNAPSHOT/quick-start/local-docker-deployment).
 
@@ -122,12 +122,12 @@ checkpoint_result = checkpoint.run()
 
 **Properties**:
 
-- `config_file_path`: the path to the **directory** holding the `config.yaml` file that describes your OpenMetadata server connection
-- `database_service_name`: [Optional] the name of the service in OpenMetadata. If not specified and 2 tables have the same name in 2 different OpenMetadata services, the action will fail
-- `database_name`: [Optional] The database name as it appears in OpenMetadata. When omitted, the database of the execution engine the expectations ran against is used
-- `schema_name`: [Optional] The schema name as it appears in OpenMetadata. For table assets the action reads this from the batch spec when present. Defaults to *default* if not specified
-- `table_name`: [Optional] The table name as it appears in OpenMetadata. For table assets the action reads this from the batch spec when present. **Required** for query assets, where the table cannot be determined automatically
-- `expectation_suite_table_config_map`: [Optional] A dictionary mapping expectation suite names to their target OpenMetadata tables. Required when running multi-table checkpoints, where different expectation suites should send results to different tables. Each entry specifies the `database_name`, `schema_name` and `table_name` for routing validation results
+- `config_file_path`: The path to the **directory** holding the `config.yaml` file that describes your OpenMetadata server connection.
+- `database_service_name`: [Optional] The name of the service in OpenMetadata. If not specified and 2 tables have the same name in 2 different OpenMetadata services, the action will fail.
+- `database_name`: [Optional] The database name as it appears in OpenMetadata. When omitted, the action uses the database of the execution engine the expectations ran against.
+- `schema_name`: [Optional] The schema name as it appears in OpenMetadata. For table assets the action reads this from the batch spec when present. Defaults to `default` if not specified.
+- `table_name`: [Optional] The table name as it appears in OpenMetadata. For table assets the action reads this from the batch spec when present. **Required** for query assets, where the action can't determine the table automatically.
+- `expectation_suite_table_config_map`: [Optional] A dictionary mapping expectation suite names to their target OpenMetadata tables. Required when running multi-table checkpoints, where different expectation suites should send results to different tables. Each entry specifies the `database_name`, `schema_name`, and `table_name` for routing validation results.
 
 <Info>
 Every part of the table name has to resolve before the action writes anything. The action looks in three places: its own configuration, the suite mapping, and the batch spec. If it can't determine the database, schema, or table, the run fails with an error naming the missing parts instead of writing to the wrong table.
@@ -160,12 +160,12 @@ Once the run completes, the test cases and their results appear on the table's D
 
 ## Multi-Table Checkpoints
 
-When validating **multiple tables in a single checkpoint**, use the `expectation_suite_table_config_map` parameter to route validation results to the correct OpenMetadata tables. This is necessary because:
-- Each expectation suite might target a different table
-- The checkpoint action needs to know where to send each suite's results
-- Without the mapping, all results would attempt to go to the same default table
+When validating multiple tables in a single checkpoint, use the `expectation_suite_table_config_map` parameter to route validation results to the correct OpenMetadata tables. This is necessary because:
+- Each expectation suite might target a different table.
+- The checkpoint action needs to know where to send each suite's results.
+- Without the mapping, all results would attempt to go to the same default table.
 
-This matters most for **query assets**: a query asset's batch spec carries the query, not the table it reads from, so the mapping is the only way the action can tell where the results belong.
+This matters most for query assets: A query asset's batch spec carries the query, not the table it reads from, so the mapping is the only way the action can tell where the results belong.
 
 ```python
 import great_expectations as gx

--- a/v2.0.x-SNAPSHOT/developers/contribute/codebase-deep-dives/sampler.mdx
+++ b/v2.0.x-SNAPSHOT/developers/contribute/codebase-deep-dives/sampler.mdx
@@ -106,14 +106,17 @@ Defined in `models.py`:
 
 ```
 SampleConfig
-  ├── profileSample: float         # Percentage (e.g., 50.0) or row count
-  ├── profileSampleType: PERCENTAGE | ROWS
-  ├── samplingMethodType: BERNOULLI | SYSTEM   # Database-specific method
+  ├── profileSampleConfig: ProfileSampleConfig | None
+  │     ├── sampleConfigType: STATIC | DYNAMIC
+  │     └── config: StaticSamplingConfig | DynamicSamplingConfig
+  │           ├── (static)  profileSample / profileSampleType / samplingMethodType
+  │           └── (dynamic) smartSampling: bool / thresholds: list
   └── randomizedSample: bool       # Whether to randomize row selection
 
-TableConfig
+TableConfig                        # extends BaseProfileConfig
   ├── fullyQualifiedName: str
-  ├── profileSample / profileSampleType / samplingMethodType
+  ├── profileSampleConfig: ProfileSampleConfig | None
+  ├── profileSample / profileSampleType / samplingMethodType   # resolved values
   ├── profileQuery: str            # Custom SQL for sampling
   ├── partitionConfig: ...         # Partition filtering
   └── columnConfig: ColumnConfig   # Include/exclude columns
@@ -277,7 +280,7 @@ Supports:
 For NoSQL databases (MongoDB, DynamoDB), `NoSQLSampler`:
 
 - Uses `NoSQLAdaptor` to abstract database-specific operations
-- Converts percentage to row count: `num_rows * (profileSample / 100)`
+- Converts percentage to row count: `num_rows * (profileSample / 100)`, using the sample resolved from `profileSampleConfig`
 - Calls `client.scan(limit=N)` for sampling
 - Transposes list-of-dicts format into columnar `TableData`
 
@@ -293,10 +296,13 @@ For NoSQL databases (MongoDB, DynamoDB), `NoSQLSampler`:
     from metadata.sampler.sqlalchemy.sampler import SQASampler
 
     class MyDBSampler(SQASampler):
-        def set_tablesample(self, selectable):
-            # Add your database's TABLESAMPLE clause
+        def set_tablesample(self, static: StaticSamplingConfig | None, selectable):
+            # Add your database's TABLESAMPLE clause. The static config is resolved
+            # by the caller, so dynamic sampling is already collapsed to a number.
+            if not static:
+                return selectable
             return selectable.tablesample(
-                func.bernoulli(self.sample_config.profileSample)
+                func.bernoulli(static.profileSample)
             )
     ```
   </Step>

--- a/v2.0.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/external-workflow.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/external-workflow.mdx
@@ -87,8 +87,11 @@ processor:
     # schemaConfig:
     # - fullyQualifiedName: demo_snowflake.new_database.new_dschema
     #   sampleDataCount: 50
-    #   profileSample: 1
-    #   profileSampleType: ROWS
+    #   profileSampleConfig:
+    #     sampleConfigType: STATIC
+    #     config:
+    #       profileSample: 1
+    #       profileSampleType: ROWS
     #   sampleDataStorageConfig:
     #     config:
     #       bucketName: awsdatalake-testing
@@ -105,8 +108,11 @@ processor:
     # databaseConfig:
     # - fullyQualifiedName: snowflake_prod.prod_db
     #   sampleDataCount: 50
-    #   profileSample: 1
-    #   profileSampleType: ROWS
+    #   profileSampleConfig:
+    #     sampleConfigType: STATIC
+    #     config:
+    #       profileSample: 1
+    #       profileSampleType: ROWS
     #   sampleDataStorageConfig:
     #     config:
     #       bucketName: awsdatalake-testing

--- a/v2.0.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/profiler-workflow.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/profiler-workflow.mdx
@@ -154,11 +154,16 @@ This is a good option if you which to execute your workflow via the Airflow SDK 
 This is a sample config for the profiler:
 
 <Steps>
-<Step title="computeMetrics">
-**computeMetrics**: Option to turn on/off computing profiler metrics. This flag is useful when you want to only ingest the sample data with the profiler workflow and not any other information.
+<Step title="computeTableMetrics">
+**computeTableMetrics**: Option to turn on/off computing table level metrics. Turn both this and `computeColumnMetrics` off when you only want to ingest sample data with the profiler workflow and not any other information.
 </Step>
-<Step title="profileSample">
-**profileSample**: Percentage of data or no. of rows we want to execute the profiler and tests on.
+<Step title="computeColumnMetrics">
+**computeColumnMetrics**: Option to turn on/off computing column level metrics.
+</Step>
+<Step title="profileSampleConfig">
+**profileSampleConfig**: How much data the profiler and tests run on.
+
+`sampleConfigType` is either `DYNAMIC` (the default), which resolves the sample size at runtime from the table's row count, or `STATIC`, which uses a fixed size you set yourself. `config` holds the settings for the type you chose.
 </Step>
 <Step title="threadCount">
 **threadCount**: Number of threads to use during metric computations.
@@ -203,8 +208,12 @@ source:
   sourceConfig:
     config:
       type: Profiler
-computeMetrics: true
-# profileSample: 85
+computeTableMetrics: true
+computeColumnMetrics: true
+# profileSampleConfig:
+#   sampleConfigType: DYNAMIC
+#   config:
+#     smartSampling: true
 # threadCount: 5
 # timeoutSeconds: 43200
 # databaseFilterPattern:
@@ -233,9 +242,10 @@ processor:
   config: {}  # Remove braces if adding properties
     # tableConfig:
     #   - fullyQualifiedName: <table fqn>
-    #     profileSample: <number between 0 and 99> # default
-
-    #     profileSample: <number between 0 and 99> # default will be 100 if omitted
+    #     profileSampleConfig:
+    #       sampleConfigType: STATIC  # omit entirely to inherit dynamic sampling
+    #       config:
+    #         profileSample: <number between 0 and 99>
     #     columnConfig:
     #       excludeColumns:
     #         - <column name>

--- a/v2.0.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/profiler-workflow.mdx
+++ b/v2.0.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/profiler-workflow.mdx
@@ -155,10 +155,10 @@ This is a sample config for the profiler:
 
 <Steps>
 <Step title="computeTableMetrics">
-**computeTableMetrics**: Option to turn on/off computing table level metrics. Turn both this and `computeColumnMetrics` off when you only want to ingest sample data with the profiler workflow and not any other information.
+**computeTableMetrics**: Option to turn on/off computing table-level metrics. Turn both this and `computeColumnMetrics` off when you only want to ingest sample data with the profiler workflow and not any other information.
 </Step>
 <Step title="computeColumnMetrics">
-**computeColumnMetrics**: Option to turn on/off computing column level metrics.
+**computeColumnMetrics**: Option to turn on/off computing column-level metrics.
 </Step>
 <Step title="profileSampleConfig">
 **profileSampleConfig**: How much data the profiler and tests run on.

--- a/v2.0.x-SNAPSHOT/sdk/python/api-reference/table-mixin.mdx
+++ b/v2.0.x-SNAPSHOT/sdk/python/api-reference/table-mixin.mdx
@@ -63,13 +63,14 @@ create_or_update_table_profiler_config(
 ) → Optional[Table]
 ```
 
-Update the profileSample property of a Table, given its FQN.
+Update the profiler configuration of a Table, given its FQN.
 
 **Args:**
 
 `fqn`: Table FQN
 
-`profile_sample`: new profile sample to set
+`table_profiler_config`: the `TableProfilerConfig` to set. Sampling lives under its
+`profileSampleConfig` field
 
 **Returns:**
 


### PR DESCRIPTION
Documents two ingestion-framework changes the docs currently contradict.

Related: open-metadata/OpenMetadata#31552 · open-metadata/OpenMetadata#31553 · open-metadata/OpenMetadata#27912

## Great Expectations 1.x — 2.0 breaking change

Support for the GX 0.18 line was removed. The action now requires
`great-expectations~=1.3`, and the interim `metadata.great_expectations.action1xx`
module and `OpenMetadataValidationAction1xx` class are gone.

- **`snippets/v2.0.x-SNAPSHOT/deployment/upgrade/upgrade-prerequisites.mdx`** — added the entry to the `<BreakingChanges>` block, covering the version floor, the `action1xx` rename, the checkpoint-definition change, and the switch to count-based test results.
- **`v2.0.x-SNAPSHOT/connectors/ingestion/great-expectations.mdx`** — rewritten. The page taught `action_list`, `great_expectations checkpoint run` and `context.sources.add_postgres`; GX 1.x removed the CLI and the YAML checkpoint file, so none of that works. It also still documented the 1.x path as an afterthought under "Working with GX 1.x.x?" using the now-deleted class.

Every code example on the rewritten page was executed against GX **1.3.0**, **1.4.0** and **1.20.0** before being written down. New sections cover carrying an expectation's `meta.description` onto the test case, and the result values the action reports.

Why 1.3 and not 1.0: GX only gained the validation-action registry in 1.3. On 1.0–1.2, `Checkpoint.actions` is a closed discriminated union that rejects the action outright.

## profileSampleConfig — 1.13+

The flat `profileSample` / `profileSampleType` / `samplingMethodType` fields were replaced by a nested `profileSampleConfig`, and `computeMetrics` was split into `computeTableMetrics` / `computeColumnMetrics`. The 1.13.0 release notes announced this, but the reference and how-to pages still documented the removed shape — so a config copied from the docs no longer validates.

Updated across **v1.13.x** and **v2.0.x-SNAPSHOT**:

| Area | Files |
|---|---|
| Connector YAML snippet | `snippets/{version}/connectors/yaml/data-profiler.mdx` |
| Profiler how-tos | `profiler-workflow.mdx`, `external-workflow.mdx` |
| API reference | `tables/profiler.mdx`, `databases/advanced.mdx`, `database-schemas/advanced.mdx` |
| SDK reference | `sdk/python/api-reference/table-mixin.mdx` (×2 paths) |
| Codebase deep-dive | `developers/contribute/codebase-deep-dives/sampler.mdx` |

### Accuracy notes

Field shapes came from the JSON Schemas in `openmetadata-spec/`, not from the release notes. Two things that turned up:

- **`tableProfile` legitimately keeps** its flat `profileSample` / `profileSampleType` — it records what a given run sampled, and has no `profileSampleConfig`. Left alone. Only its `samplingMethodType`, which the schema no longer has, was removed.
- **`computeMetrics` is gone too.** The release notes grouped it with the removed sampling fields and the schema confirms it, so the how-to pages now document `computeTableMetrics` / `computeColumnMetrics`.

The `sampler.mdx` deep-dive was checked against `ingestion/src/metadata/sampler/` — `set_tablesample()` now takes the resolved `StaticSamplingConfig` as its first argument, so the "add a sampler" example was updated to match.

### Care taken with `data-profiler.mdx`

Those pages use `<CodePreview>` with `<ContentSection lines="N">` that index into the YAML block, so replacing a one-line field with a nested block shifts every later mapping. Both edits were renumbered programmatically and then verified — each section boundary was confirmed to land on the intended YAML construct.

## Style

Reviewed against `.ai/doc-review/instructions.md` and its checklist. Fixed one Major (a sentence exceeding the comma limit, split into three) and several Minor items (ambiguous "may" → "might", first-person "our", passive constructions where the actor is worth naming). Pre-existing prose on untouched lines was left as-is.

## Not included

v1.12.x is untouched — the sampling change landed in 1.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)