### PR TITLE
Docs: Fix BigQuery connection details formatting and missing fields

### DIFF
--- a/v1.12.x/connectors/database/bigquery.mdx
+++ b/v1.12.x/connectors/database/bigquery.mdx
@@ -86,59 +86,55 @@ This will help you simplify your data management and optimize your performance i
 </Tip>
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"BigQuery"} selectServicePath={"/public/images/connectors/bigquery/select-service.png"} addNewServicePath={"/public/images/connectors/bigquery/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/bigquery/service-connection.png"} />
-# Connection Options
+### Connection Details
 <Steps>
-<Step title="Connection Options">
-**Host and Port**: BigQuery APIs URL. By default, the API URL is `bigquery.googleapis.com` you can modify this if you have custom implementation of BigQuery.
-**GCP Credentials**:
-You can authenticate with your bigquery instance using either `GCP Credentials Path` where you can specify the file path of the service account key or you can pass the values directly by choosing the `GCP Credentials Values` from the service account key file.
-You can check out [this](https://cloud.google.com/iam/docs/keys-create-delete#iam-service-account-keys-create-console) documentation on how to create the service account keys and download it.
-**GCP Credentials Values**: Passing the raw credential values provided by BigQuery. This requires us to provide the following information, all provided by BigQuery:
-- **Credentials type**: Credentials Type is the type of the account, for a service account the value of this field is `service_account`. To fetch this key, look for the value associated with the `type` key in the service account key file.
-- **Billing Project ID (Optional)**: The GCP project that should be charged for the BigQuery jobs OpenMetadata runs. Use this when the project that pays for metadata, usage, or lineage queries is different from the project ID or IDs you ingest from.
-- **Project ID**: The BigQuery project ID or IDs that OpenMetadata should scan for datasets, tables, and other metadata. For service account credentials, this usually comes from the `project_id` value in the key file. You can also pass multiple project IDs to ingest metadata from different BigQuery projects into one service.
-- **Private Key ID**: This is a unique identifier for the private key associated with the service account. To fetch this key, look for the value associated with the `private_key_id` key in the service account file.
-- **Private Key**: This is the private key associated with the service account that is used to authenticate and authorize access to BigQuery. To fetch this key, look for the value associated with the `private_key` key in the service account file.
-- **Client Email**: This is the email address associated with the service account. To fetch this key, look for the value associated with the `client_email` key in the service account key file.
-- **Client ID**: This is a unique identifier for the service account. To fetch this key, look for the value associated with the `client_id` key in the service account key  file.
-- **Auth URI**: This is the URI for the authorization server. To fetch this key, look for the value associated with the `auth_uri` key in the service account key file. The default value to Auth URI is https://accounts.google.com/o/oauth2/auth.
-- **Token URI**: The Google Cloud Token URI is a specific endpoint used to obtain an OAuth 2.0 access token from the Google Cloud IAM service. This token allows you to authenticate and access various Google Cloud resources and APIs that require authorization. To fetch this key, look for the value associated with the `token_uri` key in the service account credentials file. The default token URI is `https://oauth2.googleapis.com/token`.
-- **Authentication Provider X509 Certificate URL**: This is the URL of the certificate that verifies the authenticity of the authorization server. To fetch this key, look for the value associated with the `auth_provider_x509_cert_url` key in the service account key file. The Default value for Auth Provider X509Cert URL is https://www.googleapis.com/oauth2/v1/certs
-- **Client X509Cert URL**: This is the URL of the certificate that verifies the authenticity of the service account. To fetch this key, look for the value associated with the `client_x509_cert_url` key in the service account key  file.
-<Tip>
-`Project ID` tells OpenMetadata where to read metadata from. `Billing Project ID` tells BigQuery which project should pay for the queries.
+<Step title="Connection Details">
+- **Host and Port**: BigQuery APIs URL. By default, the API URL is `bigquery.googleapis.com`. You can modify this if you have a custom implementation of BigQuery.
+- **Billing Project ID** (Optional): The GCP project that should be charged for the BigQuery jobs OpenMetadata runs. Use this when the project that pays for metadata, usage, or lineage queries is different from the project ID or IDs you ingest from.
+- **GCP Credentials**: You can authenticate with your bigquery instance using either `GCP Credentials Path` where you can specify the file path of the service account key or you can pass the values directly by choosing the `GCP Credentials Values` from the service account key file. You can check out [this](https://cloud.google.com/iam/docs/keys-create-delete#iam-service-account-keys-create-console) documentation on how to create the service account keys and download it.
+  - **GCP Credentials Values**: Passing the raw credential values provided by BigQuery. This requires us to provide the following information, all provided by BigQuery:
+    - **Credentials type**: Credentials Type is the type of the account, for a service account the value of this field is `service_account`. To fetch this key, look for the value associated with the `type` key in the service account key file.
+    - **Project ID**: The BigQuery project ID or IDs that OpenMetadata should scan for datasets, tables, and other metadata. For service account credentials, this usually comes from the `project_id` value in the key file. You can also pass multiple project IDs to ingest metadata from different BigQuery projects into one service.
+    - **Private Key ID**: This is a unique identifier for the private key associated with the service account. To fetch this key, look for the value associated with the `private_key_id` key in the service account file.
+    - **Private Key**: This is the private key associated with the service account that is used to authenticate and authorize access to BigQuery. To fetch this key, look for the value associated with the `private_key` key in the service account file.
+    - **Client Email**: This is the email address associated with the service account. To fetch this key, look for the value associated with the `client_email` key in the service account key file.
+    - **Client ID**: This is a unique identifier for the service account. To fetch this key, look for the value associated with the `client_id` key in the service account key  file.
+    - **Auth URI**: This is the URI for the authorization server. To fetch this key, look for the value associated with the `auth_uri` key in the service account key file. The default value to Auth URI is https://accounts.google.com/o/oauth2/auth.
+    - **Token URI**: The Google Cloud Token URI is a specific endpoint used to obtain an OAuth 2.0 access token from the Google Cloud IAM service. This token allows you to authenticate and access various Google Cloud resources and APIs that require authorization. To fetch this key, look for the value associated with the `token_uri` key in the service account credentials file. The default token URI is `https://oauth2.googleapis.com/token`.
+    - **Authentication Provider X509 Certificate URL**: This is the URL of the certificate that verifies the authenticity of the authorization server. To fetch this key, look for the value associated with the `auth_provider_x509_cert_url` key in the service account key file. The Default value for Auth Provider X509Cert URL is https://www.googleapis.com/oauth2/v1/certs
+    - **Client X509Cert URL**: This is the URL of the certificate that verifies the authenticity of the service account. To fetch this key, look for the value associated with the `client_x509_cert_url` key in the service account key  file.
+  - **GCP Credentials Path**: Passing a local file path that contains the credentials.
+  - **GCP Impersonate Service Account Configuration** (Optional): Enable the authenticated service account to impersonate another service account, instead of ingesting directly with the credentials above.
+    - **Target Service Account Email**: The email of the service account to impersonate.
+    - **Lifetime**: Number of seconds the delegated credential should remain valid. Defaults to `3600`.
+  <Tip>
+  `Project ID` (above) tells OpenMetadata where to read metadata from. `Billing Project ID` tells BigQuery which project should pay for the queries.
 
-- Same-project setup: if your data lives in `analytics-prod` and that same project should pay for the queries, use `analytics-prod` as the `Project ID` and either leave `Billing Project ID` empty or set it to `analytics-prod`.
-- Cross-project billing setup: if your data lives in `marketing-prod` and `finance-prod`, but all query costs should be charged to `central-billing`, use `marketing-prod` and `finance-prod` as `Project ID` values and set `Billing Project ID` to `central-billing`.
-</Tip>
-**GCP Credentials Path**: Passing a local file path that contains the credentials.
-**Taxonomy Project ID (Optional)**: Bigquery uses taxonomies to create hierarchical groups of policy tags. To apply access controls to BigQuery columns, tag the columns with policy tags. Learn more about how yo can create policy tags and set up column-level access control [here](https://cloud.google.com/bigquery/docs/column-level-security)
-If you have attached policy tags to the columns of table available in Bigquery, then OpenMetadata will fetch those tags and attach it to the respective columns.
-In this field you need to specify the id of project in which the taxonomy was created.
-**Taxonomy Location (Optional)**: Bigquery uses taxonomies to create hierarchical groups of policy tags. To apply access controls to BigQuery columns, tag the columns with policy tags. Learn more about how yo can create policy tags and set up column-level access control [here](https://cloud.google.com/bigquery/docs/column-level-security)
-If you have attached policy tags to the columns of table available in Bigquery, then OpenMetadata will fetch those tags and attach it to the respective columns.
-In this field you need to specify the location/region in which the taxonomy was created.
-**Usage Location (Optional)**:
-Location used to query `INFORMATION_SCHEMA.JOBS_BY_PROJECT` to fetch usage data. You can pass multi-regions, such as `us` or `eu`, or your specific region such as `us-east1`. Australia and Asia multi-regions are not yet supported.
-**Cost Per TiB (Optional)**:
-The cost (in USD) per tebibyte (TiB) of data processed during BigQuery usage analysis. This value is used to estimate query costs when analyzing usage metrics from `INFORMATION_SCHEMA.JOBS_BY_PROJECT`.
-This setting does **not** affect actual billing—it is only used for internal reporting and visualization of estimated costs.
-The default value, if not set, may assume the standard on-demand BigQuery pricing (e.g., $5.00 per TiB), but you should adjust it according to your organization's negotiated rates or flat-rate pricing model.
-<Tip>
-**Application Default Credentials (ADC) Authentication**
-If you want to use [ADC authentication](https://cloud.google.com/docs/authentication#adc) for BigQuery, configure the GCP credentials with type `gcp_adc`:
-```yaml
-credentials:
-  gcpConfig:
-    type: gcp_adc
-    projectId: ["your-project-id"]  # Optional: specify project(s) for data access
-```
-**Using ADC with Billing Project ID**: When using ADC authentication, you can still specify a **Billing Project ID** to control which project pays for the BigQuery queries OpenMetadata runs. This is particularly useful when:
-- Your service account has access to multiple projects
-- You want to bill queries to a specific project different from the one containing your data
-- You're running queries that span multiple projects
-**ADC Setup**: ADC authentication works automatically when running in Google Cloud environments (GKE, Compute Engine, Cloud Run) or when you've configured it locally using `gcloud auth application-default login`.
-</Tip>
+  - Same-project setup: if your data lives in `analytics-prod` and that same project should pay for the queries, use `analytics-prod` as the `Project ID` and either leave `Billing Project ID` empty or set it to `analytics-prod`.
+  - Cross-project billing setup: if your data lives in `marketing-prod` and `finance-prod`, but all query costs should be charged to `central-billing`, use `marketing-prod` and `finance-prod` as `Project ID` values and set `Billing Project ID` to `central-billing`.
+  </Tip>
+  <Tip>
+  **Application Default Credentials (ADC) Authentication**
+
+  If you want to use [ADC authentication](https://cloud.google.com/docs/authentication#adc) for BigQuery, configure the GCP credentials with type `gcp_adc`:
+  ```yaml
+  credentials:
+    gcpConfig:
+      type: gcp_adc
+      projectId: ["your-project-id"]  # Optional: specify project(s) for data access
+  ```
+  **Using ADC with Billing Project ID**: When using ADC authentication, you can still specify a **Billing Project ID** to control which project pays for the BigQuery queries OpenMetadata runs. This is particularly useful when:
+  - Your service account has access to multiple projects
+  - You want to bill queries to a specific project different from the one containing your data
+  - You're running queries that span multiple projects
+
+  **ADC Setup**: ADC authentication works automatically when running in Google Cloud environments (GKE, Compute Engine, Cloud Run) or when you've configured it locally using `gcloud auth application-default login`.
+  </Tip>
+- **Include Policy Tags** (Optional): Option to include policy tags as part of the column description. Enabled by default.
+- **Taxonomy Project ID** (Optional): Bigquery uses taxonomies to create hierarchical groups of policy tags. To apply access controls to BigQuery columns, tag the columns with policy tags. Learn more about how yo can create policy tags and set up column-level access control [here](https://cloud.google.com/bigquery/docs/column-level-security). If you have attached policy tags to the columns of table available in Bigquery, then OpenMetadata will fetch those tags and attach it to the respective columns. In this field you need to specify the id of project in which the taxonomy was created.
+- **Taxonomy Location** (Optional): Bigquery uses taxonomies to create hierarchical groups of policy tags. To apply access controls to BigQuery columns, tag the columns with policy tags. Learn more about how yo can create policy tags and set up column-level access control [here](https://cloud.google.com/bigquery/docs/column-level-security). If you have attached policy tags to the columns of table available in Bigquery, then OpenMetadata will fetch those tags and attach it to the respective columns. In this field you need to specify the location/region in which the taxonomy was created.
+- **Usage Location** (Optional): Location used to query `INFORMATION_SCHEMA.JOBS_BY_PROJECT` to fetch usage data. You can pass multi-regions, such as `us` or `eu`, or your specific region such as `us-east1`. Australia and Asia multi-regions are not yet supported.
+- **Cost Per TiB** (Optional): The cost (in USD) per tebibyte (TiB) of data processed during BigQuery usage analysis. This value is used to estimate query costs when analyzing usage metrics from `INFORMATION_SCHEMA.JOBS_BY_PROJECT`. This setting does **not** affect actual billing—it is only used for internal reporting and visualization of estimated costs. The default value, if not set, may assume the standard on-demand BigQuery pricing (e.g., $5.00 per TiB), but you should adjust it according to your organization's negotiated rates or flat-rate pricing model.
 </Step>
 <AdvancedConfiguration />
 <TestConnection />

--- a/v1.12.x/connectors/database/bigquery/yaml.mdx
+++ b/v1.12.x/connectors/database/bigquery/yaml.mdx
@@ -106,7 +106,19 @@ Configure the source type and service name for your BigQuery connector.
 
 </ContentSection>
 
-<ContentSection id={3} title="Credentials" lines="7-8">
+<ContentSection id={3} title="Host and Port" lines="6">
+
+**hostPort**: BigQuery APIs URL. By default, the API URL is `bigquery.googleapis.com`. You can modify this if you have a custom implementation of BigQuery.
+
+</ContentSection>
+
+<ContentSection id={4} title="Billing Project ID" lines="7">
+
+**billingProjectId** (Optional): The GCP project that should be charged for the BigQuery jobs OpenMetadata runs. Use this when the project that pays for metadata, usage, or lineage queries is different from the project ID or IDs you ingest from.
+
+</ContentSection>
+
+<ContentSection id={5} title="Credentials" lines="8-9">
 
 **credentials**: You can authenticate with your BigQuery instance using either `GCP Credentials Path` where you can specify the file path of the service account key or you can pass the values directly by choosing the `GCP Credentials Values` from the service account key file.
 
@@ -114,7 +126,7 @@ You can checkout [this](https://cloud.google.com/iam/docs/keys-create-delete#iam
 
 </ContentSection>
 
-<ContentSection id={4} title="GCP Configuration" lines="8">
+<ContentSection id={6} title="GCP Configuration" lines="9">
 
 <div>
 
@@ -158,7 +170,21 @@ credentials:
 
 </ContentSection>
 
-<ContentSection id={5} title="Taxonomy Configuration" lines="9">
+<ContentSection id={7} title="GCP Impersonate Service Account" lines="10">
+
+**gcpImpersonateServiceAccount** (Optional): Enable the authenticated service account to impersonate another service account, instead of ingesting directly with the credentials above.
+- **impersonateServiceAccount**: The email of the service account to impersonate.
+- **lifetime**: Number of seconds the delegated credential should remain valid. Defaults to `3600`.
+
+</ContentSection>
+
+<ContentSection id={8} title="Include Policy Tags" lines="11">
+
+**includePolicyTags** (Optional): Option to include policy tags as part of the column description. Enabled by default.
+
+</ContentSection>
+
+<ContentSection id={9} title="Taxonomy Configuration" lines="12">
 
 <div>
 
@@ -176,13 +202,13 @@ If you have attached policy tags to the columns of table available in BigQuery, 
 
 </ContentSection>
 
-<ContentSection id={6} title="Usage Location" lines="10">
+<ContentSection id={10} title="Usage Location" lines="13">
 
 **Usage Location (Optional)**: Location used to query `INFORMATION_SCHEMA.JOBS_BY_PROJECT` to fetch usage data. You can pass multi-regions, such as `us` or `eu`, or your specific region such as `us-east1`. Australia and Asia multi-regions are not yet supported.
 
 </ContentSection>
 
-<ContentSection id={7} title="Cost Per TiB" lines="11">
+<ContentSection id={11} title="Cost Per TiB" lines="14">
 
 **Cost Per TiB (Optional)**: The cost (in USD) per tebibyte (TiB) of data processed during BigQuery usage analysis. This value is used to estimate query costs when analyzing usage metrics from `INFORMATION_SCHEMA.JOBS_BY_PROJECT`.
 
@@ -190,19 +216,13 @@ This setting does **not** affect actual billing—it is only used for internal r
 
 </ContentSection>
 
-<ContentSection id={8} title="Billing Project ID" lines="12">
-
-**Billing Project ID (Optional)**: A billing project ID is a unique string used to identify and authorize your project for billing in Google Cloud.
-
-</ContentSection>
-
-<ContentSection id={9} title="Connection Options" lines="13">
+<ContentSection id={12} title="Connection Options" lines="15">
 
 **Connection Options (Optional)**: Enter the details for any additional connection options that can be sent to database during the connection. These details must be added as Key-Value pairs.
 
 </ContentSection>
 
-<ContentSection id={10} title="Connection Arguments" lines="14">
+<ContentSection id={13} title="Connection Arguments" lines="16">
 
 **Connection Arguments (Optional)**: Enter the details for any additional connection arguments such as security or protocol configs that can be sent to database during the connection. These details must be added as Key-Value pairs.
 
@@ -210,19 +230,19 @@ This setting does **not** affect actual billing—it is only used for internal r
 
 </ContentSection>
 
-<ContentSection id={11} title="Source Config" lines="18-61">
+<ContentSection id={14} title="Source Config" lines="20-63">
 
 <SourceConfigDef />
 
 </ContentSection>
 
-<ContentSection id={12} title="Sink Configuration" lines="62-64">
+<ContentSection id={15} title="Sink Configuration" lines="64-66">
 
 <IngestionSinkDef />
 
 </ContentSection>
 
-<ContentSection id={13} title="Workflow Configuration" lines="65-81">
+<ContentSection id={16} title="Workflow Configuration" lines="67-83">
 
 <WorkflowConfigDef />
 
@@ -239,6 +259,8 @@ source:
   serviceConnection:
     config:
       type: BigQuery
+      # hostPort: bigquery.googleapis.com
+      # billingProjectId: project-id-1
       credentials:
         gcpConfig:
 ```
@@ -246,11 +268,14 @@ source:
 <GcpConfig />
 
 ```yaml
-      # taxonomyLocation: us
+        # gcpImpersonateServiceAccount:
+        #   impersonateServiceAccount: target-service-account@project.iam.gserviceaccount.com
+        #   lifetime: 3600
+      # includePolicyTags: true
       # taxonomyProjectID: ["project-id-1", "project-id-2"]
+      # taxonomyLocation: us
       # usageLocation: us
-      # costPerTiB: 5.00
-      # billingProjectId: project-id-1
+      # costPerTB: 5.00
       # connectionOptions:
       #   key: value
       # connectionArguments:

--- a/v1.13.x/connectors/database/bigquery.mdx
+++ b/v1.13.x/connectors/database/bigquery.mdx
@@ -86,59 +86,55 @@ This will help you simplify your data management and optimize your performance i
 </Tip>
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"BigQuery"} selectServicePath={"/public/images/connectors/bigquery/select-service.png"} addNewServicePath={"/public/images/connectors/bigquery/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/bigquery/service-connection.png"} />
-# Connection Options
+### Connection Details
 <Steps>
-<Step title="Connection Options">
-**Host and Port**: BigQuery APIs URL. By default, the API URL is `bigquery.googleapis.com` you can modify this if you have custom implementation of BigQuery.
-**GCP Credentials**:
-You can authenticate with your bigquery instance using either `GCP Credentials Path` where you can specify the file path of the service account key or you can pass the values directly by choosing the `GCP Credentials Values` from the service account key file.
-You can check out [this](https://cloud.google.com/iam/docs/keys-create-delete#iam-service-account-keys-create-console) documentation on how to create the service account keys and download it.
-**GCP Credentials Values**: Passing the raw credential values provided by BigQuery. This requires us to provide the following information, all provided by BigQuery:
-- **Credentials type**: Credentials Type is the type of the account, for a service account the value of this field is `service_account`. To fetch this key, look for the value associated with the `type` key in the service account key file.
-- **Billing Project ID (Optional)**: The GCP project that should be charged for the BigQuery jobs OpenMetadata runs. Use this when the project that pays for metadata, usage, or lineage queries is different from the project ID or IDs you ingest from.
-- **Project ID**: The BigQuery project ID or IDs that OpenMetadata should scan for datasets, tables, and other metadata. For service account credentials, this usually comes from the `project_id` value in the key file. You can also pass multiple project IDs to ingest metadata from different BigQuery projects into one service.
-- **Private Key ID**: This is a unique identifier for the private key associated with the service account. To fetch this key, look for the value associated with the `private_key_id` key in the service account file.
-- **Private Key**: This is the private key associated with the service account that is used to authenticate and authorize access to BigQuery. To fetch this key, look for the value associated with the `private_key` key in the service account file.
-- **Client Email**: This is the email address associated with the service account. To fetch this key, look for the value associated with the `client_email` key in the service account key file.
-- **Client ID**: This is a unique identifier for the service account. To fetch this key, look for the value associated with the `client_id` key in the service account key  file.
-- **Auth URI**: This is the URI for the authorization server. To fetch this key, look for the value associated with the `auth_uri` key in the service account key file. The default value to Auth URI is https://accounts.google.com/o/oauth2/auth.
-- **Token URI**: The Google Cloud Token URI is a specific endpoint used to obtain an OAuth 2.0 access token from the Google Cloud IAM service. This token allows you to authenticate and access various Google Cloud resources and APIs that require authorization. To fetch this key, look for the value associated with the `token_uri` key in the service account credentials file. The default token URI is `https://oauth2.googleapis.com/token`.
-- **Authentication Provider X509 Certificate URL**: This is the URL of the certificate that verifies the authenticity of the authorization server. To fetch this key, look for the value associated with the `auth_provider_x509_cert_url` key in the service account key file. The Default value for Auth Provider X509Cert URL is https://www.googleapis.com/oauth2/v1/certs
-- **Client X509Cert URL**: This is the URL of the certificate that verifies the authenticity of the service account. To fetch this key, look for the value associated with the `client_x509_cert_url` key in the service account key  file.
-<Tip>
-`Project ID` tells OpenMetadata where to read metadata from. `Billing Project ID` tells BigQuery which project should pay for the queries.
+<Step title="Connection Details">
+- **Host and Port**: BigQuery APIs URL. By default, the API URL is `bigquery.googleapis.com`. You can modify this if you have a custom implementation of BigQuery.
+- **Billing Project ID** (Optional): The GCP project that should be charged for the BigQuery jobs OpenMetadata runs. Use this when the project that pays for metadata, usage, or lineage queries is different from the project ID or IDs you ingest from.
+- **GCP Credentials**: You can authenticate with your bigquery instance using either `GCP Credentials Path` where you can specify the file path of the service account key or you can pass the values directly by choosing the `GCP Credentials Values` from the service account key file. You can check out [this](https://cloud.google.com/iam/docs/keys-create-delete#iam-service-account-keys-create-console) documentation on how to create the service account keys and download it.
+  - **GCP Credentials Values**: Passing the raw credential values provided by BigQuery. This requires us to provide the following information, all provided by BigQuery:
+    - **Credentials type**: Credentials Type is the type of the account, for a service account the value of this field is `service_account`. To fetch this key, look for the value associated with the `type` key in the service account key file.
+    - **Project ID**: The BigQuery project ID or IDs that OpenMetadata should scan for datasets, tables, and other metadata. For service account credentials, this usually comes from the `project_id` value in the key file. You can also pass multiple project IDs to ingest metadata from different BigQuery projects into one service.
+    - **Private Key ID**: This is a unique identifier for the private key associated with the service account. To fetch this key, look for the value associated with the `private_key_id` key in the service account file.
+    - **Private Key**: This is the private key associated with the service account that is used to authenticate and authorize access to BigQuery. To fetch this key, look for the value associated with the `private_key` key in the service account file.
+    - **Client Email**: This is the email address associated with the service account. To fetch this key, look for the value associated with the `client_email` key in the service account key file.
+    - **Client ID**: This is a unique identifier for the service account. To fetch this key, look for the value associated with the `client_id` key in the service account key  file.
+    - **Auth URI**: This is the URI for the authorization server. To fetch this key, look for the value associated with the `auth_uri` key in the service account key file. The default value to Auth URI is https://accounts.google.com/o/oauth2/auth.
+    - **Token URI**: The Google Cloud Token URI is a specific endpoint used to obtain an OAuth 2.0 access token from the Google Cloud IAM service. This token allows you to authenticate and access various Google Cloud resources and APIs that require authorization. To fetch this key, look for the value associated with the `token_uri` key in the service account credentials file. The default token URI is `https://oauth2.googleapis.com/token`.
+    - **Authentication Provider X509 Certificate URL**: This is the URL of the certificate that verifies the authenticity of the authorization server. To fetch this key, look for the value associated with the `auth_provider_x509_cert_url` key in the service account key file. The Default value for Auth Provider X509Cert URL is https://www.googleapis.com/oauth2/v1/certs
+    - **Client X509Cert URL**: This is the URL of the certificate that verifies the authenticity of the service account. To fetch this key, look for the value associated with the `client_x509_cert_url` key in the service account key  file.
+  - **GCP Credentials Path**: Passing a local file path that contains the credentials.
+  - **GCP Impersonate Service Account Configuration** (Optional): Enable the authenticated service account to impersonate another service account, instead of ingesting directly with the credentials above.
+    - **Target Service Account Email**: The email of the service account to impersonate.
+    - **Lifetime**: Number of seconds the delegated credential should remain valid. Defaults to `3600`.
+  <Tip>
+  `Project ID` (above) tells OpenMetadata where to read metadata from. `Billing Project ID` tells BigQuery which project should pay for the queries.
 
-- Same-project setup: if your data lives in `analytics-prod` and that same project should pay for the queries, use `analytics-prod` as the `Project ID` and either leave `Billing Project ID` empty or set it to `analytics-prod`.
-- Cross-project billing setup: if your data lives in `marketing-prod` and `finance-prod`, but all query costs should be charged to `central-billing`, use `marketing-prod` and `finance-prod` as `Project ID` values and set `Billing Project ID` to `central-billing`.
-</Tip>
-**GCP Credentials Path**: Passing a local file path that contains the credentials.
-**Taxonomy Project ID (Optional)**: Bigquery uses taxonomies to create hierarchical groups of policy tags. To apply access controls to BigQuery columns, tag the columns with policy tags. Learn more about how yo can create policy tags and set up column-level access control [here](https://cloud.google.com/bigquery/docs/column-level-security)
-If you have attached policy tags to the columns of table available in Bigquery, then OpenMetadata will fetch those tags and attach it to the respective columns.
-In this field you need to specify the id of project in which the taxonomy was created.
-**Taxonomy Location (Optional)**: Bigquery uses taxonomies to create hierarchical groups of policy tags. To apply access controls to BigQuery columns, tag the columns with policy tags. Learn more about how yo can create policy tags and set up column-level access control [here](https://cloud.google.com/bigquery/docs/column-level-security)
-If you have attached policy tags to the columns of table available in Bigquery, then OpenMetadata will fetch those tags and attach it to the respective columns.
-In this field you need to specify the location/region in which the taxonomy was created.
-**Usage Location (Optional)**:
-Location used to query `INFORMATION_SCHEMA.JOBS_BY_PROJECT` to fetch usage data. You can pass multi-regions, such as `us` or `eu`, or your specific region such as `us-east1`. Australia and Asia multi-regions are not yet supported.
-**Cost Per TiB (Optional)**:
-The cost (in USD) per tebibyte (TiB) of data processed during BigQuery usage analysis. This value is used to estimate query costs when analyzing usage metrics from `INFORMATION_SCHEMA.JOBS_BY_PROJECT`.
-This setting does **not** affect actual billing—it is only used for internal reporting and visualization of estimated costs.
-The default value, if not set, may assume the standard on-demand BigQuery pricing (e.g., $5.00 per TiB), but you should adjust it according to your organization's negotiated rates or flat-rate pricing model.
-<Tip>
-**Application Default Credentials (ADC) Authentication**
-If you want to use [ADC authentication](https://cloud.google.com/docs/authentication#adc) for BigQuery, configure the GCP credentials with type `gcp_adc`:
-```yaml
-credentials:
-  gcpConfig:
-    type: gcp_adc
-    projectId: ["your-project-id"]  # Optional: specify project(s) for data access
-```
-**Using ADC with Billing Project ID**: When using ADC authentication, you can still specify a **Billing Project ID** to control which project pays for the BigQuery queries OpenMetadata runs. This is particularly useful when:
-- Your service account has access to multiple projects
-- You want to bill queries to a specific project different from the one containing your data
-- You're running queries that span multiple projects
-**ADC Setup**: ADC authentication works automatically when running in Google Cloud environments (GKE, Compute Engine, Cloud Run) or when you've configured it locally using `gcloud auth application-default login`.
-</Tip>
+  - Same-project setup: if your data lives in `analytics-prod` and that same project should pay for the queries, use `analytics-prod` as the `Project ID` and either leave `Billing Project ID` empty or set it to `analytics-prod`.
+  - Cross-project billing setup: if your data lives in `marketing-prod` and `finance-prod`, but all query costs should be charged to `central-billing`, use `marketing-prod` and `finance-prod` as `Project ID` values and set `Billing Project ID` to `central-billing`.
+  </Tip>
+  <Tip>
+  **Application Default Credentials (ADC) Authentication**
+
+  If you want to use [ADC authentication](https://cloud.google.com/docs/authentication#adc) for BigQuery, configure the GCP credentials with type `gcp_adc`:
+  ```yaml
+  credentials:
+    gcpConfig:
+      type: gcp_adc
+      projectId: ["your-project-id"]  # Optional: specify project(s) for data access
+  ```
+  **Using ADC with Billing Project ID**: When using ADC authentication, you can still specify a **Billing Project ID** to control which project pays for the BigQuery queries OpenMetadata runs. This is particularly useful when:
+  - Your service account has access to multiple projects
+  - You want to bill queries to a specific project different from the one containing your data
+  - You're running queries that span multiple projects
+
+  **ADC Setup**: ADC authentication works automatically when running in Google Cloud environments (GKE, Compute Engine, Cloud Run) or when you've configured it locally using `gcloud auth application-default login`.
+  </Tip>
+- **Include Policy Tags** (Optional): Option to include policy tags as part of the column description. Enabled by default.
+- **Taxonomy Project ID** (Optional): Bigquery uses taxonomies to create hierarchical groups of policy tags. To apply access controls to BigQuery columns, tag the columns with policy tags. Learn more about how yo can create policy tags and set up column-level access control [here](https://cloud.google.com/bigquery/docs/column-level-security). If you have attached policy tags to the columns of table available in Bigquery, then OpenMetadata will fetch those tags and attach it to the respective columns. In this field you need to specify the id of project in which the taxonomy was created.
+- **Taxonomy Location** (Optional): Bigquery uses taxonomies to create hierarchical groups of policy tags. To apply access controls to BigQuery columns, tag the columns with policy tags. Learn more about how yo can create policy tags and set up column-level access control [here](https://cloud.google.com/bigquery/docs/column-level-security). If you have attached policy tags to the columns of table available in Bigquery, then OpenMetadata will fetch those tags and attach it to the respective columns. In this field you need to specify the location/region in which the taxonomy was created.
+- **Usage Location** (Optional): Location used to query `INFORMATION_SCHEMA.JOBS_BY_PROJECT` to fetch usage data. You can pass multi-regions, such as `us` or `eu`, or your specific region such as `us-east1`. Australia and Asia multi-regions are not yet supported.
+- **Cost Per TiB** (Optional): The cost (in USD) per tebibyte (TiB) of data processed during BigQuery usage analysis. This value is used to estimate query costs when analyzing usage metrics from `INFORMATION_SCHEMA.JOBS_BY_PROJECT`. This setting does **not** affect actual billing—it is only used for internal reporting and visualization of estimated costs. The default value, if not set, may assume the standard on-demand BigQuery pricing (e.g., $5.00 per TiB), but you should adjust it according to your organization's negotiated rates or flat-rate pricing model.
 </Step>
 <AdvancedConfiguration />
 <TestConnection />

--- a/v1.13.x/connectors/database/bigquery/yaml.mdx
+++ b/v1.13.x/connectors/database/bigquery/yaml.mdx
@@ -106,7 +106,19 @@ Configure the source type and service name for your BigQuery connector.
 
 </ContentSection>
 
-<ContentSection id={3} title="Credentials" lines="7-8">
+<ContentSection id={3} title="Host and Port" lines="6">
+
+**hostPort**: BigQuery APIs URL. By default, the API URL is `bigquery.googleapis.com`. You can modify this if you have a custom implementation of BigQuery.
+
+</ContentSection>
+
+<ContentSection id={4} title="Billing Project ID" lines="7">
+
+**billingProjectId** (Optional): The GCP project that should be charged for the BigQuery jobs OpenMetadata runs. Use this when the project that pays for metadata, usage, or lineage queries is different from the project ID or IDs you ingest from.
+
+</ContentSection>
+
+<ContentSection id={5} title="Credentials" lines="8-9">
 
 **credentials**: You can authenticate with your BigQuery instance using either `GCP Credentials Path` where you can specify the file path of the service account key or you can pass the values directly by choosing the `GCP Credentials Values` from the service account key file.
 
@@ -114,7 +126,7 @@ You can checkout [this](https://cloud.google.com/iam/docs/keys-create-delete#iam
 
 </ContentSection>
 
-<ContentSection id={4} title="GCP Configuration" lines="8">
+<ContentSection id={6} title="GCP Configuration" lines="9">
 
 <div>
 
@@ -158,7 +170,21 @@ credentials:
 
 </ContentSection>
 
-<ContentSection id={5} title="Taxonomy Configuration" lines="9">
+<ContentSection id={7} title="GCP Impersonate Service Account" lines="10">
+
+**gcpImpersonateServiceAccount** (Optional): Enable the authenticated service account to impersonate another service account, instead of ingesting directly with the credentials above.
+- **impersonateServiceAccount**: The email of the service account to impersonate.
+- **lifetime**: Number of seconds the delegated credential should remain valid. Defaults to `3600`.
+
+</ContentSection>
+
+<ContentSection id={8} title="Include Policy Tags" lines="11">
+
+**includePolicyTags** (Optional): Option to include policy tags as part of the column description. Enabled by default.
+
+</ContentSection>
+
+<ContentSection id={9} title="Taxonomy Configuration" lines="12">
 
 <div>
 
@@ -176,13 +202,13 @@ If you have attached policy tags to the columns of table available in BigQuery, 
 
 </ContentSection>
 
-<ContentSection id={6} title="Usage Location" lines="10">
+<ContentSection id={10} title="Usage Location" lines="13">
 
 **Usage Location (Optional)**: Location used to query `INFORMATION_SCHEMA.JOBS_BY_PROJECT` to fetch usage data. You can pass multi-regions, such as `us` or `eu`, or your specific region such as `us-east1`. Australia and Asia multi-regions are not yet supported.
 
 </ContentSection>
 
-<ContentSection id={7} title="Cost Per TiB" lines="11">
+<ContentSection id={11} title="Cost Per TiB" lines="14">
 
 **Cost Per TiB (Optional)**: The cost (in USD) per tebibyte (TiB) of data processed during BigQuery usage analysis. This value is used to estimate query costs when analyzing usage metrics from `INFORMATION_SCHEMA.JOBS_BY_PROJECT`.
 
@@ -190,19 +216,13 @@ This setting does **not** affect actual billing—it is only used for internal r
 
 </ContentSection>
 
-<ContentSection id={8} title="Billing Project ID" lines="12">
-
-**Billing Project ID (Optional)**: A billing project ID is a unique string used to identify and authorize your project for billing in Google Cloud.
-
-</ContentSection>
-
-<ContentSection id={9} title="Connection Options" lines="13">
+<ContentSection id={12} title="Connection Options" lines="15">
 
 **Connection Options (Optional)**: Enter the details for any additional connection options that can be sent to database during the connection. These details must be added as Key-Value pairs.
 
 </ContentSection>
 
-<ContentSection id={10} title="Connection Arguments" lines="14">
+<ContentSection id={13} title="Connection Arguments" lines="16">
 
 **Connection Arguments (Optional)**: Enter the details for any additional connection arguments such as security or protocol configs that can be sent to database during the connection. These details must be added as Key-Value pairs.
 
@@ -210,19 +230,19 @@ This setting does **not** affect actual billing—it is only used for internal r
 
 </ContentSection>
 
-<ContentSection id={11} title="Source Config" lines="18-61">
+<ContentSection id={14} title="Source Config" lines="20-63">
 
 <SourceConfigDef />
 
 </ContentSection>
 
-<ContentSection id={12} title="Sink Configuration" lines="62-64">
+<ContentSection id={15} title="Sink Configuration" lines="64-66">
 
 <IngestionSinkDef />
 
 </ContentSection>
 
-<ContentSection id={13} title="Workflow Configuration" lines="65-81">
+<ContentSection id={16} title="Workflow Configuration" lines="67-83">
 
 <WorkflowConfigDef />
 
@@ -239,6 +259,8 @@ source:
   serviceConnection:
     config:
       type: BigQuery
+      # hostPort: bigquery.googleapis.com
+      # billingProjectId: project-id-1
       credentials:
         gcpConfig:
 ```
@@ -246,11 +268,14 @@ source:
 <GcpConfig />
 
 ```yaml
-      # taxonomyLocation: us
+        # gcpImpersonateServiceAccount:
+        #   impersonateServiceAccount: target-service-account@project.iam.gserviceaccount.com
+        #   lifetime: 3600
+      # includePolicyTags: true
       # taxonomyProjectID: ["project-id-1", "project-id-2"]
+      # taxonomyLocation: us
       # usageLocation: us
-      # costPerTiB: 5.00
-      # billingProjectId: project-id-1
+      # costPerTB: 5.00
       # connectionOptions:
       #   key: value
       # connectionArguments:

--- a/v2.0.x-SNAPSHOT/connectors/database/bigquery.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/bigquery.mdx
@@ -86,59 +86,55 @@ This will help you simplify your data management and optimize your performance i
 </Tip>
 ## Metadata Ingestion
 <MetadataIngestionUi connector={"BigQuery"} selectServicePath={"/public/images/connectors/bigquery/select-service.png"} addNewServicePath={"/public/images/connectors/bigquery/add-new-service.png"} serviceConnectionPath={"/public/images/connectors/bigquery/service-connection.png"} />
-# Connection Options
+### Connection Details
 <Steps>
-<Step title="Connection Options">
-**Host and Port**: BigQuery APIs URL. By default, the API URL is `bigquery.googleapis.com` you can modify this if you have custom implementation of BigQuery.
-**GCP Credentials**:
-You can authenticate with your bigquery instance using either `GCP Credentials Path` where you can specify the file path of the service account key or you can pass the values directly by choosing the `GCP Credentials Values` from the service account key file.
-You can check out [this](https://cloud.google.com/iam/docs/keys-create-delete#iam-service-account-keys-create-console) documentation on how to create the service account keys and download it.
-**GCP Credentials Values**: Passing the raw credential values provided by BigQuery. This requires us to provide the following information, all provided by BigQuery:
-- **Credentials type**: Credentials Type is the type of the account, for a service account the value of this field is `service_account`. To fetch this key, look for the value associated with the `type` key in the service account key file.
-- **Billing Project ID (Optional)**: The GCP project that should be charged for the BigQuery jobs OpenMetadata runs. Use this when the project that pays for metadata, usage, or lineage queries is different from the project ID or IDs you ingest from.
-- **Project ID**: The BigQuery project ID or IDs that OpenMetadata should scan for datasets, tables, and other metadata. For service account credentials, this usually comes from the `project_id` value in the key file. You can also pass multiple project IDs to ingest metadata from different BigQuery projects into one service.
-- **Private Key ID**: This is a unique identifier for the private key associated with the service account. To fetch this key, look for the value associated with the `private_key_id` key in the service account file.
-- **Private Key**: This is the private key associated with the service account that is used to authenticate and authorize access to BigQuery. To fetch this key, look for the value associated with the `private_key` key in the service account file.
-- **Client Email**: This is the email address associated with the service account. To fetch this key, look for the value associated with the `client_email` key in the service account key file.
-- **Client ID**: This is a unique identifier for the service account. To fetch this key, look for the value associated with the `client_id` key in the service account key  file.
-- **Auth URI**: This is the URI for the authorization server. To fetch this key, look for the value associated with the `auth_uri` key in the service account key file. The default value to Auth URI is https://accounts.google.com/o/oauth2/auth.
-- **Token URI**: The Google Cloud Token URI is a specific endpoint used to obtain an OAuth 2.0 access token from the Google Cloud IAM service. This token allows you to authenticate and access various Google Cloud resources and APIs that require authorization. To fetch this key, look for the value associated with the `token_uri` key in the service account credentials file. The default token URI is `https://oauth2.googleapis.com/token`.
-- **Authentication Provider X509 Certificate URL**: This is the URL of the certificate that verifies the authenticity of the authorization server. To fetch this key, look for the value associated with the `auth_provider_x509_cert_url` key in the service account key file. The Default value for Auth Provider X509Cert URL is https://www.googleapis.com/oauth2/v1/certs
-- **Client X509Cert URL**: This is the URL of the certificate that verifies the authenticity of the service account. To fetch this key, look for the value associated with the `client_x509_cert_url` key in the service account key  file.
-<Tip>
-`Project ID` tells OpenMetadata where to read metadata from. `Billing Project ID` tells BigQuery which project should pay for the queries.
+<Step title="Connection Details">
+- **Host and Port**: BigQuery APIs URL. By default, the API URL is `bigquery.googleapis.com`. You can modify this if you have a custom implementation of BigQuery.
+- **Billing Project ID** (Optional): The GCP project that should be charged for the BigQuery jobs OpenMetadata runs. Use this when the project that pays for metadata, usage, or lineage queries is different from the project ID or IDs you ingest from.
+- **GCP Credentials**: You can authenticate with your bigquery instance using either `GCP Credentials Path` where you can specify the file path of the service account key or you can pass the values directly by choosing the `GCP Credentials Values` from the service account key file. You can check out [this](https://cloud.google.com/iam/docs/keys-create-delete#iam-service-account-keys-create-console) documentation on how to create the service account keys and download it.
+  - **GCP Credentials Values**: Passing the raw credential values provided by BigQuery. This requires us to provide the following information, all provided by BigQuery:
+    - **Credentials type**: Credentials Type is the type of the account, for a service account the value of this field is `service_account`. To fetch this key, look for the value associated with the `type` key in the service account key file.
+    - **Project ID**: The BigQuery project ID or IDs that OpenMetadata should scan for datasets, tables, and other metadata. For service account credentials, this usually comes from the `project_id` value in the key file. You can also pass multiple project IDs to ingest metadata from different BigQuery projects into one service.
+    - **Private Key ID**: This is a unique identifier for the private key associated with the service account. To fetch this key, look for the value associated with the `private_key_id` key in the service account file.
+    - **Private Key**: This is the private key associated with the service account that is used to authenticate and authorize access to BigQuery. To fetch this key, look for the value associated with the `private_key` key in the service account file.
+    - **Client Email**: This is the email address associated with the service account. To fetch this key, look for the value associated with the `client_email` key in the service account key file.
+    - **Client ID**: This is a unique identifier for the service account. To fetch this key, look for the value associated with the `client_id` key in the service account key  file.
+    - **Auth URI**: This is the URI for the authorization server. To fetch this key, look for the value associated with the `auth_uri` key in the service account key file. The default value to Auth URI is https://accounts.google.com/o/oauth2/auth.
+    - **Token URI**: The Google Cloud Token URI is a specific endpoint used to obtain an OAuth 2.0 access token from the Google Cloud IAM service. This token allows you to authenticate and access various Google Cloud resources and APIs that require authorization. To fetch this key, look for the value associated with the `token_uri` key in the service account credentials file. The default token URI is `https://oauth2.googleapis.com/token`.
+    - **Authentication Provider X509 Certificate URL**: This is the URL of the certificate that verifies the authenticity of the authorization server. To fetch this key, look for the value associated with the `auth_provider_x509_cert_url` key in the service account key file. The Default value for Auth Provider X509Cert URL is https://www.googleapis.com/oauth2/v1/certs
+    - **Client X509Cert URL**: This is the URL of the certificate that verifies the authenticity of the service account. To fetch this key, look for the value associated with the `client_x509_cert_url` key in the service account key  file.
+  - **GCP Credentials Path**: Passing a local file path that contains the credentials.
+  - **GCP Impersonate Service Account Configuration** (Optional): Enable the authenticated service account to impersonate another service account, instead of ingesting directly with the credentials above.
+    - **Target Service Account Email**: The email of the service account to impersonate.
+    - **Lifetime**: Number of seconds the delegated credential should remain valid. Defaults to `3600`.
+  <Tip>
+  `Project ID` (above) tells OpenMetadata where to read metadata from. `Billing Project ID` tells BigQuery which project should pay for the queries.
 
-- Same-project setup: if your data lives in `analytics-prod` and that same project should pay for the queries, use `analytics-prod` as the `Project ID` and either leave `Billing Project ID` empty or set it to `analytics-prod`.
-- Cross-project billing setup: if your data lives in `marketing-prod` and `finance-prod`, but all query costs should be charged to `central-billing`, use `marketing-prod` and `finance-prod` as `Project ID` values and set `Billing Project ID` to `central-billing`.
-</Tip>
-**GCP Credentials Path**: Passing a local file path that contains the credentials.
-**Taxonomy Project ID (Optional)**: Bigquery uses taxonomies to create hierarchical groups of policy tags. To apply access controls to BigQuery columns, tag the columns with policy tags. Learn more about how yo can create policy tags and set up column-level access control [here](https://cloud.google.com/bigquery/docs/column-level-security)
-If you have attached policy tags to the columns of table available in Bigquery, then OpenMetadata will fetch those tags and attach it to the respective columns.
-In this field you need to specify the id of project in which the taxonomy was created.
-**Taxonomy Location (Optional)**: Bigquery uses taxonomies to create hierarchical groups of policy tags. To apply access controls to BigQuery columns, tag the columns with policy tags. Learn more about how yo can create policy tags and set up column-level access control [here](https://cloud.google.com/bigquery/docs/column-level-security)
-If you have attached policy tags to the columns of table available in Bigquery, then OpenMetadata will fetch those tags and attach it to the respective columns.
-In this field you need to specify the location/region in which the taxonomy was created.
-**Usage Location (Optional)**:
-Location used to query `INFORMATION_SCHEMA.JOBS_BY_PROJECT` to fetch usage data. You can pass multi-regions, such as `us` or `eu`, or your specific region such as `us-east1`. Australia and Asia multi-regions are not yet supported.
-**Cost Per TiB (Optional)**:
-The cost (in USD) per tebibyte (TiB) of data processed during BigQuery usage analysis. This value is used to estimate query costs when analyzing usage metrics from `INFORMATION_SCHEMA.JOBS_BY_PROJECT`.
-This setting does **not** affect actual billing—it is only used for internal reporting and visualization of estimated costs.
-The default value, if not set, may assume the standard on-demand BigQuery pricing (e.g., $5.00 per TiB), but you should adjust it according to your organization's negotiated rates or flat-rate pricing model.
-<Tip>
-**Application Default Credentials (ADC) Authentication**
-If you want to use [ADC authentication](https://cloud.google.com/docs/authentication#adc) for BigQuery, configure the GCP credentials with type `gcp_adc`:
-```yaml
-credentials:
-  gcpConfig:
-    type: gcp_adc
-    projectId: ["your-project-id"]  # Optional: specify project(s) for data access
-```
-**Using ADC with Billing Project ID**: When using ADC authentication, you can still specify a **Billing Project ID** to control which project pays for the BigQuery queries OpenMetadata runs. This is particularly useful when:
-- Your service account has access to multiple projects
-- You want to bill queries to a specific project different from the one containing your data
-- You're running queries that span multiple projects
-**ADC Setup**: ADC authentication works automatically when running in Google Cloud environments (GKE, Compute Engine, Cloud Run) or when you've configured it locally using `gcloud auth application-default login`.
-</Tip>
+  - Same-project setup: if your data lives in `analytics-prod` and that same project should pay for the queries, use `analytics-prod` as the `Project ID` and either leave `Billing Project ID` empty or set it to `analytics-prod`.
+  - Cross-project billing setup: if your data lives in `marketing-prod` and `finance-prod`, but all query costs should be charged to `central-billing`, use `marketing-prod` and `finance-prod` as `Project ID` values and set `Billing Project ID` to `central-billing`.
+  </Tip>
+  <Tip>
+  **Application Default Credentials (ADC) Authentication**
+
+  If you want to use [ADC authentication](https://cloud.google.com/docs/authentication#adc) for BigQuery, configure the GCP credentials with type `gcp_adc`:
+  ```yaml
+  credentials:
+    gcpConfig:
+      type: gcp_adc
+      projectId: ["your-project-id"]  # Optional: specify project(s) for data access
+  ```
+  **Using ADC with Billing Project ID**: When using ADC authentication, you can still specify a **Billing Project ID** to control which project pays for the BigQuery queries OpenMetadata runs. This is particularly useful when:
+  - Your service account has access to multiple projects
+  - You want to bill queries to a specific project different from the one containing your data
+  - You're running queries that span multiple projects
+
+  **ADC Setup**: ADC authentication works automatically when running in Google Cloud environments (GKE, Compute Engine, Cloud Run) or when you've configured it locally using `gcloud auth application-default login`.
+  </Tip>
+- **Include Policy Tags** (Optional): Option to include policy tags as part of the column description. Enabled by default.
+- **Taxonomy Project ID** (Optional): Bigquery uses taxonomies to create hierarchical groups of policy tags. To apply access controls to BigQuery columns, tag the columns with policy tags. Learn more about how yo can create policy tags and set up column-level access control [here](https://cloud.google.com/bigquery/docs/column-level-security). If you have attached policy tags to the columns of table available in Bigquery, then OpenMetadata will fetch those tags and attach it to the respective columns. In this field you need to specify the id of project in which the taxonomy was created.
+- **Taxonomy Location** (Optional): Bigquery uses taxonomies to create hierarchical groups of policy tags. To apply access controls to BigQuery columns, tag the columns with policy tags. Learn more about how yo can create policy tags and set up column-level access control [here](https://cloud.google.com/bigquery/docs/column-level-security). If you have attached policy tags to the columns of table available in Bigquery, then OpenMetadata will fetch those tags and attach it to the respective columns. In this field you need to specify the location/region in which the taxonomy was created.
+- **Usage Location** (Optional): Location used to query `INFORMATION_SCHEMA.JOBS_BY_PROJECT` to fetch usage data. You can pass multi-regions, such as `us` or `eu`, or your specific region such as `us-east1`. Australia and Asia multi-regions are not yet supported.
+- **Cost Per TiB** (Optional): The cost (in USD) per tebibyte (TiB) of data processed during BigQuery usage analysis. This value is used to estimate query costs when analyzing usage metrics from `INFORMATION_SCHEMA.JOBS_BY_PROJECT`. This setting does **not** affect actual billing—it is only used for internal reporting and visualization of estimated costs. The default value, if not set, may assume the standard on-demand BigQuery pricing (e.g., $5.00 per TiB), but you should adjust it according to your organization's negotiated rates or flat-rate pricing model.
 </Step>
 <AdvancedConfiguration />
 <TestConnection />

--- a/v2.0.x-SNAPSHOT/connectors/database/bigquery/yaml.mdx
+++ b/v2.0.x-SNAPSHOT/connectors/database/bigquery/yaml.mdx
@@ -106,7 +106,19 @@ Configure the source type and service name for your BigQuery connector.
 
 </ContentSection>
 
-<ContentSection id={3} title="Credentials" lines="7-8">
+<ContentSection id={3} title="Host and Port" lines="6">
+
+**hostPort**: BigQuery APIs URL. By default, the API URL is `bigquery.googleapis.com`. You can modify this if you have a custom implementation of BigQuery.
+
+</ContentSection>
+
+<ContentSection id={4} title="Billing Project ID" lines="7">
+
+**billingProjectId** (Optional): The GCP project that should be charged for the BigQuery jobs OpenMetadata runs. Use this when the project that pays for metadata, usage, or lineage queries is different from the project ID or IDs you ingest from.
+
+</ContentSection>
+
+<ContentSection id={5} title="Credentials" lines="8-9">
 
 **credentials**: You can authenticate with your BigQuery instance using either `GCP Credentials Path` where you can specify the file path of the service account key or you can pass the values directly by choosing the `GCP Credentials Values` from the service account key file.
 
@@ -114,7 +126,7 @@ You can checkout [this](https://cloud.google.com/iam/docs/keys-create-delete#iam
 
 </ContentSection>
 
-<ContentSection id={4} title="GCP Configuration" lines="8">
+<ContentSection id={6} title="GCP Configuration" lines="9">
 
 <div>
 
@@ -158,7 +170,21 @@ credentials:
 
 </ContentSection>
 
-<ContentSection id={5} title="Taxonomy Configuration" lines="9">
+<ContentSection id={7} title="GCP Impersonate Service Account" lines="10">
+
+**gcpImpersonateServiceAccount** (Optional): Enable the authenticated service account to impersonate another service account, instead of ingesting directly with the credentials above.
+- **impersonateServiceAccount**: The email of the service account to impersonate.
+- **lifetime**: Number of seconds the delegated credential should remain valid. Defaults to `3600`.
+
+</ContentSection>
+
+<ContentSection id={8} title="Include Policy Tags" lines="11">
+
+**includePolicyTags** (Optional): Option to include policy tags as part of the column description. Enabled by default.
+
+</ContentSection>
+
+<ContentSection id={9} title="Taxonomy Configuration" lines="12">
 
 <div>
 
@@ -176,13 +202,13 @@ If you have attached policy tags to the columns of table available in BigQuery, 
 
 </ContentSection>
 
-<ContentSection id={6} title="Usage Location" lines="10">
+<ContentSection id={10} title="Usage Location" lines="13">
 
 **Usage Location (Optional)**: Location used to query `INFORMATION_SCHEMA.JOBS_BY_PROJECT` to fetch usage data. You can pass multi-regions, such as `us` or `eu`, or your specific region such as `us-east1`. Australia and Asia multi-regions are not yet supported.
 
 </ContentSection>
 
-<ContentSection id={7} title="Cost Per TiB" lines="11">
+<ContentSection id={11} title="Cost Per TiB" lines="14">
 
 **Cost Per TiB (Optional)**: The cost (in USD) per tebibyte (TiB) of data processed during BigQuery usage analysis. This value is used to estimate query costs when analyzing usage metrics from `INFORMATION_SCHEMA.JOBS_BY_PROJECT`.
 
@@ -190,19 +216,13 @@ This setting does **not** affect actual billing—it is only used for internal r
 
 </ContentSection>
 
-<ContentSection id={8} title="Billing Project ID" lines="12">
-
-**Billing Project ID (Optional)**: A billing project ID is a unique string used to identify and authorize your project for billing in Google Cloud.
-
-</ContentSection>
-
-<ContentSection id={9} title="Connection Options" lines="13">
+<ContentSection id={12} title="Connection Options" lines="15">
 
 **Connection Options (Optional)**: Enter the details for any additional connection options that can be sent to database during the connection. These details must be added as Key-Value pairs.
 
 </ContentSection>
 
-<ContentSection id={10} title="Connection Arguments" lines="14">
+<ContentSection id={13} title="Connection Arguments" lines="16">
 
 **Connection Arguments (Optional)**: Enter the details for any additional connection arguments such as security or protocol configs that can be sent to database during the connection. These details must be added as Key-Value pairs.
 
@@ -210,19 +230,19 @@ This setting does **not** affect actual billing—it is only used for internal r
 
 </ContentSection>
 
-<ContentSection id={11} title="Source Config" lines="18-61">
+<ContentSection id={14} title="Source Config" lines="20-63">
 
 <SourceConfigDef />
 
 </ContentSection>
 
-<ContentSection id={12} title="Sink Configuration" lines="62-64">
+<ContentSection id={15} title="Sink Configuration" lines="64-66">
 
 <IngestionSinkDef />
 
 </ContentSection>
 
-<ContentSection id={13} title="Workflow Configuration" lines="65-81">
+<ContentSection id={16} title="Workflow Configuration" lines="67-83">
 
 <WorkflowConfigDef />
 
@@ -239,6 +259,8 @@ source:
   serviceConnection:
     config:
       type: BigQuery
+      # hostPort: bigquery.googleapis.com
+      # billingProjectId: project-id-1
       credentials:
         gcpConfig:
 ```
@@ -246,11 +268,14 @@ source:
 <GcpConfig />
 
 ```yaml
-      # taxonomyLocation: us
+        # gcpImpersonateServiceAccount:
+        #   impersonateServiceAccount: target-service-account@project.iam.gserviceaccount.com
+        #   lifetime: 3600
+      # includePolicyTags: true
       # taxonomyProjectID: ["project-id-1", "project-id-2"]
+      # taxonomyLocation: us
       # usageLocation: us
-      # costPerTiB: 5.00
-      # billingProjectId: project-id-1
+      # costPerTB: 5.00
       # connectionOptions:
       #   key: value
       # connectionArguments:


### PR DESCRIPTION
## Summary
- "Connection Options" rendered as an unbulleted wall of text on the BigQuery connector page; reformats it as "Connection Details" (matching every other connector) with proper bullets, reordered to match the JSON schema and the actual product UI (Host and Port → Billing Project ID → GCP Credentials → Include Policy Tags → Taxonomy Project ID → Taxonomy Location → Usage Location → Cost Per TiB).
- Adds fields that were completely undocumented: `includePolicyTags` and `gcpImpersonateServiceAccount` (Target Service Account Email + Lifetime).
- Fixes a real bug in the yaml.mdx sample config: `costPerTiB` → `costPerTB` (wrong property name, didn't match the schema).
- Adds the missing `hostPort` ContentSection to yaml.mdx (documented on the main page but absent from the YAML reference).
- Applied consistently across v1.12.x, v1.13.x, and v2.0.x-SNAPSHOT.
<img width="2940" height="1602" alt="image" src="https://github.com/user-attachments/assets/d782ae89-4ad1-4ce6-8d09-01cd05edab32" />

## Test plan
- [ ] Run `mint dev` and verify the BigQuery connector page renders the Connection Details step as a bulleted list (not a run-on paragraph) for all three versions
- [ ] Verify the yaml.mdx sample config's `costPerTB` line and confirm it matches `bigQueryConnection.json`
- [ ] Run `mint broken-links` to confirm no broken links were introduced
